### PR TITLE
chore: drop deprecated AGP flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,12 +15,9 @@ org.gradle.jvmargs=-Xmx2048m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 
 systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
 systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl


### PR DESCRIPTION
## Summary
- Remove `android.enableJetifier=true` (default is `false`; all direct deps are AndroidX)
- Remove `android.nonFinalResIds=false` (default is `true`)

Both flags emit AGP deprecation warnings and will be removed in AGP 10.0.

## Test plan
- [ ] CI `apk-artifact.yaml` builds `assembleFdroidDebug` without the two warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)