### PR TITLE
fix: replace Float with BigDecimal for currency precision

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/model/Rate.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/Rate.kt
@@ -1,10 +1,8 @@
 package de.salomax.currencies.model
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import java.math.BigDecimal
 
-@JsonClass(generateAdapter = true)
 data class Rate(
-    @field:Json(name = "name") val currency: Currency,
-    @field:Json(name = "value") val value: Float
+    val currency: Currency,
+    val value: BigDecimal
 )

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
@@ -65,7 +65,7 @@ internal class BankOfCanadaRatesAdapter {
                         val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
                         reader.beginObject()
                         reader.skipName() // always "v"
-                        val value = reader.nextDouble().toBigDecimal()
+                        val value = BigDecimal(reader.nextString())
                         reader.endObject()
                         currency?.let { rates.add(Rate(it, BigDecimal.ONE.divide(value, MathContext.DECIMAL128))) }
                     }

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
@@ -9,6 +9,8 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Rate
 import java.io.IOException
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 
 private const val CURRENCY_CODE_START = 2
@@ -63,16 +65,16 @@ internal class BankOfCanadaRatesAdapter {
                         val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
                         reader.beginObject()
                         reader.skipName() // always "v"
-                        val value = reader.nextDouble()
+                        val value = reader.nextDouble().toBigDecimal()
                         reader.endObject()
-                        currency?.let { rates.add(Rate(it, 1f / value.toFloat())) }
+                        currency?.let { rates.add(Rate(it, BigDecimal.ONE.divide(value, MathContext.DECIMAL128))) }
                     }
                 }
             }
         }
         if (rates.isNotEmpty())
             // finally, add CAD...
-            rates.add(Rate(Currency.CAD, 1f))
+            rates.add(Rate(Currency.CAD, BigDecimal.ONE))
 
         return ExchangeRates(
             success = errorMessage == null && rates.isNotEmpty() && date != null,

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
@@ -90,7 +90,7 @@ internal class BankOfCanadaTimelineAdapter(
                     val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
                     reader.beginObject()
                     reader.skipName() // always "v"
-                    val value = reader.nextDouble().toBigDecimal()
+                    val value = BigDecimal(reader.nextString())
                     reader.endObject()
                     currency?.let {
                         if (it == base)

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
@@ -9,6 +9,8 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.model.Timeline
 import java.io.IOException
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 
 private const val CURRENCY_CODE_START = 2
@@ -75,8 +77,8 @@ internal class BankOfCanadaTimelineAdapter(
     private fun convertObservation(reader: JsonReader): Pair<LocalDate, Rate>? {
         var date: LocalDate? = null
 
-        var baseValue: Float? = null
-        var symbolValue: Float? = null
+        var baseValue: BigDecimal? = null
+        var symbolValue: BigDecimal? = null
 
         reader.beginObject()
         while (reader.hasNext()) {
@@ -88,19 +90,19 @@ internal class BankOfCanadaTimelineAdapter(
                     val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
                     reader.beginObject()
                     reader.skipName() // always "v"
-                    val value = reader.nextDouble()
+                    val value = reader.nextDouble().toBigDecimal()
                     reader.endObject()
                     currency?.let {
                         if (it == base)
-                            baseValue = value.toFloat()
+                            baseValue = value
                         else if (it == symbol)
-                            symbolValue = value.toFloat()
+                            symbolValue = value
                     }
                 }
             }
             if (date != null && baseValue != null && symbolValue != null) {
                 reader.endObject()
-                return Pair(date, Rate(symbol, baseValue / symbolValue))
+                return Pair(date, Rate(symbol, baseValue.divide(symbolValue, MathContext.DECIMAL128)))
             }
         }
         return null

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiRatesXmlParser.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiRatesXmlParser.kt
@@ -7,6 +7,8 @@ import de.salomax.currencies.model.Rate
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -22,7 +24,7 @@ class BankRossiiRatesXmlParser {
         var tagname: String? = null
         var eventType = parser.eventType
         var currency: Currency? = null
-        var value: Float? = null
+        var value: BigDecimal? = null
 
         while (eventType != XmlPullParser.END_DOCUMENT) {
             tagname = parser.name ?: tagname
@@ -34,7 +36,10 @@ class BankRossiiRatesXmlParser {
                     )
                 XmlPullParser.TEXT -> when (tagname) {
                     "CharCode" -> currency = Currency.fromString(parser.text)
-                    "VunitRate" -> value = 1f / parser.text.replace(',', '.').toFloat()
+                    "VunitRate" -> value = BigDecimal.ONE.divide(
+                        parser.text.replace(',', '.').toBigDecimal(),
+                        MathContext.DECIMAL128
+                    )
                 }
                 XmlPullParser.END_TAG -> if (tagname == "Valute") {
                     recordRate(currency, value)
@@ -56,14 +61,14 @@ class BankRossiiRatesXmlParser {
         )
     }
 
-    private fun recordRate(currency: Currency?, value: Float?) {
+    private fun recordRate(currency: Currency?, value: BigDecimal?) {
         if (currency != null && value != null)
             rates.add(Rate(currency, value))
     }
 
     private fun addSyntheticRates() {
         if (rates.isEmpty()) return
-        rates.add(Rate(Currency.RUB, 1f))
+        rates.add(Rate(Currency.RUB, BigDecimal.ONE))
         if (rates.find { it.currency == Currency.FOK } == null)
             rates.find { it.currency == Currency.DKK }?.value?.let { dkk ->
                 rates.add(Rate(Currency.FOK, dkk))

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiTimelineXmlParser.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankRossiiTimelineXmlParser.kt
@@ -7,6 +7,8 @@ import de.salomax.currencies.model.Timeline
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -22,7 +24,7 @@ class BankRossiiTimelineXmlParser(private val ids: Map<String, String>) {
         var eventType = parser.eventType
         var date: LocalDate? = null
         var currencyId: String? = null
-        var value: Float? = null
+        var value: BigDecimal? = null
 
         while (eventType != XmlPullParser.END_DOCUMENT) {
             tagname = parser.name ?: tagname
@@ -35,7 +37,10 @@ class BankRossiiTimelineXmlParser(private val ids: Map<String, String>) {
                     currencyId = parser.getAttributeValue(null, "Id")
                 }
                 XmlPullParser.TEXT -> if (tagname == "VunitRate")
-                    value = 1f / parser.text.replace(',', '.').toFloat()
+                    value = BigDecimal.ONE.divide(
+                        parser.text.replace(',', '.').toBigDecimal(),
+                        MathContext.DECIMAL128
+                    )
                 XmlPullParser.END_TAG -> if (tagname == "Record") {
                     recordRate(date, value, currencyId)
                     date = null
@@ -57,7 +62,7 @@ class BankRossiiTimelineXmlParser(private val ids: Map<String, String>) {
         )
     }
 
-    private fun recordRate(date: LocalDate?, value: Float?, currencyId: String?) {
+    private fun recordRate(date: LocalDate?, value: BigDecimal?, currencyId: String?) {
         val isoCode = currencyId?.let { ids[it] } ?: return
         if (date == null || value == null) return
         val currency = Currency.fromString(isoCode) ?: return

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
@@ -25,7 +25,7 @@ internal class FrankfurterAppRatesAdapter(private val base: Currency) {
         // convert
         while (reader.hasNext()) {
             val name: String = reader.nextName()
-            val value: BigDecimal = reader.nextDouble().toBigDecimal()
+            val value: BigDecimal = BigDecimal(reader.nextString())
             Currency.fromString(name)?.let { list.add(Rate(it, value)) }
         }
         reader.endObject()

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
@@ -7,6 +7,7 @@ import com.squareup.moshi.ToJson
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
 import java.io.IOException
+import java.math.BigDecimal
 
 /*
  * Converts currency object to array of currencies.
@@ -24,13 +25,13 @@ internal class FrankfurterAppRatesAdapter(private val base: Currency) {
         // convert
         while (reader.hasNext()) {
             val name: String = reader.nextName()
-            val value: Double = reader.nextDouble()
-            Currency.fromString(name)?.let { list.add(Rate(it, value.toFloat())) }
+            val value: BigDecimal = reader.nextDouble().toBigDecimal()
+            Currency.fromString(name)?.let { list.add(Rate(it, value)) }
         }
         reader.endObject()
         // add base - but only if it's missing in the api response!
         if (list.find { rate -> rate.currency == base } == null)
-            list.add(Rate(base, 1f))
+            list.add(Rate(base, BigDecimal.ONE))
         // also add Faroese króna (same as Danish krone) if it isn't already there - I simply like it!
         if (list.find { it.currency == Currency.FOK } == null)
             list.find { it.currency == Currency.DKK }?.value?.let { dkk ->

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
@@ -31,7 +31,7 @@ internal class FrankfurterAppTimelineAdapter(private val symbol: Currency) {
             // sometimes there's no rate yet, but an empty body or more than one rate, so check first
             while (reader.hasNext() && reader.peek() == JsonReader.Token.NAME) {
                 val name = Currency.fromString(reader.nextName())
-                val value: BigDecimal = reader.nextDouble().toBigDecimal()
+                val value: BigDecimal = BigDecimal(reader.nextString())
                 rate =
                         // change dkk to fok, when needed
                     if (name == Currency.DKK && symbol == Currency.FOK)

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
@@ -7,6 +7,7 @@ import com.squareup.moshi.ToJson
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
 import java.io.IOException
+import java.math.BigDecimal
 import java.time.LocalDate
 
 /*
@@ -30,7 +31,7 @@ internal class FrankfurterAppTimelineAdapter(private val symbol: Currency) {
             // sometimes there's no rate yet, but an empty body or more than one rate, so check first
             while (reader.hasNext() && reader.peek() == JsonReader.Token.NAME) {
                 val name = Currency.fromString(reader.nextName())
-                val value = reader.nextDouble().toFloat()
+                val value: BigDecimal = reader.nextDouble().toBigDecimal()
                 rate =
                         // change dkk to fok, when needed
                     if (name == Currency.DKK && symbol == Currency.FOK)

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
@@ -9,6 +9,7 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Rate
 import java.io.IOException
+import java.math.BigDecimal
 import java.time.LocalDate
 
 @Suppress("unused", "UNUSED_PARAMETER")
@@ -41,11 +42,11 @@ internal class InforEuroRatesAdapter(private val date: LocalDate) {
     private fun parseEntry(reader: JsonReader): Rate? {
         reader.beginObject()
         var name: Currency? = null
-        var value: Float? = null
+        var value: BigDecimal? = null
         while (reader.hasNext()) {
             when (reader.nextName()) {
                 "isoA3Code" -> name = Currency.fromString(reader.nextString())
-                "value" -> value = reader.nextDouble().toFloat()
+                "value" -> value = reader.nextDouble().toBigDecimal()
                 else -> reader.skipValue()
             }
         }

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
@@ -46,7 +46,7 @@ internal class InforEuroRatesAdapter(private val date: LocalDate) {
         while (reader.hasNext()) {
             when (reader.nextName()) {
                 "isoA3Code" -> name = Currency.fromString(reader.nextString())
-                "value" -> value = reader.nextDouble().toBigDecimal()
+                "value" -> value = BigDecimal(reader.nextString())
                 else -> reader.skipValue()
             }
         }

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
@@ -9,6 +9,7 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.model.Timeline
 import java.io.IOException
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -51,13 +52,13 @@ internal class InforEuroTimelineAdapter(
     ) {
         reader.beginObject()
         var currencyIso: Currency? = null
-        var value: Float? = null
+        var value: BigDecimal? = null
         var dateStart: LocalDate? = null
         var dateEnd: LocalDate? = null
         while (reader.hasNext()) {
             when (reader.nextName()) {
                 "currencyIso" -> currencyIso = Currency.fromString(reader.nextString())
-                "amount" -> value = reader.nextDouble().toFloat()
+                "amount" -> value = reader.nextDouble().toBigDecimal()
                 "dateStart" -> dateStart = LocalDate.parse(reader.nextString(), datePattern)
                 "dateEnd" -> dateEnd = LocalDate.parse(reader.nextString(), datePattern)
                 else -> reader.skipValue()

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
@@ -58,7 +58,7 @@ internal class InforEuroTimelineAdapter(
         while (reader.hasNext()) {
             when (reader.nextName()) {
                 "currencyIso" -> currencyIso = Currency.fromString(reader.nextString())
-                "amount" -> value = reader.nextDouble().toBigDecimal()
+                "amount" -> value = BigDecimal(reader.nextString())
                 "dateStart" -> dateStart = LocalDate.parse(reader.nextString(), datePattern)
                 "dateEnd" -> dateEnd = LocalDate.parse(reader.nextString(), datePattern)
                 else -> reader.skipValue()

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/NorgesBankRatesXmlParser.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/NorgesBankRatesXmlParser.kt
@@ -7,6 +7,8 @@ import de.salomax.currencies.model.Rate
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import kotlin.math.pow
 
@@ -32,7 +34,7 @@ class NorgesBankRatesXmlParser {
                     }
                     tagname.equals("Obs", ignoreCase = true) -> {
                         val obsDate = LocalDate.parse(parser.getAttributeValue(null, "TIME_PERIOD"))
-                        val value = parser.getAttributeValue(null, "OBS_VALUE").toFloatOrNull()
+                        val value = parser.getAttributeValue(null, "OBS_VALUE").toBigDecimalOrNull()
                         recordObservation(base, value, obsDate, multiplier, requestedDate)
                         base = null
                         updateDate(obsDate)
@@ -59,7 +61,7 @@ class NorgesBankRatesXmlParser {
 
     private fun recordObservation(
         base: Currency?,
-        value: Float?,
+        value: BigDecimal?,
         date: LocalDate,
         multiplier: Int,
         requestedDate: LocalDate
@@ -68,7 +70,7 @@ class NorgesBankRatesXmlParser {
         // api delivers historical rates for e.g. RUB; ignore stale ones
         if (!date.isAfter(requestedDate.minusWeeks(2))) return
         rates.removeIf { rate -> rate.currency == base }
-        rates.add(Rate(base, (1f / value) * multiplier))
+        rates.add(Rate(base, BigDecimal.ONE.divide(value, MathContext.DECIMAL128) * multiplier.toBigDecimal()))
     }
 
     private fun updateDate(date: LocalDate) {
@@ -78,7 +80,7 @@ class NorgesBankRatesXmlParser {
 
     private fun addSyntheticRates() {
         if (rates.isEmpty()) return
-        rates.add(Rate(Currency.NOK, 1f))
+        rates.add(Rate(Currency.NOK, BigDecimal.ONE))
         if (rates.find { it.currency == Currency.FOK } == null)
             rates.find { it.currency == Currency.DKK }?.value?.let { dkk ->
                 rates.add(Rate(Currency.FOK, dkk))

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/NorgesBankTimelineXmlParser.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/NorgesBankTimelineXmlParser.kt
@@ -7,6 +7,8 @@ import de.salomax.currencies.model.Timeline
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import kotlin.math.pow
 
@@ -41,9 +43,12 @@ class NorgesBankTimelineXmlParser(
                 eventType == XmlPullParser.START_TAG
                     && tagname.equals("Obs", ignoreCase = true) -> {
                     val date = LocalDate.parse(parser.getAttributeValue(null, "TIME_PERIOD"))
-                    val value = parser.getAttributeValue(null, "OBS_VALUE").toFloatOrNull()
+                    val value = parser.getAttributeValue(null, "OBS_VALUE").toBigDecimalOrNull()
                     if (seriesCurrency != null && value != null)
-                        currentTimeline[date] = Rate(seriesCurrency, (1f / value) * multiplier)
+                        currentTimeline[date] = Rate(
+                            seriesCurrency,
+                            BigDecimal.ONE.divide(value, MathContext.DECIMAL128) * multiplier.toBigDecimal()
+                        )
                 }
                 eventType == XmlPullParser.END_TAG
                     && tagname.equals("Series", ignoreCase = true) -> {
@@ -71,7 +76,7 @@ class NorgesBankTimelineXmlParser(
         val series = mutableMapOf<LocalDate, Rate>()
         var currentDate = startDate
         while (!currentDate.isAfter(endDate)) {
-            series[currentDate] = Rate(Currency.NOK, 1f)
+            series[currentDate] = Rate(Currency.NOK, BigDecimal.ONE)
             currentDate = currentDate.plusDays(1)
         }
         return series
@@ -85,7 +90,7 @@ class NorgesBankTimelineXmlParser(
         for (entry in baseList) {
             val baseValue = entry.value.value
             val symbolValue = symbolList[entry.key]?.value ?: continue
-            rates[entry.key] = Rate(this.symbol, symbolValue.div(baseValue))
+            rates[entry.key] = Rate(this.symbol, symbolValue.divide(baseValue, MathContext.DECIMAL128))
         }
         return rates
     }

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
@@ -58,7 +58,7 @@ internal class OpenExchangeratesRatesAdapter {
         reader.beginObject()
         while (reader.hasNext()) {
             val name = Currency.fromString(reader.nextName())
-            val value: BigDecimal = reader.nextDouble().toBigDecimal()
+            val value: BigDecimal = BigDecimal(reader.nextString())
             if (name != null)
                 rates.add(Rate(name, value))
         }

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
@@ -9,6 +9,7 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Rate
 import java.io.IOException
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -57,7 +58,7 @@ internal class OpenExchangeratesRatesAdapter {
         reader.beginObject()
         while (reader.hasNext()) {
             val name = Currency.fromString(reader.nextName())
-            val value = reader.nextDouble().toFloat()
+            val value: BigDecimal = reader.nextDouble().toBigDecimal()
             if (name != null)
                 rates.add(Rate(name, value))
         }

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/BankRossii.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/BankRossii.kt
@@ -16,6 +16,8 @@ import de.salomax.currencies.model.adapter.BankRossiiCurrencyCodesXmlParser
 import de.salomax.currencies.model.adapter.BankRossiiRatesXmlParser
 import de.salomax.currencies.model.adapter.BankRossiiTimelineXmlParser
 import java.io.InputStream
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -104,7 +106,9 @@ class BankRossii : ApiProvider.Api() {
                 symbolTimeline.get().copy(
                     rates = symbolRates
                         .filter { (date, _) -> baseRates[date] != null }
-                        .mapValues { (date, rate) -> rate.copy(value = rate.value / baseRates[date]!!.value) }
+                        .mapValues { (date, rate) ->
+                            rate.copy(value = rate.value.divide(baseRates[date]!!.value, MathContext.DECIMAL128))
+                        }
                 )
             }
     }
@@ -113,7 +117,7 @@ class BankRossii : ApiProvider.Api() {
         val rubMap = LinkedHashMap<LocalDate, Rate>()
         var currentDate = startDate
         while (currentDate.isBefore(endDate) || currentDate.isEqual(endDate)) {
-            rubMap[currentDate] = Rate(Currency.RUB, 1f)
+            rubMap[currentDate] = Rate(Currency.RUB, BigDecimal.ONE)
             currentDate = currentDate.plusDays(1)
         }
         return Timeline(

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/InforEuro.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/InforEuro.kt
@@ -17,6 +17,8 @@ import de.salomax.currencies.model.Rate
 import de.salomax.currencies.model.Timeline
 import de.salomax.currencies.model.adapter.InforEuroRatesAdapter
 import de.salomax.currencies.model.adapter.InforEuroTimelineAdapter
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
 import java.time.ZoneOffset
 
@@ -101,7 +103,13 @@ class InforEuro : ApiProvider.Api() {
                     val baseValue = resultBase.get().rates?.get(symbolEntry.key)
                     Pair(
                         symbolEntry.key,
-                        Rate(symbol, symbolEntry.value.value.div(baseValue?.value ?: 1f))
+                        Rate(
+                            symbol,
+                            symbolEntry.value.value.divide(
+                                baseValue?.value ?: BigDecimal.ONE,
+                                MathContext.DECIMAL128
+                            )
+                        )
                     )
                 }?.toMap()
             )

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -10,7 +10,6 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.util.SharedPreferenceBooleanLiveData
 import de.salomax.currencies.util.SharedPreferenceExchangeRatesLiveData
-import de.salomax.currencies.util.SharedPreferenceFloatLiveData
 import de.salomax.currencies.util.SharedPreferenceIntLiveData
 import de.salomax.currencies.util.SharedPreferenceLongLiveData
 import de.salomax.currencies.util.SharedPreferenceStringLiveData
@@ -20,7 +19,8 @@ import de.salomax.currencies.util.toMillis
 import java.math.BigDecimal
 import java.time.LocalDate
 
-private const val DEFAULT_FEE_PERCENT = 2.2f
+private const val DEFAULT_FEE_PERCENT = "2.2"
+private const val LEGACY_FEE_KEY = "_fee"
 
 class Database(context: Context) {
 
@@ -180,7 +180,7 @@ class Database(context: Context) {
     private val keyTheme = "_theme"
     private val keyPureBlackEnabled = "_pureBlackEnabled"
     private val keyFeeEnabled = "_feeEnabled"
-    private val keyFeeValue = "_fee"
+    private val keyFeeValue = "_fee_str"
     private val keyPreviewConversionEnabled = "_previewConversionEnabled"
     private val keyKeyboardType = "_keyboardType"
     private val keyHapticFeedback = "_hapticFeedback"
@@ -258,14 +258,21 @@ class Database(context: Context) {
 
     fun setFee(fee: BigDecimal) {
         prefs.apply {
-            // store as Float to preserve backward compatibility with existing installations
-            edit().putFloat(keyFeeValue, fee.toFloat()).apply()
+            edit().putString(keyFeeValue, fee.toPlainString()).apply()
         }
     }
 
     fun getFee(): LiveData<BigDecimal> {
-        return SharedPreferenceFloatLiveData(prefs, keyFeeValue, DEFAULT_FEE_PERCENT)
-            .map { it.toBigDecimal() }
+        migrateLegacyFeeIfNeeded()
+        return SharedPreferenceStringLiveData(prefs, keyFeeValue, DEFAULT_FEE_PERCENT)
+            .map { (it ?: DEFAULT_FEE_PERCENT).toBigDecimal() }
+    }
+
+    private fun migrateLegacyFeeIfNeeded() {
+        if (prefs.contains(keyFeeValue) || !prefs.contains(LEGACY_FEE_KEY)) return
+        val legacy = runCatching { prefs.getFloat(LEGACY_FEE_KEY, Float.NaN) }.getOrNull()
+        val migrated = if (legacy != null && !legacy.isNaN()) legacy.toString() else DEFAULT_FEE_PERCENT
+        prefs.edit().putString(keyFeeValue, migrated).remove(LEGACY_FEE_KEY).apply()
     }
 
     /* preview conversion */

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -17,6 +17,7 @@ import de.salomax.currencies.util.SharedPreferenceStringLiveData
 import de.salomax.currencies.util.SharedPreferenceStringSetLiveData
 import de.salomax.currencies.util.toLocalDate
 import de.salomax.currencies.util.toMillis
+import java.math.BigDecimal
 import java.time.LocalDate
 
 private const val DEFAULT_FEE_PERCENT = 2.2f
@@ -44,7 +45,7 @@ class Database(context: Context) {
                 editor.putString(keyBaseRate, items.base?.iso4217Alpha())
                 editor.putInt(keyProvider, items.provider?.id ?: -1)
                 items.rates?.forEach { rate ->
-                    editor.putFloat(rate.currency.iso4217Alpha(), rate.value)
+                    editor.putString(rate.currency.iso4217Alpha(), rate.value.toPlainString())
                 }
                 // persist
                 editor.apply()
@@ -255,14 +256,16 @@ class Database(context: Context) {
         return SharedPreferenceBooleanLiveData(prefs, keyFeeEnabled, false)
     }
 
-    fun setFee(fee: Float) {
+    fun setFee(fee: BigDecimal) {
         prefs.apply {
-            edit().putFloat(keyFeeValue, fee).apply()
+            // store as Float to preserve backward compatibility with existing installations
+            edit().putFloat(keyFeeValue, fee.toFloat()).apply()
         }
     }
 
-    fun getFee(): LiveData<Float> {
+    fun getFee(): LiveData<BigDecimal> {
         return SharedPreferenceFloatLiveData(prefs, keyFeeValue, DEFAULT_FEE_PERCENT)
+            .map { it.toBigDecimal() }
     }
 
     /* preview conversion */

--- a/app/src/main/kotlin/de/salomax/currencies/util/MathUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/MathUtils.kt
@@ -1,24 +1,22 @@
 package de.salomax.currencies.util
 
-private const val SIGNIFICANT_THRESHOLD = 0.01f
+import java.math.BigDecimal
+import java.math.MathContext
 
-fun calculateDifference(old: Float?, new: Float?): Float? {
-    return if (old == null || new == null)
+private val SIGNIFICANT_THRESHOLD = BigDecimal("0.01")
+
+fun calculateDifference(old: BigDecimal?, new: BigDecimal?): BigDecimal? {
+    return if (old == null || new == null || old.compareTo(BigDecimal.ZERO) == 0)
         null
-    else {
-        val percentage = (new - old) / old * 100
-        if (percentage.isFinite())
-            percentage
-        else
-            null
-    }
+    else
+        (new - old).divide(old, MathContext.DECIMAL128) * BigDecimal("100")
 }
 
-fun Float.getSignificantDecimalPlaces(significantNumbers: Int = 2): Int {
-    if (this >= SIGNIFICANT_THRESHOLD) {
+fun BigDecimal.getSignificantDecimalPlaces(significantNumbers: Int = 2): Int {
+    if (this.abs() >= SIGNIFICANT_THRESHOLD) {
         return significantNumbers
     }
-    val decimalStr = this.toBigDecimal().stripTrailingZeros().toPlainString()
+    val decimalStr = this.abs().stripTrailingZeros().toPlainString()
     val decimalPart = decimalStr.substringAfter('.', "")
     // find leading zeros
     val leadingZeros = decimalPart.takeWhile { it == '0' }.length

--- a/app/src/main/kotlin/de/salomax/currencies/util/SharedPreferenceExchangeRatesLiveData.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/SharedPreferenceExchangeRatesLiveData.kt
@@ -7,28 +7,31 @@ import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Rate
+import java.math.BigDecimal
 import java.time.LocalDate
 
 class SharedPreferenceExchangeRatesLiveData(private val sharedPrefs: SharedPreferences) : LiveData<ExchangeRates?>() {
 
     private fun getValueFromPreferences(): ExchangeRates? {
-        return if (sharedPrefs.getString("_base", null) == null || sharedPrefs.getString("_date", null) == null)
-            null
-        else
-            ExchangeRates(
-                true, // success always true, when serving cached data
-                null, // error message always null, when serving cached data
-                Currency.fromString(sharedPrefs.getString("_base", null)!!),
-                LocalDate.parse(sharedPrefs.getString("_date", null))!!,
-                sharedPrefs.all.entries
-                    .filter { !it.key.startsWith("_") }
-                    .sortedBy { it.key }
-                    .mapNotNull { entry ->
-                        Currency.fromString(entry.key!!)?.let { Rate(it, entry.value as Float) }
-                    }
-                    .toList(),
-                sharedPrefs.getInt("_provider", -1).let { ApiProvider.fromId(it) }
-            )
+        if (sharedPrefs.getString("_base", null) == null || sharedPrefs.getString("_date", null) == null)
+            return null
+        // values were previously stored as Float; skip stale entries and return null if all are stale
+        val rates = sharedPrefs.all.entries
+            .filter { !it.key.startsWith("_") }
+            .sortedBy { it.key }
+            .mapNotNull { entry ->
+                val str = entry.value as? String ?: return@mapNotNull null
+                Currency.fromString(entry.key!!)?.let { Rate(it, BigDecimal(str)) }
+            }
+        if (rates.isEmpty()) return null
+        return ExchangeRates(
+            true, // success always true, when serving cached data
+            null, // error message always null, when serving cached data
+            Currency.fromString(sharedPrefs.getString("_base", null)!!),
+            LocalDate.parse(sharedPrefs.getString("_date", null))!!,
+            rates,
+            sharedPrefs.getInt("_provider", -1).let { ApiProvider.fromId(it) }
+        )
     }
 
     private val preferenceChangeListener = OnSharedPreferenceChangeListener { _: SharedPreferences?, _: String? ->

--- a/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
@@ -3,6 +3,7 @@ package de.salomax.currencies.util
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import de.salomax.currencies.R
+import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -70,7 +71,7 @@ fun hasAppendedCurrencySymbol(context: Context): Boolean {
  * - uses the correct numbers (e.g. east arabian) of the locale
  * - adds plus sign and/or a suffix, if wanted
  */
-fun Float.toHumanReadableNumber(
+fun BigDecimal.toHumanReadableNumber(
     context: Context,
     decimalPlaces: Int? = null,
     showPositiveSign: Boolean = false,
@@ -78,7 +79,6 @@ fun Float.toHumanReadableNumber(
     trim: Boolean = false
 ): String {
     return this
-        .toBigDecimal()
         .toPlainString()
         .toHumanReadableNumber(context, decimalPlaces, showPositiveSign, suffix, trim)
 }
@@ -101,7 +101,7 @@ fun String.toHumanReadableNumber(
     // + sign
     if (showPositiveSign
         && DecimalFormat.getInstance().parse(this) != null
-        && DecimalFormat.getInstance().parse(this)!!.toFloat() >= 0
+        && DecimalFormat.getInstance().parse(this)!!.toDouble() >= 0.0
     )
         sb.append("+ ")
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -44,6 +44,7 @@ import de.salomax.currencies.util.getLocale
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.util.toNumber
 import de.salomax.currencies.view.BaseActivity
+import java.math.BigDecimal
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
 import de.salomax.currencies.view.preference.PreferenceActivity
 import de.salomax.currencies.view.timeline.TimelineActivity
@@ -382,10 +383,10 @@ class MainActivity : BaseActivity() {
             ?.let { spinnerFrom.setCurrentRate(Rate(currency, it)) }
     }
 
-    private fun observeFeeValue(fee: Float) {
+    private fun observeFeeValue(fee: BigDecimal) {
         tvFee.text = fee.toHumanReadableNumber(this, showPositiveSign = true, suffix = "%")
         tvFee.setTextColor(
-            if (fee >= 0) MaterialColors.getColor(this, R.attr.colorError, null)
+            if (fee >= BigDecimal.ZERO) MaterialColors.getColor(this, R.attr.colorError, null)
             else MaterialColors.getColor(this, R.attr.colorPrimary, null)
         )
     }

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinner.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinner.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentActivity
 import de.salomax.currencies.R
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
+import java.math.BigDecimal
 
 class SearchableSpinner : AppCompatSpinner {
 
@@ -88,7 +89,7 @@ class SearchableSpinner : AppCompatSpinner {
         // set in dialog
         spinnerDialog.setCurrentRate(currentRate)
     }
-    fun setCurrentSum(currentSum: Double) {
+    fun setCurrentSum(currentSum: BigDecimal) {
         // set in dialog
         spinnerDialog.setCurrentSum(currentSum)
     }

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
@@ -16,6 +16,7 @@ import de.salomax.currencies.R
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.viewmodel.main.MainViewModel
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
+import java.math.BigDecimal
 
 class SearchableSpinnerDialog(context: Context) : AppCompatDialogFragment(), SearchView.OnQueryTextListener {
 
@@ -33,7 +34,7 @@ class SearchableSpinnerDialog(context: Context) : AppCompatDialogFragment(), Sea
     fun setCurrentRate(currentRate: Rate) {
         adapter.setCurrentRate(currentRate)
     }
-    fun setCurrentSum(currentSum: Double) {
+    fun setCurrentSum(currentSum: BigDecimal) {
         adapter.setCurrentSum(currentSum)
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
@@ -32,7 +32,7 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
 
     private var isPreviewConversionEnabled: Boolean = false
     private var currentBaseRate: Rate? = null
-    private var currentBaseSum: Double = 1.0
+    private var currentBaseSum: BigDecimal = BigDecimal.ONE
 
     private var filterStarred = false
     private var filterText: String? = null
@@ -133,20 +133,19 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
         currentBaseRate = currentRate
         update()
     }
-    fun setCurrentSum(currentSum: Double) {
+    fun setCurrentSum(currentSum: BigDecimal) {
         currentBaseSum = currentSum
         update()
     }
 
     private fun buildConversionText(item: Rate): String {
-        val sum = if (currentBaseSum == 0.0) 1.0 else currentBaseSum
+        val sum = if (currentBaseSum.compareTo(BigDecimal.ZERO) == 0) BigDecimal.ONE else currentBaseSum
         val sourceSymbol = currentBaseRate!!.currency.symbol() ?: ""
-        val source = sum.toString().toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
+        val source = sum.toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
         val destinationSymbol = item.currency.symbol() ?: ""
-        val destination = BigDecimal(sum)
+        val destination = sum
             .divide(currentBaseRate!!.value, MathContext.DECIMAL128)
             .multiply(item.value)
-            .toPlainString()
             .toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
         val left = if (sourceSymbol.isEmpty()) source
             else if (hasAppendedCurrencySymbol(context)) "$source $sourceSymbol"

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
@@ -15,6 +15,8 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.util.hasAppendedCurrencySymbol
 import de.salomax.currencies.util.toHumanReadableNumber
+import java.math.BigDecimal
+import java.math.MathContext
 
 @SuppressLint("NotifyDataSetChanged")
 class SearchableSpinnerDialogAdapter(private val context: Context) :
@@ -141,8 +143,11 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
         val sourceSymbol = currentBaseRate!!.currency.symbol() ?: ""
         val source = sum.toString().toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
         val destinationSymbol = item.currency.symbol() ?: ""
-        val destination = sum.div(currentBaseRate!!.value).times(item.value)
-            .toString().toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
+        val destination = BigDecimal(sum)
+            .divide(currentBaseRate!!.value, MathContext.DECIMAL128)
+            .multiply(item.value)
+            .toPlainString()
+            .toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
         val left = if (sourceSymbol.isEmpty()) source
             else if (hasAppendedCurrencySymbol(context)) "$source $sourceSymbol"
             else "$sourceSymbol $source"

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -19,6 +19,7 @@ import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
 import de.salomax.currencies.widget.EditTextSwitchPreference
 import de.salomax.currencies.widget.LongSummaryPreference
+import java.math.BigDecimal
 import java.util.Calendar
 
 @Suppress("unused")
@@ -44,18 +45,14 @@ class PreferenceFragment: PreferenceFragmentCompat() {
         val feePreference = findPreference<EditTextSwitchPreference>(getString(R.string.fee_key))
         feePreference?.setOnPreferenceChangeListener { _, newValue ->
             if (newValue is String)
-                try {
-                    viewModel.setFee(if (newValue.isEmpty()) 0f else newValue.toFloat())
-                } catch (e: NumberFormatException) {
-                    viewModel.setFee(0f)
-                }
+                viewModel.setFee(newValue.toBigDecimalOrNull() ?: BigDecimal.ZERO)
             else if (newValue is Boolean)
                 viewModel.setFeeEnabled(newValue)
             true
         }
         viewModel.getFee().observe(this) {
             feePreference?.summary = it.toHumanReadableNumber(requireContext(), showPositiveSign = true, suffix = "%")
-            feePreference?.text = it.toString()
+            feePreference?.text = it.toPlainString()
         }
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/timeline/ChartAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/timeline/ChartAdapter.kt
@@ -16,10 +16,10 @@ class ChartAdapter : SparkAdapter() {
 
     override fun getItem(index: Int): Map.Entry<LocalDate, Rate>? = entries?.get(index)
 
-    override fun getY(index: Int): Float = getItem(index)?.value?.value ?: 0f
+    override fun getY(index: Int): Float = getItem(index)?.value?.value?.toFloat() ?: 0f
 
     override fun hasBaseLine() = true
 
-    override fun getBaseLine(): Float = entries?.last()?.value?.value ?: 0f
+    override fun getBaseLine(): Float = entries?.last()?.value?.value?.toFloat() ?: 0f
 
 }

--- a/app/src/main/kotlin/de/salomax/currencies/view/timeline/TimelineActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/timeline/TimelineActivity.kt
@@ -32,6 +32,7 @@ import de.salomax.currencies.view.BaseActivity
 import de.salomax.currencies.viewmodel.timeline.TimelineViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -226,7 +227,7 @@ class TimelineActivity : BaseActivity() {
             textRateDifference.text = it?.toHumanReadableNumber(this, 2, true, "%")
             if (it != null)
                 textRateDifference.setTextColor(
-                    if (it < 0) MaterialColors.getColor(this, R.attr.colorError, null)
+                    if (it < BigDecimal.ZERO) MaterialColors.getColor(this, R.attr.colorError, null)
                     else getColor(R.color.dollarBill)
                 )
         }
@@ -278,7 +279,7 @@ class TimelineActivity : BaseActivity() {
         }
     }
 
-    private fun populateStat(parent: View, symbol: String?, value: Float?, date: LocalDate?, places: Int = 3) {
+    private fun populateStat(parent: View, symbol: String?, value: BigDecimal?, date: LocalDate?, places: Int = 3) {
         // hide entire row when there's no data
         parent.visibility = if (symbol == null) View.GONE else View.VISIBLE
         // hide dotted line when there's no date
@@ -289,7 +290,7 @@ class TimelineActivity : BaseActivity() {
     }
 
     private fun combineValueAndSymbol(
-        value: Float,
+        value: BigDecimal,
         symbol: String?,
         decimalPlaces: Int
     ): SpannableStringBuilder {

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -337,11 +337,11 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     }
 
     /**
-     * the total base value, converted to double (internal is string)
+     * the total base value, as BigDecimal (internal is string)
      */
-    internal fun getCurrentBaseValueAsNumber(): LiveData<Double> {
+    internal fun getCurrentBaseValueAsNumber(): LiveData<BigDecimal> {
         return currentBaseValue.map {
-            it?.toBigDecimal()?.toDouble() ?: 0.0
+            it?.toBigDecimalOrNull() ?: BigDecimal.ZERO
         }
     }
 
@@ -431,11 +431,11 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     }
 
     /**
-     * the total destination value, converted to double (internal is string)
+     * the total destination value, as BigDecimal (internal is string)
      */
-    internal fun getResultAsNumber(): LiveData<Double> {
+    internal fun getResultAsNumber(): LiveData<BigDecimal> {
         return result.map {
-            it?.toBigDecimal()?.toDouble() ?: 0.0
+            it?.toBigDecimalOrNull() ?: BigDecimal.ZERO
         }
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -19,7 +19,6 @@ import de.salomax.currencies.repository.Database
 import de.salomax.currencies.repository.ExchangeRatesRepository
 import de.salomax.currencies.util.combineWith
 import de.salomax.currencies.util.getDecimalSeparator
-import de.salomax.currencies.util.getLocale
 import de.salomax.currencies.util.getSignificantDecimalPlaces
 import de.salomax.currencies.util.hasAppendedCurrencySymbol
 import de.salomax.currencies.util.toHumanReadableNumber
@@ -271,11 +270,10 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
                         R.string.info_conversion,
                         "1",
                         baseCurrency!!.iso4217Alpha(),
-                        String.format(
-                            getLocale(app),
-                            "%.${destinationValueCalculated?.getSignificantDecimalPlaces(2)}f",
-                            destinationValueCalculated
-                        ),
+                        destinationValueCalculated?.toHumanReadableNumber(
+                            app,
+                            decimalPlaces = destinationValueCalculated.getSignificantDecimalPlaces(2)
+                        ) ?: "",
                         destinationCurrency!!.iso4217Alpha()
                     ),
                     HtmlCompat.FROM_HTML_MODE_LEGACY

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -24,11 +24,13 @@ import de.salomax.currencies.util.getSignificantDecimalPlaces
 import de.salomax.currencies.util.hasAppendedCurrencySymbol
 import de.salomax.currencies.util.toHumanReadableNumber
 import org.mariuszgromada.math.mxparser.Expression
+import java.math.BigDecimal
+import java.math.MathContext
 import java.text.Collator
 import java.time.LocalDate
 import java.time.ZoneId
 
-private const val PERCENTAGE_DIVISOR = 100f
+private val PERCENTAGE_DIVISOR = BigDecimal("100")
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidViewModel(app) {
@@ -69,7 +71,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
 
     // fee
     private val isFeeEnabled: LiveData<Boolean>
-    private val fee: LiveData<Float>
+    private val fee: LiveData<BigDecimal>
 
     /*
      * repository data =============================================================================
@@ -238,7 +240,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     /**
      * the fee amount
      */
-    internal fun getFee(): LiveData<Float> {
+    internal fun getFee(): LiveData<BigDecimal> {
         return fee
     }
 
@@ -259,7 +261,9 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
                 val baseValue = exchangeRates!!.rates?.find { it.currency == baseCurrency }?.value
                 // target currency
                 val destinationValue = exchangeRates!!.rates?.find { it.currency == destinationCurrency }?.value
-                val destinationValueCalculated = baseValue?.let { destinationValue?.div(it) }
+                val destinationValueCalculated = baseValue?.let {
+                    destinationValue?.divide(it, MathContext.DECIMAL128)
+                }
 
                 // create string
                 this.value = HtmlCompat.fromHtml(
@@ -387,7 +391,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
         var baseValue: String? = null
         var baseCurrency: Currency? = null
         var destinationCurrency: Currency? = null
-        var feeValue: Float? = null
+        var feeValue: BigDecimal? = null
         var feeEnabled: Boolean? = null
 
         init {
@@ -406,22 +410,24 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
         }
 
         private fun calculateResult() {
-            val baseValue: Double = baseValue?.toBigDecimal()?.toDouble() ?: 0.0
+            val baseValue: BigDecimal = baseValue?.toBigDecimal() ?: BigDecimal.ZERO
             val baseRate = rates?.rates?.find { it.currency == baseCurrency }
             val destinationRate = rates?.rates?.find { it.currency == destinationCurrency }
 
             if (baseRate != null && destinationRate != null) {
                 this.value =
-                    baseValue.div(baseRate.value).times(destinationRate.value)
+                    baseValue
+                        .divide(baseRate.value, MathContext.DECIMAL128)
+                        .multiply(destinationRate.value)
                         .let {
                             // add fee, if enabled
                             if (feeEnabled != null && feeEnabled == true && feeValue != null) {
-                                it + (it * (feeValue!! / PERCENTAGE_DIVISOR))
+                                it + it.multiply(feeValue!!.divide(PERCENTAGE_DIVISOR, MathContext.DECIMAL128))
                             } else {
                                 it
                             }
                         }
-                        .toString()
+                        .toPlainString()
             }
         }
     }

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
@@ -14,6 +14,7 @@ import de.salomax.currencies.repository.Database
 import de.salomax.currencies.repository.ExchangeRatesRepository
 import de.salomax.currencies.view.main.MainActivity
 import de.salomax.currencies.view.preference.PreferenceActivity
+import java.math.BigDecimal
 
 class PreferenceViewModel(private val app: Application) : AndroidViewModel(app) {
 
@@ -115,11 +116,11 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app) 
         return x || y
     }
 
-    fun setFee(fee: Float) {
+    fun setFee(fee: BigDecimal) {
         Database(app).setFee(fee)
     }
 
-    fun getFee(): LiveData<Float> {
+    fun getFee(): LiveData<BigDecimal> {
         return Database(app).getFee()
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/timeline/TimelineViewModel.kt
@@ -18,8 +18,9 @@ import de.salomax.currencies.model.Timeline
 import de.salomax.currencies.repository.ExchangeRatesRepository
 import de.salomax.currencies.util.calculateDifference
 import de.salomax.currencies.util.getSignificantDecimalPlaces
+import java.math.BigDecimal
+import java.math.MathContext
 import java.time.LocalDate
-import kotlin.math.absoluteValue
 import kotlin.math.min
 
 private const val DEFAULT_DECIMAL_PLACES = 3
@@ -182,8 +183,8 @@ class TimelineViewModel(
         }
     }
 
-    fun getRatesDifferencePercent(): LiveData<Float?> {
-        return MediatorLiveData<Float?>().apply {
+    fun getRatesDifferencePercent(): LiveData<BigDecimal?> {
+        return MediatorLiveData<BigDecimal?>().apply {
             var scrubDate: LocalDate? = null
             var rates: Set<Map.Entry<LocalDate, Rate?>>? = null
 
@@ -217,12 +218,14 @@ class TimelineViewModel(
             var rates: Set<Map.Entry<LocalDate, Rate?>>? = null
 
             fun update() {
-                val avg: Rate? = rates
+                val values = rates
                     ?.filter { map -> scrubDate?.let { !map.key.isBefore(it) } ?: true }
-                    ?.map { entry -> entry.value }
-                    ?.map { rate -> rate?.value ?: 0f }
-                    ?.average()
-                    ?.let { average -> Rate(target, average.toFloat()) }
+                    ?.mapNotNull { entry -> entry.value?.value }
+                val avg: Rate? = if (values.isNullOrEmpty()) null
+                    else values
+                        .fold(BigDecimal.ZERO, BigDecimal::add)
+                        .divide(BigDecimal(values.size), MathContext.DECIMAL128)
+                        .let { Rate(target, it) }
                 this.value = Pair(avg, decimalPlaces)
             }
 
@@ -251,12 +254,12 @@ class TimelineViewModel(
             fun update() {
                 val min: Rate? = rates
                     ?.filter { map -> scrubDate?.let { !map.key.isBefore(it) } ?: true }
-                    ?.map { entry -> entry.value }
-                    ?.minOfOrNull { rate -> rate?.value ?: 0f }
-                    ?.let { min -> Rate(target, min) }
+                    ?.mapNotNull { entry -> entry.value }
+                    ?.minByOrNull { rate -> rate.value }
+                    ?.let { Rate(target, it.value) }
                 val date: LocalDate? = rates
                     ?.filter { map -> scrubDate?.let { !map.key.isBefore(it) } ?: true }
-                    ?.findLast { entry -> entry.value?.value == min?.value }
+                    ?.findLast { entry -> entry.value?.value?.compareTo(min?.value) == 0 }
                     ?.key
                 this.value = Triple(min, date, decimalPlaces)
             }
@@ -286,12 +289,12 @@ class TimelineViewModel(
             fun update() {
                 val max: Rate? = rates
                     ?.filter { map -> scrubDate?.let { !map.key.isBefore(it) } ?: true }
-                    ?.map { entry -> entry.value }
-                    ?.maxOfOrNull { rate -> rate?.value ?: 0f }
-                    ?.let { max -> Rate(target, max) }
+                    ?.mapNotNull { entry -> entry.value }
+                    ?.maxByOrNull { rate -> rate.value }
+                    ?.let { Rate(target, it.value) }
                 val date: LocalDate? = rates
                     ?.filter { map -> scrubDate?.let { !map.key.isBefore(it) } ?: true }
-                    ?.findLast { entry -> entry.value?.value == max?.value }
+                    ?.findLast { entry -> entry.value?.value?.compareTo(max?.value) == 0 }
                     ?.key
                 this.value = Triple(max, date, decimalPlaces)
             }
@@ -315,19 +318,19 @@ class TimelineViewModel(
 
     private fun getDecimalPlaces(): LiveData<Int> {
         return MediatorLiveData<Int>().apply {
-            var min = 0f
-            var max = 0f
+            var min = BigDecimal.ZERO
+            var max = BigDecimal.ZERO
 
             fun update() {
                 this.value = min(
-                    (min - max).absoluteValue.getSignificantDecimalPlaces(SIGNIFICANT_DIGITS),
+                    (min - max).abs().getSignificantDecimalPlaces(SIGNIFICANT_DIGITS),
                     MAX_DECIMAL_PLACES
                 )
             }
 
             addSource(dbLiveItems) {
-                min = it?.rates?.entries?.minOfOrNull { rate -> rate.value.value } ?: 0f
-                max = it?.rates?.entries?.maxOfOrNull { rate -> rate.value.value } ?: 0f
+                min = it?.rates?.entries?.minOfOrNull { rate -> rate.value.value } ?: BigDecimal.ZERO
+                max = it?.rates?.entries?.maxOfOrNull { rate -> rate.value.value } ?: BigDecimal.ZERO
                 update()
             }
         }

--- a/app/src/test/kotlin/de/salomax/currencies/util/MathUtilsTest.kt
+++ b/app/src/test/kotlin/de/salomax/currencies/util/MathUtilsTest.kt
@@ -1,35 +1,38 @@
 package de.salomax.currencies.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
+import java.math.BigDecimal
 
 @RunWith(MockitoJUnitRunner::class)
 class MathUtilsTest {
 
     @Test
     fun calculateDifferenceTest() {
-        assertEquals(10f, calculateDifference(100f, 110f))
-        assertEquals(-10f, calculateDifference(100f, 90f))
-        assertEquals(null, calculateDifference(null, 1f))
-        assertEquals(null, calculateDifference(1f, null))
-        assertEquals(null, calculateDifference(null, null))
-        assertEquals(null, calculateDifference(Float.POSITIVE_INFINITY, 1f))
-        assertEquals(null, calculateDifference(Float.NEGATIVE_INFINITY, 1f))
+        assertEquals(0, calculateDifference(bd("100"), bd("110"))?.compareTo(bd("10")))
+        assertEquals(0, calculateDifference(bd("100"), bd("90"))?.compareTo(bd("-10")))
+        assertNull(calculateDifference(null, bd("1")))
+        assertNull(calculateDifference(bd("1"), null))
+        assertNull(calculateDifference(null, null))
+        assertNull(calculateDifference(BigDecimal.ZERO, bd("1")))
     }
 
     @Test
     fun getSignificantDecimalPlacesTest() {
-        assertEquals(2, 1f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.9f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.991f.getSignificantDecimalPlaces(2))
-        assertEquals(4, 0.0026f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.998f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.9991f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.99991f.getSignificantDecimalPlaces(2))
-        assertEquals(2, 0.999991f.getSignificantDecimalPlaces(2))
-        assertEquals(5, 0.9999991f.getSignificantDecimalPlaces(5))
+        assertEquals(2, bd("1").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.9").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.991").getSignificantDecimalPlaces(2))
+        assertEquals(4, bd("0.0026").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.998").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.9991").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.99991").getSignificantDecimalPlaces(2))
+        assertEquals(2, bd("0.999991").getSignificantDecimalPlaces(2))
+        assertEquals(5, bd("0.9999991").getSignificantDecimalPlaces(5))
     }
+
+    private fun bd(value: String) = BigDecimal(value)
 
 }


### PR DESCRIPTION
## Summary

- Replaces `Float` (7 significant digits) with `BigDecimal` throughout the entire currency value pipeline — parse, cache, calculate, and display
- All 10 adapters (JSON + XML) now parse values as `BigDecimal` instead of `toFloat()`. JSON adapters read via `BigDecimal(reader.nextString())` to preserve exact decimal precision from the source (never through IEEE-754 double)
- SharedPreferences cache switches from `putFloat` to `putString(toPlainString())`; any stale `Float` entries from old installs are skipped and trigger a fresh API fetch
- All arithmetic in `MainViewModel` uses `BigDecimal.divide(…, MathContext.DECIMAL128)` and `multiply` — no more precision loss in `baseValue / baseRate * destinationRate`
- Info footer uses `toHumanReadableNumber` instead of `String.format("%f", …)` to avoid silent downcast to double
- `TimelineViewModel` avg/min/max/difference all use BigDecimal
- `TextUtils.Float.toHumanReadableNumber` → `BigDecimal.toHumanReadableNumber`
- `MathUtils.calculateDifference` and `getSignificantDecimalPlaces` use BigDecimal
- Fee is stored as `String` (`toPlainString`) under a new `_fee_str` key, with one-time migration from the legacy `_fee` Float key on first read
- `ChartAdapter.getY` / `getBaseLine` convert to `Float` only at the `SparkAdapter` boundary (library requirement)

Closes #7 (upstream)

## Test plan
- [ ] CI build passes
- [ ] Main conversion (e.g. 1 USD → EUR) shows correct result without floating-point artifacts
- [ ] Fee toggle still works; existing fee setting is migrated on upgrade (legacy `_fee` Float → new `_fee_str` String)
- [ ] Timeline chart renders, avg/min/max stats display correctly
- [ ] Conversion preview in currency picker shows correct values
- [ ] First launch after upgrade fetches fresh rates (old Float cache is discarded gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)