### PR TITLE
chore: bump JDK to 21 and Android SDK to 37

### DIFF
--- a/.github/workflows/apk-artifact.yaml
+++ b/.github/workflows/apk-artifact.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup java environment
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Setup Gradle

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup java environment
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Setup Gradle

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,13 +21,13 @@ base {
 
 android {
     namespace = "de.salomax.currencies"
-    compileSdk = 36
-    buildToolsVersion = "36.0.0"
+    compileSdk = 37
+    buildToolsVersion = "37.0.0"
 
     defaultConfig {
         applicationId = "de.salomax.currencies"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         // SemVer
         versionName = "1.23.0"
         versionCode = 12300
@@ -91,7 +91,7 @@ android {
 
 dependencies {
     // kotlin
-    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.core:core-ktx:1.19.0")
     // support libs
     val appCompatVersion = "1.7.1"
     implementation("androidx.appcompat:appcompat:$appCompatVersion")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 
@@ -72,8 +72,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility(JavaVersion.VERSION_17)
-        targetCompatibility(JavaVersion.VERSION_17)
+        sourceCompatibility(JavaVersion.VERSION_21)
+        targetCompatibility(JavaVersion.VERSION_21)
     }
 
     testOptions {

--- a/helpers/build.gradle.kts
+++ b/helpers/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }


### PR DESCRIPTION
## Summary
Re-apply of the contents of #4, which was accidentally merged into its base branch (`chore/update-dependencies`) rather than master, so its changes never landed on `master`.

- Kotlin `jvmTarget` and Java `source/targetCompatibility` 17 → 21 in `app` and `helpers`
- CI `setup-java` 17 → 21 in both workflows
- `compileSdk` and `targetSdk` 36 → 37 (API 37 stable)
- `buildToolsVersion` 36.0.0 → 37.0.0
- `androidx.core:core-ktx` 1.18.0 → 1.19.0 (requires compileSdk 37)

## Test plan
- [ ] CI `Build APK artifact` workflow succeeds on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)