### PR TITLE
chore: clean up Kotlin compiler warnings

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
@@ -100,7 +100,7 @@ internal class BankOfCanadaTimelineAdapter(
             }
             if (date != null && baseValue != null && symbolValue != null) {
                 reader.endObject()
-                return Pair(date, Rate(symbol, baseValue!! / symbolValue!!))
+                return Pair(date, Rate(symbol, baseValue / symbolValue))
             }
         }
         return null

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiTimelineXmlParser.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiTimelineXmlParser.kt
@@ -47,7 +47,7 @@ class BankRossiiTimelineXmlParser(private val ids: Map<String, String>) {
                     if (date != null && value != null && currencyId != null && ids[currencyId] != null) {
                         val currency = Currency.fromString(ids[currencyId]!!)
                         if (currency != null)
-                            rates[date] = Rate(currency, value.toFloat())
+                            rates[date] = Rate(currency, value)
                     }
                     // reset
                     date = null

--- a/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
@@ -20,7 +20,7 @@ import java.util.*
  * - system=af & app=system-default -> en (as there's no af localization it falls back to en)
  */
 fun getLocale(context: Context): Locale {
-    return AppCompatDelegate.getApplicationLocales()[0] ?: Locale(
+    return AppCompatDelegate.getApplicationLocales()[0] ?: Locale.of(
         context.getString(R.string.locale_language),
         context.getString(R.string.locale_country)
     )


### PR DESCRIPTION
## Summary
- Drop unnecessary `!!` on locals already smart-cast to non-null `Float` in `BankOfCanadaTimelineAdapter`
- Drop redundant `Float.toFloat()` call in `BankRossiiTimelineXmlParser`
- Use `Locale.of(...)` (added in Java 19) instead of the JDK-21-deprecated `Locale(String, String)` constructor in `TextUtils`

## Test plan
- [ ] CI `apk-artifact.yaml` builds `assembleFdroidDebug` with none of these three warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)