### PR TITLE
ci: add code-quality and security scan workflows

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,22 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: raven-actions/actionlint@v2
+        with:
+          fail-on-error: true

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: on-failure
+          fail-on-severity: high

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  DETEKT_VERSION: "1.23.7"
+
 jobs:
   detekt:
     runs-on: ubuntu-latest
@@ -18,18 +21,23 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
+      - name: Install detekt CLI
+        run: |
+          curl -sSLo detekt-cli.zip \
+            "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}.zip"
+          unzip -q detekt-cli.zip
+          echo "$PWD/detekt-cli-${DETEKT_VERSION}/bin" >> "$GITHUB_PATH"
       - name: Run detekt
-        uses: natiginfo/action-detekt-all@1.23.7
         continue-on-error: true
-        with:
-          args: >-
-            --input app/src,helpers/src
-            --report sarif:detekt-results.sarif
-            --report txt:detekt-results.txt
+        run: |
+          detekt-cli \
+            --input app/src,helpers/src \
+            --report sarif:detekt-results.sarif \
+            --report txt:detekt-results.txt \
             --jvm-target 21
       - name: Upload SARIF to code scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        if: always() && hashFiles('detekt-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: detekt-results.sarif
           category: detekt
@@ -40,3 +48,4 @@ jobs:
           name: detekt-report
           path: detekt-results.*
           retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -1,0 +1,42 @@
+name: Detekt
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  detekt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Run detekt
+        uses: natiginfo/action-detekt-all@1.23.7
+        continue-on-error: true
+        with:
+          args: >-
+            --input app/src,helpers/src
+            --report sarif:detekt-results.sarif
+            --report txt:detekt-results.txt
+            --jvm-target 21
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: detekt-results.sarif
+          category: detekt
+      - name: Upload detekt report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: detekt-report
+          path: detekt-results.*
+          retention-days: 14

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,23 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/owasp-dependency-check.yaml
+++ b/.github/workflows/owasp-dependency-check.yaml
@@ -1,0 +1,48 @@
+name: OWASP Dependency Check
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Resolve app runtime dependencies
+        run: |
+          ./gradlew :app:dependencies \
+            --configuration fdroidReleaseRuntimeClasspath > /dev/null
+      - name: Run OWASP Dependency-Check
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: currencies
+          path: '.'
+          format: SARIF
+          out: reports
+          args: >-
+            --failOnCVSS 7
+            --enableRetired
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/dependency-check-report.sarif
+          category: owasp-dependency-check
+      - name: Upload full report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: owasp-report
+          path: reports/
+          retention-days: 30

--- a/.github/workflows/owasp-dependency-check.yaml
+++ b/.github/workflows/owasp-dependency-check.yaml
@@ -35,7 +35,7 @@ jobs:
             --enableRetired
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: reports/dependency-check-report.sarif
           category: owasp-dependency-check

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -32,6 +32,6 @@ jobs:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,37 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,38 @@
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config=p/default \
+            --config=p/security-audit \
+            --config=p/kotlin \
+            --config=p/java \
+            --config=p/github-actions \
+            --sarif \
+            --output=semgrep.sarif \
+            || true
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -32,7 +32,7 @@ jobs:
             || true
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
## Summary

Adds 7 new workflows:

| Workflow | Trigger | Purpose |
|---|---|---|
| `dependency-review.yaml` | PR | Blocks PRs adding high-severity vulnerable deps (GitHub-native) |
| `actionlint.yaml` | PR + main (workflow paths) | Validates workflow YAML syntax/expressions |
| `scorecard.yaml` | main + weekly | OpenSSF supply-chain posture, publishes to code scanning |
| `detekt.yaml` | PR + main | Kotlin static analysis, non-blocking, SARIF to code scanning |
| `gitleaks.yaml` | PR + main + weekly | Historical secret scan across full git history |
| `owasp-dependency-check.yaml` | weekly | Extra SCA on top of Dependabot |
| `semgrep.yaml` | PR + main + weekly | SAST across kotlin/java/actions rulesets |

All workflows use least-privilege `GITHUB_TOKEN` scopes.

## Notes
- Detekt runs with default config and `continue-on-error: true` — findings surface in Code Scanning but don't block merges. Tighten later if noise stays low.
- OWASP dep check may overlap with Dependabot; kept weekly per request.
- Semgrep uses public rulesets; no auth token needed.
- Scheduled runs are staggered (Mon 06:00 / 07:00 / 08:00 / 09:00 UTC).

## Test plan
- [ ] Each workflow runs to green (or expected outcome) on this PR
- [ ] Findings appear in Code Scanning tab after merge
- [ ] No workflow needs additional secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)