### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/apk-artifact.yaml
+++ b/.github/workflows/apk-artifact.yaml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup java environment
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build fdroid debug APK
         run: ./gradlew assembleFdroidDebug
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: currencies-fdroid-debug-${{ github.sha }}
           path: app/build/outputs/apk/fdroid/debug/*.apk

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup java environment
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Lint, test and build the debug apk
         run: ./gradlew check assembleDebug


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v7
- `actions/setup-java` v4 → v5
- `gradle/actions/setup-gradle` v4 → v6
- `actions/upload-artifact` v4 → v7

Fixes the GitHub Actions warning:
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

Independent of #3 and #4 — CI-only.

## Test plan
- [ ] Both `Build` and `Build APK artifact` workflows succeed without the Node 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)