### PR TITLE
chore: update build tooling and dependencies to latest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,26 +2,35 @@
 
 import java.util.Properties
 import java.io.FileInputStream
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("com.google.devtools.ksp") version "2.2.0-2.0.2"
+    id("com.google.devtools.ksp") version "2.3.9"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+base {
+    archivesName.set("de.salomax.currencies-v12300")
 }
 
 android {
     namespace = "de.salomax.currencies"
-    compileSdk = 35
-    buildToolsVersion = "35.0.0"
+    compileSdk = 36
+    buildToolsVersion = "36.0.0"
 
     defaultConfig {
         applicationId = "de.salomax.currencies"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         // SemVer
         versionName = "1.23.0"
         versionCode = 12300
-        setProperty("archivesBaseName", "$applicationId-v$versionCode")
     }
 
     signingConfigs {
@@ -67,10 +76,6 @@ android {
         targetCompatibility(JavaVersion.VERSION_17)
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     testOptions {
         unitTests.isReturnDefaultValues = true
     }
@@ -86,20 +91,20 @@ android {
 
 dependencies {
     // kotlin
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     // support libs
     val appCompatVersion = "1.7.1"
     implementation("androidx.appcompat:appcompat:$appCompatVersion")
     implementation("androidx.appcompat:appcompat-resources:$appCompatVersion")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    val livecycleVersion = "2.9.1"
+    val livecycleVersion = "2.11.0"
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$livecycleVersion")
     implementation("androidx.preference:preference-ktx:1.2.1")
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("androidx.window:window:1.4.0")
-    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
+    implementation("androidx.window:window:1.5.1")
+    implementation("com.google.android.material:material:1.14.0")
     // downloader
     val fuelVersion = "2.3.1"
     implementation("com.github.kittinunf.fuel:fuel:$fuelVersion")
@@ -115,7 +120,7 @@ dependencies {
     implementation("com.robinhood.spark:spark:1.2.0")
     // test
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.mockito:mockito-core:5.18.0")
+    testImplementation("org.mockito:mockito-core:5.23.0")
 }
 
 fun getSecret(key: String): String? {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.4.0" apply false
     // dependency-update-checker
-    id("com.github.ben-manes.versions") version "0.52.0"
+    id("com.github.ben-manes.versions") version "0.54.0"
 }
 
 // only check for stable versions

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/helpers/build.gradle.kts
+++ b/helpers/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("kotlin")
+    id("org.jetbrains.kotlin.jvm")
 }
 
 tasks.withType<KotlinCompile>().configureEach {


### PR DESCRIPTION
## Summary

Bumps build tooling and library dependencies to the latest stable versions reported by `./gradlew dependencyUpdates`.

### Build tooling (major bumps)
- Gradle wrapper `8.14.3` → `9.6.1`
- Android Gradle Plugin `8.11.1` → `9.2.1`
- Kotlin `2.2.0` → `2.4.0`
- KSP `2.2.0-2.0.2` → `2.3.9`
- ben-manes versions plugin `0.52.0` → `0.54.0`

### Migrations required by AGP 9 / Gradle 9 / Kotlin 2.4
- Removed `org.jetbrains.kotlin.android` — AGP 9 provides Kotlin support built-in.
- Root plugin switched to `org.jetbrains.kotlin.jvm` so the `helpers` module still gets a Kotlin classpath.
- `helpers/build.gradle.kts`: `id("kotlin")` → `id("org.jetbrains.kotlin.jvm")`.
- `kotlinOptions { jvmTarget = ... }` removed → replaced with top-level `kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_17) } }`.
- `defaultConfig { setProperty("archivesBaseName", ...) }` removed by Gradle 9 → replaced with top-level `base { archivesName.set(...) }`.

### Android SDK
- `compileSdk` / `targetSdk` `35` → `36`
- `buildToolsVersion` `35.0.0` → `36.0.0`

### Library bumps
- `androidx.core:core-ktx` `1.16.0` → `1.18.0` (1.19.0 requires compileSdk 37)
- `androidx.lifecycle:*` `2.9.1` → `2.11.0`
- `androidx.swiperefreshlayout` `1.1.0` → `1.2.0`
- `androidx.window` `1.4.0` → `1.5.1`
- `com.google.android.material` `1.12.0` → `1.14.0`
- `org.mockito:mockito-core` `5.18.0` → `5.23.0`

### Intentionally left alone
- `org.mariuszgromada.math:MathParser.org-mXparser` stays on `4.4.3` (5.x+ has a license incompatible with F-Droid).
- All other direct deps (appcompat 1.7.1, constraintlayout 2.2.1, preference-ktx 1.2.1, fuel 2.3.1, moshi 1.15.2, spark 1.2.0, junit 4.13.2) are already on the latest stable.

## Test plan
- [ ] CI `Build` workflow (`./gradlew check assembleDebug`) passes on master
- [ ] CI `Build APK artifact` workflow produces an fdroid debug APK
- [ ] Local: `assembleFdroidDebug` completed configuration + Kotlin/Java compile on Termux; full APK build blocked only by Termux's inability to run the x86_64 aapt2 binary (env-only, not a project issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)