### PR TITLE
ci: pin GITHUB_TOKEN to contents:read (least-privilege)

### DIFF
--- a/.github/workflows/apk-artifact.yaml
+++ b/.github/workflows/apk-artifact.yaml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds workflow-level `permissions: contents: read` to both workflows. Resolves CodeQL `actions/missing-workflow-permissions` alerts (medium).

Neither workflow writes to the repo — they only check out code, run Gradle, and upload an artifact.

## Test plan
- [ ] `apk-artifact.yaml` still builds and uploads the fdroid debug APK on this PR
- [ ] CodeQL rescan shows the two alerts closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)