### PR TITLE
docs: add Markdown reference docs and GitHub Pages site

### DIFF
--- a/docs/html/CNAME
+++ b/docs/html/CNAME
@@ -1,0 +1,1 @@
+currencies.machlev.org

--- a/docs/html/features.html
+++ b/docs/html/features.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Features — Currencies</title>
+  <meta name="description" content="Full list of features in the Currencies Android app — calculator, historical rates, charts, fee calculator, themes, and more.">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💱</text></svg>">
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-brand" href="index.html">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      Currencies
+    </a>
+    <ul class="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="features.html" class="active">Features</a></li>
+      <li><a href="providers.html">Providers</a></li>
+      <li><a href="privacy.html">Privacy</a></li>
+    </ul>
+  </div>
+</nav>
+
+<header class="hero" style="padding: 3.5rem 1.5rem 3rem;">
+  <div class="hero-inner">
+    <h1 style="font-size:clamp(1.6rem,4vw,2.4rem);">Features</h1>
+    <p class="tagline" style="font-size:1.05rem;">Everything Currencies can do, explained in one place.</p>
+  </div>
+</header>
+
+<main class="page">
+
+  <h2 class="section-title">Currency Conversion</h2>
+  <div class="cards">
+    <div class="card">
+      <span class="card-icon">🌐</span>
+      <h3>Multiple Providers</h3>
+      <p>Choose from 6 active exchange-rate providers. Switch at any time in Settings — the next refresh uses the new source.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">⭐</span>
+      <h3>Starred Currencies</h3>
+      <p>Mark currencies as favourites to keep your most-used ones at the top. Tap the star icon next to any currency to toggle.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🔄</span>
+      <h3>Swap &amp; Mirror</h3>
+      <p>Instantly swap the base and target currencies. The conversion result updates in real time without re-entering values.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">📋</span>
+      <h3>Copy / Paste</h3>
+      <p>Long-press the result to copy it to the clipboard, or paste a value directly into the input field.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Calculator</h2>
+  <div class="cards">
+    <div class="card">
+      <span class="card-icon">🧮</span>
+      <h3>Full Arithmetic</h3>
+      <p>Addition, subtraction, multiplication, and division — evaluated before conversion using the <strong>mXparser</strong> engine.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">⌨️</span>
+      <h3>Extended Keypad</h3>
+      <p>Optional expanded keypad mode adds operator keys directly on the main screen. Enable in Settings → Extended keypad.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🖥️</span>
+      <h3>Hardware Keyboard</h3>
+      <p>Physical keyboard input is fully supported — great for tablets and foldable devices with an attached keyboard.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Fee Calculator</h2>
+  <div class="cards" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));">
+    <div class="card">
+      <span class="card-icon">💳</span>
+      <h3>Foreign Exchange Fee</h3>
+      <p>Add a configurable fee percentage (e.g., 1.5 %) to every conversion. The result shows both the raw and fee-inclusive amounts simultaneously.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🔧</span>
+      <h3>Custom Percentage</h3>
+      <p>Set any fee from 0 % to any value in Settings. Useful for credit-card foreign-transaction fees or bureau-de-change margins.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Historical Rates &amp; Charts</h2>
+  <div class="cards">
+    <div class="card">
+      <span class="card-icon">📅</span>
+      <h3>Past Dates</h3>
+      <p>Select any historical date using the built-in date picker. Data availability depends on the provider — Frankfurter.app goes back to <strong>2010-01-04</strong>.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">📈</span>
+      <h3>1-Year Chart</h3>
+      <p>Tap the chart icon on the converter to see a full year of daily rate history for the selected currency pair.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🔍</span>
+      <h3>Interactive Timeline</h3>
+      <p>Scrub along the chart to see exact rates on any day. High and low points are highlighted for quick reference.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">UI &amp; Customisation</h2>
+  <div class="cards">
+    <div class="card">
+      <span class="card-icon">🎨</span>
+      <h3>Material 3 Design</h3>
+      <p>Built with the latest Material Design system components — adaptive colours, proper elevation, and dynamic theming.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🌙</span>
+      <h3>Dark &amp; Pure Black</h3>
+      <p>Three theme options: Light, Dark, and Pure Black (OLED-friendly). Follows system setting or can be locked manually.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">📱</span>
+      <h3>Foldable Support</h3>
+      <p>Detects fold state via <code>WindowInfoTracker</code> and switches to a multi-pane layout when unfolded, making full use of the larger screen.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🌏</span>
+      <h3>20+ Languages</h3>
+      <p>Translated by the community via <a href="https://translate.codeberg.org/engage/currencies/">Weblate</a>. RTL languages are fully supported.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Privacy &amp; Permissions</h2>
+  <div class="cards" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));">
+    <div class="card">
+      <span class="card-icon">🔒</span>
+      <h3>Single Permission</h3>
+      <p>Only <code>INTERNET</code> is requested — to fetch exchange rates. No location, no contacts, no camera, no microphone.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🚫</span>
+      <h3>No Tracking</h3>
+      <p>Zero advertising SDKs. Zero analytics. No crash reporter. Your usage never leaves your device.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">💾</span>
+      <h3>Local Storage Only</h3>
+      <p>All data (cached rates, preferences, starred currencies) is stored in SharedPreferences on your device. Nothing is synced to any server.</p>
+    </div>
+  </div>
+
+</main>
+
+<footer>
+  <p>Currencies &copy; 2020 Maximilian Salomon &mdash; Licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL-3.0</a></p>
+  <p style="margin-top:.4rem;"><a href="https://github.com/sal0max/currencies">GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="https://translate.codeberg.org/engage/currencies/">Translate</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Currencies — Simple Currency Converter for Android</title>
+  <meta name="description" content="A simple, privacy-focused currency converter for Android. No ads, no tracking. Supports 6 exchange rate providers with 30–160+ currencies.">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💱</text></svg>">
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <span class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      Currencies
+    </span>
+    <ul class="nav-links">
+      <li><a href="index.html" class="active">Home</a></li>
+      <li><a href="features.html">Features</a></li>
+      <li><a href="providers.html">Providers</a></li>
+      <li><a href="privacy.html">Privacy</a></li>
+    </ul>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="hero-inner">
+    <div class="hero-icon">💱</div>
+    <h1>Currencies</h1>
+    <p class="tagline">A simple, ad-free currency converter for Android — built for travellers, not traders.</p>
+    <div class="badge-row">
+      <a class="badge" href="https://play.google.com/store/apps/details?id=de.salomax.currencies">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M3 20.5v-17c0-.83 1-.83 1.5-.5l15 8.5-15 8.5c-.5.33-1.5.33-1.5-.5z"/></svg>
+        Google Play
+      </a>
+      <a class="badge" href="https://f-droid.org/packages/de.salomax.currencies/">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15v-4H7l5-8v4h4l-5 8z"/></svg>
+        F-Droid
+      </a>
+      <a class="badge" href="https://github.com/sal0max/currencies">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.37.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.83 2.8 1.3 3.49 1 .11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.14 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.82 1.1.82 2.22v3.29c0 .32.21.7.83.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
+        Source
+      </a>
+    </div>
+  </div>
+</header>
+
+<main class="page">
+
+  <h2 class="section-title">Why Currencies?</h2>
+  <div class="cards">
+    <div class="card">
+      <span class="card-icon">🔒</span>
+      <h3>Privacy First</h3>
+      <p>No ads, no analytics, no crash reporters. The only network call is fetching exchange rates from the provider you choose.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🌍</span>
+      <h3>160+ Currencies</h3>
+      <p>From major world currencies to exotic ones — choose from 6 exchange-rate providers offering 30–160+ currencies each.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🧮</span>
+      <h3>Built-in Calculator</h3>
+      <p>Do full arithmetic (+, −, ×, ÷) before converting. Perfect for splitting restaurant bills or calculating bulk prices.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">📈</span>
+      <h3>Historical Charts</h3>
+      <p>See a full year of exchange-rate history at a glance, or look up rates on any past date back to 2010.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🎨</span>
+      <h3>Material 3 Design</h3>
+      <p>Clean adaptive UI with light, dark, and pure-black themes. Follows your system theme automatically.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">📱</span>
+      <h3>Foldable-Ready</h3>
+      <p>Adaptive multi-pane layout on foldable devices. Proper support for hardware keyboards and all screen sizes.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Exchange Rate Providers</h2>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Currencies</th>
+          <th>Updates</th>
+          <th>Base</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Frankfurter.app</strong><br><small>European Central Bank</small></td>
+          <td><span class="tag">~33</span></td>
+          <td>Business days</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
+          <td><strong>OpenExchangerates</strong></td>
+          <td><span class="tag">160+</span></td>
+          <td>Hourly</td>
+          <td>USD</td>
+        </tr>
+        <tr>
+          <td><strong>InforEuro</strong><br><small>European Commission</small></td>
+          <td><span class="tag">~150</span></td>
+          <td>Monthly</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
+          <td><strong>Bank of Canada</strong></td>
+          <td><span class="tag">~23</span></td>
+          <td>Business days</td>
+          <td>CAD</td>
+        </tr>
+        <tr>
+          <td><strong>Norges Bank</strong></td>
+          <td><span class="tag">~40</span></td>
+          <td>Business days</td>
+          <td>NOK</td>
+        </tr>
+        <tr>
+          <td><strong>Bank Rossii</strong></td>
+          <td><span class="tag">~44</span></td>
+          <td>Business days</td>
+          <td>RUB</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="section-title">Open Source</h2>
+  <div class="cards" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));">
+    <div class="card">
+      <span class="card-icon">⚖️</span>
+      <h3>GPL-3.0 License</h3>
+      <p>Full source code available on GitHub. Inspect, audit, fork, and contribute under the GNU General Public License v3.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🔄</span>
+      <h3>F-Droid Reproducible</h3>
+      <p>The <code>fdroid</code> build flavor is reproducible and fully free of proprietary SDKs — verified by the F-Droid build system.</p>
+    </div>
+    <div class="card">
+      <span class="card-icon">🛡️</span>
+      <h3>Automated Security</h3>
+      <p>CI runs Detekt, Qodana, Semgrep, OWASP Dependency Check, Gitleaks, and OpenSSF Scorecard on every change.</p>
+    </div>
+  </div>
+
+</main>
+
+<footer>
+  <p>Currencies &copy; 2020 Maximilian Salomon &mdash; Licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL-3.0</a></p>
+  <p style="margin-top:.4rem;"><a href="https://github.com/sal0max/currencies">GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="https://translate.codeberg.org/engage/currencies/">Translate</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/html/privacy.html
+++ b/docs/html/privacy.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Currencies</title>
+  <meta name="description" content="Privacy policy for the Currencies Android app. The app does not collect, store, or share any personal data.">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💱</text></svg>">
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-brand" href="index.html">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      Currencies
+    </a>
+    <ul class="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="features.html">Features</a></li>
+      <li><a href="providers.html">Providers</a></li>
+      <li><a href="privacy.html" class="active">Privacy</a></li>
+    </ul>
+  </div>
+</nav>
+
+<header class="hero" style="padding: 3.5rem 1.5rem 3rem;">
+  <div class="hero-inner">
+    <h1 style="font-size:clamp(1.6rem,4vw,2.4rem);">Privacy Policy</h1>
+    <p class="tagline" style="font-size:1.05rem;">Short version: we collect nothing. The long version is below.</p>
+  </div>
+</header>
+
+<main class="page">
+
+  <div class="prose">
+
+    <p><em>Last updated: July 2026</em></p>
+
+    <h2>Summary</h2>
+    <p>Currencies does <strong>not</strong> collect, transmit, store, or share any personal data. The app has no account system, no analytics, no advertising SDK, and no crash reporter. The sole network activity is fetching exchange rates from the provider you select.</p>
+
+    <h2>Data Collected by This App</h2>
+    <p><strong>None.</strong> The app does not collect any data whatsoever from users.</p>
+
+    <h2>Permissions</h2>
+    <p>The app requests a single Android permission:</p>
+    <ul>
+      <li><strong><code>android.permission.INTERNET</code></strong> — required to download exchange rates from the selected provider. No other permission is requested or used.</li>
+    </ul>
+    <p>The app does <em>not</em> request access to your location, contacts, camera, microphone, storage, phone state, or any other sensitive permission.</p>
+
+    <h2>Network Activity</h2>
+    <p>The app makes outbound HTTPS requests <em>only</em> to the exchange rate provider you have selected in Settings. The request contains:</p>
+    <ul>
+      <li>The URL of the rates or history endpoint (publicly documented by each provider)</li>
+      <li>Your device's standard HTTP headers (User-Agent, Accept-Encoding, etc.)</li>
+    </ul>
+    <p>No personally identifiable information is included in these requests. The providers' own privacy policies govern how they handle server-side access logs.</p>
+
+    <h3>Provider Privacy Policies</h3>
+    <ul>
+      <li><a href="https://www.frankfurter.app/">Frankfurter.app</a> — open-source proxy, no account required</li>
+      <li><a href="https://openexchangerates.org/privacy">OpenExchangerates</a> — account required; subject to their privacy policy</li>
+      <li><a href="https://commission.europa.eu/privacy-policy-websites_en">InforEuro (European Commission)</a></li>
+      <li><a href="https://www.bankofcanada.ca/privacy/">Bank of Canada</a></li>
+      <li><a href="https://www.norges-bank.no/en/about/privacy-cookies/">Norges Bank</a></li>
+      <li><a href="https://cbr.ru/eng/contacts/policy/">Bank Rossii</a></li>
+    </ul>
+
+    <h2>Local Storage</h2>
+    <p>The following data is stored <strong>locally on your device</strong> in Android SharedPreferences. It is never transmitted to any server:</p>
+    <ul>
+      <li>Cached exchange rates (from the last successful fetch)</li>
+      <li>Selected base and target currencies</li>
+      <li>Starred (favourite) currencies</li>
+      <li>User preferences (theme, fee percentage, provider choice, extended keypad toggle)</li>
+      <li>Last selected historical date</li>
+    </ul>
+    <p>This data is cleared when you uninstall the app. It can also be cleared via Android Settings → Apps → Currencies → Clear Data.</p>
+
+    <h2>Third-Party SDKs</h2>
+    <p>Currencies does <strong>not</strong> include any third-party analytics, advertising, crash-reporting, or social-login SDK. The complete dependency list is public in the repository's <code>app/build.gradle.kts</code> file.</p>
+
+    <h2>Children</h2>
+    <p>The app does not knowingly collect any data from children or from any user, regardless of age.</p>
+
+    <h2>Changes to This Policy</h2>
+    <p>If the privacy posture of the app ever changes materially, this page will be updated and the change will be noted in the release changelog.</p>
+
+    <h2>Contact</h2>
+    <p>For privacy questions or concerns, open an issue on the <a href="https://github.com/sal0max/currencies/issues">GitHub repository</a>.</p>
+
+  </div>
+
+</main>
+
+<footer>
+  <p>Currencies &copy; 2020 Maximilian Salomon &mdash; Licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL-3.0</a></p>
+  <p style="margin-top:.4rem;"><a href="https://github.com/sal0max/currencies">GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="https://translate.codeberg.org/engage/currencies/">Translate</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/html/providers.html
+++ b/docs/html/providers.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Exchange Rate Providers — Currencies</title>
+  <meta name="description" content="Compare all exchange rate providers supported by the Currencies Android app — Frankfurter, OpenExchangerates, InforEuro, Bank of Canada, Norges Bank, Bank Rossii.">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💱</text></svg>">
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-brand" href="index.html">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      Currencies
+    </a>
+    <ul class="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="features.html">Features</a></li>
+      <li><a href="providers.html" class="active">Providers</a></li>
+      <li><a href="privacy.html">Privacy</a></li>
+    </ul>
+  </div>
+</nav>
+
+<header class="hero" style="padding: 3.5rem 1.5rem 3rem;">
+  <div class="hero-inner">
+    <h1 style="font-size:clamp(1.6rem,4vw,2.4rem);">Exchange Rate Providers</h1>
+    <p class="tagline" style="font-size:1.05rem;">Compare the 6 active data sources. Switch freely in Settings — no account needed for most.</p>
+  </div>
+</header>
+
+<main class="page">
+
+  <h2 class="section-title">Provider Comparison</h2>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Currencies</th>
+          <th>Update Frequency</th>
+          <th>Base Currency</th>
+          <th>History</th>
+          <th>API Key</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Frankfurter.app</strong><br><small style="color:var(--clr-text-muted)">European Central Bank</small></td>
+          <td><span class="tag">~33</span></td>
+          <td>Business days (~16:00 CET)</td>
+          <td>EUR</td>
+          <td>From 2010-01-04</td>
+          <td>No</td>
+        </tr>
+        <tr>
+          <td><strong>OpenExchangerates</strong></td>
+          <td><span class="tag">160+</span></td>
+          <td>Hourly</td>
+          <td>USD</td>
+          <td>Yes</td>
+          <td>Free tier available</td>
+        </tr>
+        <tr>
+          <td><strong>InforEuro</strong><br><small style="color:var(--clr-text-muted)">European Commission</small></td>
+          <td><span class="tag">~150</span></td>
+          <td>Monthly</td>
+          <td>EUR</td>
+          <td>Yes</td>
+          <td>No</td>
+        </tr>
+        <tr>
+          <td><strong>Bank of Canada</strong></td>
+          <td><span class="tag">~23</span></td>
+          <td>Business days</td>
+          <td>CAD</td>
+          <td>Yes</td>
+          <td>No</td>
+        </tr>
+        <tr>
+          <td><strong>Norges Bank</strong><br><small style="color:var(--clr-text-muted)">Norwegian Central Bank</small></td>
+          <td><span class="tag">~40</span></td>
+          <td>Business days</td>
+          <td>NOK</td>
+          <td>Yes</td>
+          <td>No</td>
+        </tr>
+        <tr>
+          <td><strong>Bank Rossii</strong><br><small style="color:var(--clr-text-muted)">Russian Central Bank</small></td>
+          <td><span class="tag">~44</span></td>
+          <td>Business days</td>
+          <td>RUB</td>
+          <td>Yes</td>
+          <td>No</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="section-title">Provider Details</h2>
+
+  <div class="cards" style="grid-template-columns: 1fr;">
+
+    <div class="card">
+      <span class="card-icon">🇪🇺</span>
+      <h3>Frankfurter.app</h3>
+      <p>A free, open-source API wrapper around the <strong>European Central Bank</strong> reference rates. Rates are published every business day around 16:00 CET. Covers major world currencies (~33). Historical data starts at 2010-01-04 and the service is highly reliable. No sign-up required.</p>
+      <p style="margin-top:.5rem;"><a href="https://frankfurter.app/">frankfurter.app</a></p>
+    </div>
+
+    <div class="card">
+      <span class="card-icon">🌐</span>
+      <h3>OpenExchangerates</h3>
+      <p>A commercial service offering the widest currency coverage of any provider in the app — <strong>160+ currencies</strong> updated hourly. The free "App ID" tier provides access to current and historical rates. A free account is required; the API key is entered in Settings.</p>
+      <p style="margin-top:.5rem;"><a href="https://openexchangerates.org/">openexchangerates.org</a></p>
+    </div>
+
+    <div class="card">
+      <span class="card-icon">🏛️</span>
+      <h3>InforEuro</h3>
+      <p>The <strong>European Commission's</strong> official monthly accounting rates for the euro, used for EU budget and grant calculations. Covers ~150 currencies and is updated once per month. Ideal when you need the official EU rate rather than market rates.</p>
+      <p style="margin-top:.5rem;"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_en">European Commission</a></p>
+    </div>
+
+    <div class="card">
+      <span class="card-icon">🍁</span>
+      <h3>Bank of Canada</h3>
+      <p>Daily exchange rates published by the <strong>Canadian Central Bank</strong>. Covers approximately 23 currencies against CAD. Updated every business day. No API key required.</p>
+      <p style="margin-top:.5rem;"><a href="https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates/">bankofcanada.ca</a></p>
+    </div>
+
+    <div class="card">
+      <span class="card-icon">🇳🇴</span>
+      <h3>Norges Bank</h3>
+      <p>The <strong>Norwegian Central Bank</strong> publishes about 40 exchange rates against NOK every business day. Data is returned as XML and parsed natively in the app. No API key required.</p>
+      <p style="margin-top:.5rem;"><a href="https://www.norges-bank.no/en/topics/Statistics/exchange_rates/">norges-bank.no</a></p>
+    </div>
+
+    <div class="card">
+      <span class="card-icon">🇷🇺</span>
+      <h3>Bank Rossii</h3>
+      <p>The <strong>Russian Central Bank</strong> lists ~44 exchange rates against RUB, updated every business day. Returns XML data. Particularly useful for RUB-based conversions and as a reliable fallback for providers that have been retired.</p>
+      <p style="margin-top:.5rem;"><a href="https://cbr.ru/eng/currency_base/daily/">cbr.ru</a></p>
+    </div>
+
+  </div>
+
+  <h2 class="section-title" style="margin-top:2.5rem;">Retired &amp; Deactivated Providers</h2>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th>Provider</th><th>Reason</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>fer.ee</strong></td>
+          <td>Deactivated — persistent API instability made it unreliable</td>
+        </tr>
+        <tr>
+          <td><strong>exchangerate.host</strong></td>
+          <td>Removed — the service shut down its free API</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="section-title">Switching Providers</h2>
+  <div class="prose">
+    <p>Open <strong>Settings → Exchange rate provider</strong> and select a provider. The change takes effect immediately on the next pull-to-refresh or app restart. Cached rates from the previous provider are discarded.</p>
+    <p>If a provider requires an API key (currently only OpenExchangerates), an input field appears in Settings after selecting it. The key is stored locally in SharedPreferences and is never transmitted to any server other than the provider's own API.</p>
+  </div>
+
+</main>
+
+<footer>
+  <p>Currencies &copy; 2020 Maximilian Salomon &mdash; Licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL-3.0</a></p>
+  <p style="margin-top:.4rem;"><a href="https://github.com/sal0max/currencies">GitHub</a> &middot; <a href="privacy.html">Privacy</a> &middot; <a href="https://translate.codeberg.org/engage/currencies/">Translate</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/html/style.css
+++ b/docs/html/style.css
@@ -1,0 +1,294 @@
+/* ── Reset & base ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --clr-primary:      #2E7D32;
+  --clr-primary-lt:   #4CAF50;
+  --clr-primary-dk:   #1B5E20;
+  --clr-accent:       #FFC107;
+  --clr-bg:           #F9FBF9;
+  --clr-surface:      #FFFFFF;
+  --clr-border:       #DCE8DC;
+  --clr-text:         #1A1A1A;
+  --clr-text-muted:   #5A6B5A;
+  --clr-nav-bg:       #1B5E20;
+  --clr-nav-text:     #E8F5E9;
+  --clr-hero-bg:      #1B5E20;
+  --clr-hero-text:    #FFFFFF;
+  --clr-card-bg:      #FFFFFF;
+  --clr-tag-bg:       #E8F5E9;
+  --clr-tag-text:     #1B5E20;
+  --shadow:           0 2px 12px rgba(0,0,0,.08);
+  --radius:           12px;
+  --radius-sm:        8px;
+  --font:             'Segoe UI', system-ui, -apple-system, sans-serif;
+  --max-w:            960px;
+  --transition:       0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --clr-bg:           #0E1A0E;
+    --clr-surface:      #162016;
+    --clr-border:       #2A3D2A;
+    --clr-text:         #E8F5E9;
+    --clr-text-muted:   #8DB88D;
+    --clr-nav-bg:       #0A140A;
+    --clr-nav-text:     #C8E6C9;
+    --clr-hero-bg:      #0A140A;
+    --clr-hero-text:    #E8F5E9;
+    --clr-card-bg:      #162016;
+    --clr-tag-bg:       #1B3A1B;
+    --clr-tag-text:     #81C784;
+    --shadow:           0 2px 12px rgba(0,0,0,.4);
+  }
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font);
+  background: var(--clr-bg);
+  color: var(--clr-text);
+  line-height: 1.65;
+  font-size: 16px;
+}
+
+a { color: var(--clr-primary-lt); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Navigation ───────────────────────────────────────────── */
+nav {
+  background: var(--clr-nav-bg);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0,0,0,.3);
+}
+
+.nav-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  height: 56px;
+}
+
+.nav-brand {
+  color: var(--clr-nav-text);
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: .02em;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  white-space: nowrap;
+}
+
+.nav-brand svg { flex-shrink: 0; }
+
+.nav-links {
+  display: flex;
+  gap: 0;
+  list-style: none;
+  margin-left: auto;
+}
+
+.nav-links a {
+  color: var(--clr-nav-text);
+  opacity: .8;
+  padding: .4rem .85rem;
+  border-radius: var(--radius-sm);
+  font-size: .92rem;
+  transition: opacity var(--transition), background var(--transition);
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  opacity: 1;
+  background: rgba(255,255,255,.1);
+  text-decoration: none;
+}
+
+/* ── Hero ─────────────────────────────────────────────────── */
+.hero {
+  background: var(--clr-hero-bg);
+  color: var(--clr-hero-text);
+  padding: 5rem 1.5rem 4rem;
+  text-align: center;
+}
+
+.hero-inner { max-width: var(--max-w); margin: 0 auto; }
+
+.hero-icon {
+  width: 96px;
+  height: 96px;
+  background: rgba(255,255,255,.12);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.5rem;
+  font-size: 2.8rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -.02em;
+  margin-bottom: .75rem;
+}
+
+.hero .tagline {
+  font-size: 1.2rem;
+  opacity: .85;
+  max-width: 540px;
+  margin: 0 auto 2rem;
+}
+
+.badge-row {
+  display: flex;
+  gap: .75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  background: rgba(255,255,255,.15);
+  border: 1px solid rgba(255,255,255,.25);
+  color: var(--clr-hero-text);
+  padding: .5rem 1rem;
+  border-radius: 999px;
+  font-size: .9rem;
+  font-weight: 500;
+  transition: background var(--transition);
+}
+
+.badge:hover {
+  background: rgba(255,255,255,.25);
+  text-decoration: none;
+}
+
+/* ── Page wrapper ─────────────────────────────────────────── */
+.page {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+/* ── Section title ────────────────────────────────────────── */
+.section-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  padding-bottom: .5rem;
+  border-bottom: 2px solid var(--clr-border);
+  color: var(--clr-primary);
+}
+
+/* ── Cards grid ───────────────────────────────────────────── */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.card {
+  background: var(--clr-card-bg);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0,0,0,.12); }
+
+.card-icon {
+  font-size: 1.8rem;
+  margin-bottom: .75rem;
+  display: block;
+}
+
+.card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: .4rem;
+  color: var(--clr-primary);
+}
+
+.card p {
+  font-size: .92rem;
+  color: var(--clr-text-muted);
+  line-height: 1.55;
+}
+
+/* ── Tables ───────────────────────────────────────────────── */
+.table-wrap { overflow-x: auto; margin-bottom: 2.5rem; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--clr-card-bg);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  font-size: .93rem;
+}
+
+thead { background: var(--clr-primary); color: #fff; }
+thead th { padding: .85rem 1rem; text-align: left; font-weight: 600; }
+tbody tr:nth-child(even) { background: var(--clr-tag-bg); }
+tbody td { padding: .75rem 1rem; border-bottom: 1px solid var(--clr-border); vertical-align: top; }
+tbody tr:last-child td { border-bottom: none; }
+
+.tag {
+  display: inline-block;
+  background: var(--clr-tag-bg);
+  color: var(--clr-tag-text);
+  border-radius: 999px;
+  padding: .15rem .6rem;
+  font-size: .78rem;
+  font-weight: 600;
+}
+
+/* ── Prose ────────────────────────────────────────────────── */
+.prose h2 { font-size: 1.35rem; font-weight: 700; margin: 2rem 0 .75rem; color: var(--clr-primary); }
+.prose h3 { font-size: 1.1rem; font-weight: 600; margin: 1.5rem 0 .5rem; }
+.prose p  { margin-bottom: 1rem; }
+.prose ul, .prose ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+.prose li { margin-bottom: .35rem; }
+.prose code {
+  background: var(--clr-tag-bg);
+  color: var(--clr-primary-dk);
+  padding: .1em .35em;
+  border-radius: 4px;
+  font-size: .88em;
+  font-family: 'Courier New', monospace;
+}
+
+/* ── Footer ───────────────────────────────────────────────── */
+footer {
+  background: var(--clr-nav-bg);
+  color: var(--clr-nav-text);
+  text-align: center;
+  padding: 2rem 1.5rem;
+  font-size: .88rem;
+  opacity: .9;
+}
+
+footer a { color: var(--clr-primary-lt); }
+
+/* ── Responsive ───────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .nav-links a { padding: .4rem .55rem; font-size: .82rem; }
+  .hero { padding: 3.5rem 1rem 3rem; }
+  .page { padding: 2rem 1rem 4rem; }
+  .cards { grid-template-columns: 1fr; }
+}

--- a/docs/markDown/api-providers.md
+++ b/docs/markDown/api-providers.md
@@ -1,0 +1,38 @@
+# Exchange Rate Providers
+
+Currencies supports multiple exchange-rate data sources. The active provider is selected in **Settings → Exchange rate provider**. Switching takes effect on the next refresh.
+
+## Comparison
+
+| Provider | Currencies | Update freq | Base | Notes |
+|---|---|---|---|---|
+| [Frankfurter.app](https://frankfurter.app/) | ~33 | Business days | EUR | European Central Bank data |
+| [OpenExchangerates](https://openexchangerates.org/) | 160+ | Hourly | USD | Free tier requires API key |
+| [InforEuro](https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_en) | ~150 | Monthly | EUR | EU Commission accounting rates |
+| [Bank of Canada](https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates/) | ~23 | Business days | CAD | Canadian Central Bank |
+| [Norges Bank](https://www.norges-bank.no/en/topics/Statistics/exchange_rates/) | ~40 | Business days | NOK | Norwegian Central Bank |
+| [Bank Rossii](https://cbr.ru/eng/currency_base/daily/) | ~44 | Business days | RUB | Russian Central Bank |
+
+## Deactivated / Removed Providers
+
+| Provider | Reason |
+|---|---|
+| fer.ee | Persistent API instability |
+| exchangerate.host | API shutdown |
+
+## Historical Rate Support
+
+All active providers support historical rates to varying degrees. Frankfurter.app data goes back to **2010-01-04** (ECB reference start date). Bank Rossii and InforEuro have their own historical archives.
+
+When a historical date is selected in the app, the provider's history endpoint is queried instead of the live-rates endpoint.
+
+## Provider Implementation
+
+Each provider is implemented as an object inside `app/src/main/kotlin/de/salomax/currencies/model/provider/`. They all conform to the `Api` abstract interface defined in `ApiProvider.kt`:
+
+```kotlin
+abstract fun getRates(base: Currency, date: LocalDate?): Call<ExchangeRates?>
+abstract fun getTimeline(base: Currency, quote: Currency): Call<Timeline?>
+```
+
+Response parsing is handled by provider-specific Moshi adapters (`model/adapter/`) or SAX XML parsers (for Norges Bank and Bank Rossii, which return XML).

--- a/docs/markDown/architecture.md
+++ b/docs/markDown/architecture.md
@@ -1,0 +1,93 @@
+# Architecture
+
+Currencies follows **MVVM** (Model-View-ViewModel) with a Repository layer, implemented in Kotlin with AndroidX Lifecycle components.
+
+## Layer Overview
+
+```
+┌──────────────────────────────────────┐
+│              View Layer              │
+│  Activities · Custom Views · Dialogs │
+└──────────────┬───────────────────────┘
+               │ observes LiveData
+┌──────────────▼───────────────────────┐
+│           ViewModel Layer            │
+│  MainViewModel · TimelineViewModel   │
+│  PreferenceViewModel                 │
+└──────────────┬───────────────────────┘
+               │ calls
+┌──────────────▼───────────────────────┐
+│          Repository Layer            │
+│  ExchangeRatesRepository             │
+│  ExchangeRatesService                │
+└──────────────┬───────────────────────┘
+               │ reads/writes
+┌──────────────▼───────────────────────┐
+│      Data / Persistence Layer        │
+│  ApiProvider (HTTP clients)          │
+│  Database (SharedPreferences)        │
+└──────────────────────────────────────┘
+```
+
+## Source Layout
+
+```
+app/src/main/kotlin/de/salomax/currencies/
+├── model/
+│   ├── ApiProvider.kt          # Enum of 6 providers + abstract Api interface
+│   ├── Currency.kt             # 190+ ISO-4217 currencies with symbols & flags
+│   ├── ExchangeRates.kt        # Snapshot of rates for a base currency
+│   ├── Rate.kt                 # Single (currency, rate) pair
+│   ├── Timeline.kt             # Historical rate series
+│   ├── adapter/                # Moshi / XML adapters per provider
+│   └── provider/               # HTTP implementations per provider
+├── repository/
+│   ├── Database.kt             # Typed SharedPreferences wrapper
+│   ├── ExchangeRatesRepository.kt
+│   └── ExchangeRatesService.kt # Singleton, coroutine-based fetch orchestration
+├── view/
+│   ├── main/                   # Converter screen
+│   ├── preference/             # Settings screen
+│   ├── timeline/               # Chart screen
+│   └── BaseActivity.kt
+├── viewmodel/
+│   ├── main/MainViewModel.kt   # 631 lines — core conversion + calculator logic
+│   ├── preference/
+│   └── timeline/
+└── util/                       # Date, math, text, LiveData helpers
+
+helpers/src/main/kotlin/de/salomax/helpers/
+├── changelog/
+│   ├── FastlaneToResource.kt   # Fastlane changelogs → Android XML resources
+│   └── ResourceToFastlane.kt   # Reverse: Android XML → Fastlane format
+└── currencies/
+    └── CurrencyFetcher.kt      # Generates localized currency-name XML resources
+```
+
+## Key Design Decisions
+
+### Multiple API Providers via Enum + Abstract Interface
+
+`ApiProvider` is an enum whose entries each implement `Api`, an abstract interface exposing `getRates()` and `getTimeline()`. Switching provider at runtime is a single SharedPreferences write; no factory classes required.
+
+### SharedPreferences as the Only Persistence Layer
+
+The app has no SQLite database. All data (cached rates, starred currencies, user state, preferences) lives in namespaced SharedPreferences instances managed by `Database.kt`. This keeps the install size small and the data model simple.
+
+### Moshi + Custom Adapters for Diverse API Formats
+
+Each exchange-rate API returns a different JSON (or XML) schema. Rather than normalising at the network layer, each provider ships its own Moshi adapter (or SAX parser for Norges Bank / Bank Rossii) that maps the raw response to the shared `ExchangeRates` / `Timeline` model.
+
+### LiveData for Reactive UI
+
+ViewModels expose `LiveData<T>` streams. Activities observe them without holding references to the ViewModel, ensuring lifecycle-safety and no memory leaks. `SharedPreferenceLiveData` bridges SharedPreferences changes into the LiveData graph so preference changes propagate automatically.
+
+### Build Flavors: `play` vs `fdroid`
+
+| Dimension | `fdroid` | `play` |
+|---|---|---|
+| Play Services | None | Allowed |
+| Reproducibility | Yes | No |
+| Distribution | F-Droid | Google Play |
+
+Source sets under `app/src/fdroid/` and `app/src/play/` override or add flavor-specific code without touching the shared `main` source set.

--- a/docs/markDown/build-and-flavors.md
+++ b/docs/markDown/build-and-flavors.md
@@ -1,0 +1,95 @@
+# Build & Flavors
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| JDK | 21 (Temurin recommended) |
+| Android Gradle Plugin | see `build.gradle.kts` |
+| Kotlin | 2.4.0 |
+| Min SDK | 26 |
+| Target SDK | 37 |
+
+## Product Flavors
+
+Two flavors are defined in `app/build.gradle.kts`:
+
+| Flavor | Description |
+|---|---|
+| `fdroid` | F-Droid distribution — no Play Services dependency, fully open-source, reproducible |
+| `play` | Google Play distribution — may use Play-specific APIs |
+
+### Common Gradle tasks
+
+```bash
+# Debug builds
+./gradlew assembleFdroidDebug
+./gradlew assemblePlayDebug
+
+# Release builds (requires signing config in secrets.properties)
+./gradlew assembleFdroidRelease
+./gradlew assemblePlayRelease
+
+# Lint + unit tests + debug build (CI gate)
+./gradlew check assembleDebug
+```
+
+## Key Dependencies
+
+### Android / AndroidX
+
+| Dependency | Version |
+|---|---|
+| `androidx.appcompat:appcompat` | 1.7.1 |
+| `androidx.lifecycle:lifecycle-*` | 2.11.0 |
+| `androidx.constraintlayout:constraintlayout` | 2.2.1 |
+| `com.google.android.material:material` | 1.14.0 |
+| `androidx.window:window` | 1.5.1 |
+
+### HTTP & Serialisation
+
+| Dependency | Version |
+|---|---|
+| `com.github.kittinunf.fuel:*` | 2.3.1 |
+| `com.squareup.moshi:moshi-kotlin` | 1.15.2 |
+| `com.google.devtools.ksp:*` | 2.3.9 |
+
+### Calculator
+
+| Dependency | Version | Note |
+|---|---|---|
+| `org.mariuszgromada.math:MathParser.org-mXparser` | **4.4.3** | Pinned — v5+ has an F-Droid-incompatible licence |
+
+### Charts
+
+| Dependency | Version |
+|---|---|
+| `com.robinhood.spark:spark` | 1.2.0 |
+
+### Testing
+
+| Dependency | Version |
+|---|---|
+| `junit:junit` | 4.13.2 |
+| `org.mockito:mockito-core` | 5.23.0 |
+
+## Signing (Release)
+
+Create `secrets.properties` in the project root (not committed):
+
+```properties
+storeFile=path/to/keystore.jks
+storePassword=...
+keyAlias=...
+keyPassword=...
+```
+
+## Version Code Generation
+
+`versionCode` is derived automatically from `versionName`:
+
+```
+1.23.0  →  1 * 10000 + 23 * 100 + 0  =  12300
+```
+
+A pre-build consistency check verifies that `versionName` and `versionCode` are in sync.

--- a/docs/markDown/ci-cd.md
+++ b/docs/markDown/ci-cd.md
@@ -1,0 +1,86 @@
+# CI / CD
+
+All automation lives in `.github/workflows/`. Every workflow pins its GitHub Actions to a full 40-character commit SHA to prevent supply-chain attacks.
+
+## Workflow Summary
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `build.yaml` | Push → `master` | Lint, test, build debug APK |
+| `apk-artifact.yaml` | Push → non-master, manual | Build fdroid debug APK and upload as artifact |
+| `detekt.yaml` | PR, push → `master` | Kotlin static analysis |
+| `qodana.yaml` | PR, push → `master`, weekly | JetBrains Qodana JVM analysis |
+| `codeql.yaml` | PR, push → `master`, weekly | GitHub CodeQL (Actions YAML) |
+| `semgrep.yaml` | PR, push → `master` | SAST security pattern scanning |
+| `gitleaks.yaml` | Weekly (Mon 07:00 UTC) | Secret / credential scanning |
+| `owasp-dependency-check.yaml` | Weekly (Mon 08:00 UTC) | Dependency vulnerability scan (CVSS ≥ 7) |
+| `dependency-review.yaml` | PR | Block high-severity new dependencies |
+| `scorecard.yaml` | Push → `master`, weekly | OpenSSF Scorecard supply-chain score |
+| `actionlint.yaml` | PR/push on `.github/workflows/**` | Validate workflow YAML syntax |
+
+## Build Gate (`build.yaml`)
+
+Runs `./gradlew check assembleDebug`, which includes:
+- `lint` — Android Lint (missing translations suppressed)
+- `test` — JUnit unit tests
+- `assembleDebug` — compiles the debug APK for all flavors
+
+## Security Scans
+
+### Detekt
+- Version: 1.23.7 (pinned via `DETEKT_VERSION` env var)
+- Inputs: `app/src`, `helpers/src`
+- JVM target: 21
+- Output: SARIF uploaded to GitHub Security tab + artifact retained 14 days
+
+### Qodana
+- Image: `qodana-jvm-community:2025.1`
+- Posts inline PR comments on findings
+- SARIF uploaded to GitHub Security tab
+
+### CodeQL
+- Language scope: `actions` (YAML workflows only — Kotlin delegated to Qodana)
+
+### OWASP Dependency Check
+- CVSS threshold: 7 (high+)
+- Scans runtime classpath only
+- Detects retired/archived dependencies
+- Uploads HTML + XML reports as artifact
+
+### OpenSSF Scorecard
+- Evaluates pinned-dependencies, branch-protection, SAST, etc.
+- Results written to `scorecard-results.sarif` and uploaded to Security tab
+
+## Dependabot
+
+Configured in `.github/dependabot.yml` with weekly Monday schedule.
+
+**Ecosystems:**
+
+| Ecosystem | Directories | Open PR limit | Cooldown |
+|---|---|---|---|
+| `gradle` | `/`, `/app`, `/helpers` | 10 | 7 days |
+| `github-actions` | `/` | 5 | 7 days |
+
+**Grouped updates** keep related libraries in one PR:
+- `androidx.*`
+- `com.google.android.material:*`
+- `org.jetbrains.kotlin*` + `com.google.devtools.ksp*`
+- `com.squareup.moshi:*`
+- `com.github.kittinunf.fuel:*`
+- Test dependencies
+- All GitHub Actions (single PR)
+
+**Pinned dependency:** `MathParser.org-mXparser` is ignored at v5+ due to licence incompatibility with F-Droid.
+
+## Permission Model
+
+All workflows use `permissions: contents: read` by default. Additional permissions are granted only when needed:
+
+| Workflow | Extra permissions |
+|---|---|
+| `detekt.yaml` | `security-events: write` |
+| `codeql.yaml` | `security-events: write`, `actions: read` |
+| `scorecard.yaml` | `security-events: write`, `id-token: write` |
+| `dependency-review.yaml` | `pull-requests: write` |
+| `owasp-dependency-check.yaml` | `security-events: write` |

--- a/docs/markDown/contributing.md
+++ b/docs/markDown/contributing.md
@@ -1,0 +1,66 @@
+# Contributing
+
+## What We Accept
+
+| Type | Accepted? |
+|---|---|
+| Bug fixes | Yes |
+| Translations | Yes — via Weblate |
+| New exchange rate providers | Discuss first |
+| New features | Discuss first |
+| Refactors | Discuss first |
+
+The project favours simplicity. Large feature additions are unlikely to be merged without prior discussion.
+
+## Translations
+
+Translations are managed on [Weblate](https://translate.codeberg.org/engage/currencies/). Do **not** open PRs that edit string resource XML files directly — translate through the Weblate interface.
+
+## Code Contributions
+
+### Setup
+
+1. Fork and clone the repository.
+2. Open in Android Studio (latest stable recommended).
+3. JDK 21 is required.
+4. `./gradlew assembleFdroidDebug` should build without errors.
+
+### Branch Naming
+
+Use descriptive branch names. The CI `apk-artifact.yaml` workflow runs on any non-master push and uploads a debug APK as an artifact for easy review.
+
+### Code Style
+
+- Kotlin only (no Java in `app/` or `helpers/`).
+- Follow existing patterns — MVVM, Repository, LiveData.
+- Run `./gradlew detekt` locally before opening a PR. CI will fail on Detekt findings.
+- Avoid `java.lang.*` qualifiers (Kotlin imports these automatically).
+- Avoid swallowed exceptions: always use the caught exception variable in the catch block.
+
+### Pull Request Checklist
+
+- [ ] `./gradlew check assembleDebug` passes locally
+- [ ] No new Detekt warnings
+- [ ] If adding a dependency: check F-Droid licence compatibility
+- [ ] `mXparser` must remain at 4.4.3 — v5+ is not F-Droid compatible
+
+### Commit Message Convention
+
+```
+type(scope): short description
+
+Examples:
+feat(providers): add ECB historical fallback
+fix(calculator): handle division by zero
+chore(deps): bump moshi to 1.15.2
+chore(ci): pin checkout action to SHA
+```
+
+## Reporting Issues
+
+Open a GitHub Issue with:
+- Android version
+- App version (`Settings → About`)
+- Selected exchange rate provider
+- Steps to reproduce
+- Expected vs. actual behaviour

--- a/docs/markDown/overview.md
+++ b/docs/markDown/overview.md
@@ -1,0 +1,44 @@
+# Currencies — Overview
+
+**Currencies** is a simple, privacy-focused Android currency converter designed as a travel companion rather than a financial trading tool.
+
+- **Package**: `de.salomax.currencies`
+- **Min SDK**: 26 (Android 8.0 Oreo)
+- **Target SDK**: 37 (Android 15)
+- **License**: GNU General Public License v3+
+- **Language**: Kotlin
+
+## What It Does
+
+Convert between 30–160+ world currencies using live exchange rates fetched from your chosen provider. All conversions happen on-device with no ads, no analytics, and no user tracking.
+
+## Core Features
+
+| Feature | Details |
+|---|---|
+| Exchange rate providers | 6 active providers (ECB, OER, InforEuro, Bank of Canada, Norges Bank, Bank Rossii) |
+| Built-in calculator | Full arithmetic (+, −, ×, ÷) before conversion |
+| Fee calculator | Optional configurable foreign-exchange fee percentage |
+| Historical rates | Access rates back to 2010 |
+| Rate charts | 1-year historical timeline visualization |
+| Starred currencies | Favourite/filter currencies for quick access |
+| Themes | Light, dark, and pure-black modes; follows system setting |
+| Foldable support | Adaptive multi-pane layout via WindowInfoTracker |
+| Internationalization | 20+ languages via Weblate |
+
+## Distribution
+
+| Store | Link |
+|---|---|
+| Google Play | `play.google.com/store/apps/details?id=de.salomax.currencies` |
+| F-Droid | `f-droid.org/packages/de.salomax.currencies/` |
+
+The `fdroid` build flavor excludes any Play-Store-specific APIs and is reproducible.
+
+## Privacy
+
+The app requests only the `INTERNET` permission. No analytics SDK, no crash reporter, no advertising ID access. Exchange rates are fetched directly from public central-bank or open-data APIs.
+
+## Version Scheme
+
+Versions follow [Semantic Versioning](https://semver.org/). The Android `versionCode` is derived automatically: `1.23.0 → 12300`.

--- a/docs/markDown/security.md
+++ b/docs/markDown/security.md
@@ -1,0 +1,60 @@
+# Security
+
+## Supply Chain
+
+### Actions Pinning
+
+Every GitHub Actions `uses:` reference is pinned to a full 40-character commit SHA, with the human-readable tag preserved in a trailing comment:
+
+```yaml
+uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+```
+
+This prevents a compromised or reused tag from injecting malicious code into CI. Enforced by the Semgrep rule `yaml.github-actions.security.github-actions-mutable-action-tag` and verified by the OpenSSF Scorecard `Pinned-Dependencies` check.
+
+### Dependabot Cooldown
+
+Both Gradle and GitHub Actions ecosystems enforce a **7-day cooldown** (`cooldown: default-days: 7`) before Dependabot proposes a version bump. This mitigates supply-chain attacks where a dependency is compromised shortly after publication.
+
+### Dependency Review
+
+The `dependency-review` workflow blocks any PR that introduces a dependency with a **high or critical** CVE (CVSS ≥ 7).
+
+### OWASP Dependency Check
+
+Weekly scan of the runtime classpath against the NVD database. Fails the workflow on CVSS ≥ 7 findings. Also flags retired/archived libraries.
+
+## Secrets
+
+- Release signing credentials are stored in `secrets.properties` (gitignored) and referenced only at build time.
+- No API keys are stored in source code. OpenExchangerates key (if used) is expected as an environment variable or build config field.
+- Gitleaks scans the full repository weekly for accidental credential commits.
+
+## Runtime Permissions
+
+The app declares a single permission:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+No location, contacts, storage, camera, or microphone access.
+
+## Code Analysis
+
+| Tool | Scope | Frequency |
+|---|---|---|
+| Detekt | Kotlin source (app + helpers) | Every PR and master push |
+| Qodana JVM Community | Kotlin / Java | Every PR, master push, weekly |
+| CodeQL | GitHub Actions YAML | Every PR, master push, weekly |
+| Semgrep | Security patterns | Every PR and master push |
+
+## OpenSSF Scorecard
+
+The repository is evaluated weekly by the [OpenSSF Scorecard](https://securityscorecards.dev/). Results are uploaded to the GitHub Security tab. Key checks:
+
+- **Pinned-Dependencies** — all CI actions and Docker images use SHA pins
+- **Branch-Protection** — master branch is protected
+- **SAST** — multiple static analysis tools are active
+- **Dependency-Update-Tool** — Dependabot is configured
+- **Token-Permissions** — workflows use least-privilege permissions


### PR DESCRIPTION
## Summary

- Adds `docs/markDown/` with 7 topic-separated reference files: `overview`, `architecture`, `api-providers`, `build-and-flavors`, `ci-cd`, `security`, `contributing`
- Adds `docs/html/` with a full GitHub Pages site (4 HTML pages + shared CSS): home, features, providers, privacy policy
- Adds `docs/html/CNAME` for custom domain `currencies.machlev.org`

## Enabling GitHub Pages

After merging, go to **Settings → Pages → Source** and set branch `master`, folder `/docs/html`.

## Test plan

- [ ] Open each HTML page locally and verify navigation, dark mode, and responsive layout
- [ ] Verify `CNAME` contains `currencies.machlev.org`
- [ ] Confirm Markdown files render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)