### PR TITLE
Bump workflow actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup java environment
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: adopt
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Lint, test and build the debug apk
-        uses: eskatos/gradle-command-action@v2
-        with:
-          gradle-version: current
-          arguments: check assembleDebug
+        run: ./gradlew check assembleDebug


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v3 → v4
- Bump `actions/setup-java` v3 → v4, switch distribution `adopt` → `temurin` (adopt was renamed years ago)
- Drop the unmaintained `eskatos/gradle-command-action@v2` in favor of `gradle/actions/setup-gradle@v4` + an explicit `./gradlew check assembleDebug` step

Fixes the GitHub Actions warning:
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3, actions/setup-java@v3, eskatos/gradle-command-action@v2.

## Test plan
- [x] `Build` workflow run on this branch's merge to master finishes green
- [x] No Node 20 deprecation warnings in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)