### PR TITLE
fix: add missing androidx.lifecycle.map import in TimelineViewModel

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/timeline/TimelineViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import de.salomax.currencies.R
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate


### PR DESCRIPTION
## Summary
- Adds the missing `import androidx.lifecycle.map` extension import that caused `Unresolved reference 'map'` compilation errors on lines 101, 125, and 131 of `TimelineViewModel.kt`
- This broke the `Build fdroid debug APK` workflow on master

## Test plan
- [ ] `Build fdroid debug APK` workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)