### PR TITLE
feat: order currency list with favorites first and drag-to-reorder

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -13,7 +13,6 @@ import de.salomax.currencies.util.SharedPreferenceExchangeRatesLiveData
 import de.salomax.currencies.util.SharedPreferenceIntLiveData
 import de.salomax.currencies.util.SharedPreferenceLongLiveData
 import de.salomax.currencies.util.SharedPreferenceStringLiveData
-import de.salomax.currencies.util.SharedPreferenceStringSetLiveData
 import de.salomax.currencies.util.toLocalDate
 import de.salomax.currencies.util.toMillis
 import java.math.BigDecimal
@@ -120,42 +119,40 @@ class Database(context: Context) {
         context.getSharedPreferences("starred_currencies", MODE_PRIVATE)
 
     private val keyStars = "_stars"
+    private val keyStarsOrder = "_starsOrder"
     private val keyStarredEnabled = "_starredActive"
 
-    fun toggleCurrencyStar(currency: Currency) {
-        prefsStarredCurrencies.apply {
-            if (prefsStarredCurrencies.getStringSet(keyStars, HashSet<String>())!!.contains(currency.iso4217Alpha()))
-                removeCurrencyStar(currency)
-            else
-                starCurrency(currency)
-        }
+    private fun readOrderedStarCodes(): List<String> {
+        val stored = prefsStarredCurrencies.getString(keyStarsOrder, null)
+        if (stored != null)
+            return if (stored.isEmpty()) emptyList() else stored.split(",")
+        // migrate legacy Set<String> to ordered CSV (alphabetical)
+        val legacy = prefsStarredCurrencies.getStringSet(keyStars, HashSet<String>())!!
+        return legacy.sorted()
     }
 
-    fun getStarredCurrencies(): LiveData<Set<Currency>> {
-        return SharedPreferenceStringSetLiveData(prefsStarredCurrencies, keyStars, HashSet())
-            .map { set ->
-                set.mapNotNull { code ->
-                    Currency.fromString(code)
-                }.toSet()
+    private fun writeOrderedStarCodes(codes: List<String>) {
+        prefsStarredCurrencies.edit()
+            .putString(keyStarsOrder, codes.joinToString(","))
+            .apply()
+    }
+
+    fun toggleCurrencyStar(currency: Currency) {
+        val code = currency.iso4217Alpha()
+        val current = readOrderedStarCodes()
+        val next = if (current.contains(code)) current.minus(code) else current.plus(code)
+        writeOrderedStarCodes(next)
+    }
+
+    fun getStarredCurrencies(): LiveData<List<Currency>> {
+        return SharedPreferenceStringLiveData(prefsStarredCurrencies, keyStarsOrder, null)
+            .map { _ ->
+                readOrderedStarCodes().mapNotNull { code -> Currency.fromString(code) }
             }
     }
 
-    private fun starCurrency(currency: Currency) {
-        prefsStarredCurrencies.apply {
-            edit().putStringSet(keyStars,
-                prefsStarredCurrencies.getStringSet(keyStars, HashSet<String>())!!
-                    .plus(currency.iso4217Alpha())
-            ).apply()
-        }
-    }
-
-    private fun removeCurrencyStar(currency: Currency) {
-        prefsStarredCurrencies.apply {
-            edit().putStringSet(keyStars,
-                prefsStarredCurrencies.getStringSet(keyStars, HashSet<String>())!!
-                    .minus(currency.iso4217Alpha())
-            ).apply()
-        }
+    fun setStarredCurrencyOrder(currencies: List<Currency>) {
+        writeOrderedStarCodes(currencies.map { it.iso4217Alpha() })
     }
 
     fun isFilterStarredEnabled(): SharedPreferenceBooleanLiveData {

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.salomax.currencies.R
@@ -57,6 +58,52 @@ class SearchableSpinnerDialog(context: Context) : AppCompatDialogFragment(), Sea
         adapter.onStarClicked = {
             mainViewModel.toggleCurrencyStar(it.currency)
         }
+
+        // drag-to-reorder for starred rows (long-press to drag)
+        val dragCallback = object : ItemTouchHelper.Callback() {
+            override fun isLongPressDragEnabled(): Boolean = true
+            override fun isItemViewSwipeEnabled(): Boolean = false
+
+            override fun getMovementFlags(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder
+            ): Int {
+                val pos = viewHolder.bindingAdapterPosition
+                return if (adapter.isDraggable(pos))
+                    makeMovementFlags(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0)
+                else 0
+            }
+
+            override fun onMove(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder
+            ): Boolean {
+                return adapter.moveItem(
+                    viewHolder.bindingAdapterPosition,
+                    target.bindingAdapterPosition
+                )
+            }
+
+            override fun canDropOver(
+                recyclerView: RecyclerView,
+                current: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder
+            ): Boolean {
+                return adapter.isDraggable(target.bindingAdapterPosition)
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) = Unit
+
+            override fun clearView(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder
+            ) {
+                super.clearView(recyclerView, viewHolder)
+                mainViewModel.setStarredCurrencyOrder(adapter.getCurrentStarredOrder())
+            }
+        }
+        ItemTouchHelper(dragCallback).attachToRecyclerView(listView)
 
         // searchView
         searchView = view.findViewById(R.id.searchView)

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
@@ -28,7 +28,7 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
 
     private var rates: List<Rate> = listOf()
     private var ratesFiltered: MutableList<Rate> = mutableListOf()
-    private var stars: Set<Currency> = setOf()
+    private var stars: List<Currency> = listOf()
 
     private var isPreviewConversionEnabled: Boolean = false
     private var currentBaseRate: Rate? = null
@@ -106,12 +106,35 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
         update()
     }
 
-    fun setStars(stars: Set<Currency>?) {
-        if (stars == null)
-            this.stars = HashSet()
-        else
-            this.stars = stars
+    fun setStars(stars: List<Currency>?) {
+        this.stars = stars ?: emptyList()
         update()
+    }
+
+    fun isStarred(position: Int): Boolean {
+        if (position < 0 || position >= ratesFiltered.size) return false
+        return stars.contains(ratesFiltered[position].currency)
+    }
+
+    fun isDraggable(position: Int): Boolean {
+        return filterText.isNullOrEmpty() && isStarred(position)
+    }
+
+    fun moveItem(from: Int, to: Int): Boolean {
+        if (from == to) return false
+        if (from !in ratesFiltered.indices || to !in ratesFiltered.indices) return false
+        if (!isStarred(from) || !isStarred(to)) return false
+        val item = ratesFiltered.removeAt(from)
+        ratesFiltered.add(to, item)
+        notifyItemMoved(from, to)
+        return true
+    }
+
+    fun getCurrentStarredOrder(): List<Currency> {
+        val visibleOrder = ratesFiltered.map { it.currency }.filter { stars.contains(it) }
+        // preserve any starred currencies that aren't in the current rates (e.g. after api switch)
+        val missing = stars.filterNot { visibleOrder.contains(it) }
+        return visibleOrder + missing
     }
 
     fun filterStarred(enabled: Boolean) {
@@ -157,7 +180,7 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
     }
 
     private fun update() {
-        ratesFiltered = rates
+        val filtered = rates
             // find all rates based on both their code name or their full name
             .filter { rate ->
                 if (filterText != null)
@@ -174,7 +197,11 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
                     stars.contains(rate.currency)
                 else
                     true
-            }.toMutableList()
+            }
+        // starred rates come first, in the user's stored order; everything else keeps its order
+        val starredRates = stars.mapNotNull { code -> filtered.find { it.currency == code } }
+        val rest = filtered.filterNot { stars.contains(it.currency) }
+        ratesFiltered = (starredRates + rest).toMutableList()
 
         notifyDataSetChanged()
     }

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -50,7 +50,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     // repository data
     private var dbLiveItems: LiveData<ExchangeRates?>
     private var exchangeRates: LiveData<ExchangeRates?>
-    private val starredLiveItems: LiveData<Set<Currency>>
+    private val starredLiveItems: LiveData<List<Currency>>
     private val onlyShowStarred: LiveData<Boolean>
     private val liveError = repository.getError()
 
@@ -194,8 +194,15 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     /**
      * all the currencies that the user has starred
      */
-    internal fun getStarredCurrencies(): LiveData<Set<Currency>> {
+    internal fun getStarredCurrencies(): LiveData<List<Currency>> {
         return starredLiveItems
+    }
+
+    /**
+     * persist the user's manual ordering of starred currencies
+     */
+    internal fun setStarredCurrencyOrder(currencies: List<Currency>) {
+        Database(getApplication()).setStarredCurrencyOrder(currencies)
     }
 
     /**


### PR DESCRIPTION
## Summary
- Favorites now always appear first in the picker, in a user-defined order that persists between sessions
- Long-press a starred row in the picker to drag it up/down; drops are restricted to the starred zone, and the new order is saved on release
- Star storage migrated from `Set<String>` to an ordered CSV string (`_starsOrder`); legacy set is auto-migrated (alphabetical) on first read

## Details
- **Database**: new `setStarredCurrencyOrder()`; `getStarredCurrencies()` returns `LiveData<List<Currency>>`. `toggleCurrencyStar` appends to the end when starring, preserves position when unstarring.
- **MainViewModel**: passthrough `setStarredCurrencyOrder()`, updated LiveData type.
- **Adapter**: `update()` partitions filtered rates into starred (in stored order) then everything else. New helpers `isDraggable` / `moveItem` / `getCurrentStarredOrder`. Non-visible starred codes (e.g. after API switch) are preserved when persisting.
- **Dialog**: attaches an `ItemTouchHelper` with long-press drag. Dragging disabled while search is active.

## Test plan
- [ ] Fresh install: star a few currencies, close/reopen picker — starred come first (alphabetical initially).
- [ ] Long-press a favorite, drag it, release — new position sticks after closing and reopening the picker.
- [ ] Try dragging into the non-starred zone — drop is rejected.
- [ ] Type in the search box — dragging is disabled.
- [ ] Existing users with legacy starred set: their favorites still appear (alphabetically) and can be reordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)