### PR TITLE
chore: refactor complex methods flagged by detekt

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaRatesAdapter.kt
@@ -51,29 +51,12 @@ internal class BankOfCanadaRatesAdapter {
         var date: LocalDate? = null
         val rates = mutableListOf<Rate>()
 
-        if (reader.peek() == JsonReader.Token.END_ARRAY)
-            // no data
+        if (reader.peek() == JsonReader.Token.END_ARRAY) {
             errorMessage = "No data found."
-        else {
-            reader.beginObject()
-            while (reader.hasNext()) {
-                when (val nextName = reader.nextName()) {
-                    // date
-                    "d" -> date = LocalDate.parse(reader.nextString())
-                    // rate
-                    else -> {
-                        val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
-                        reader.beginObject()
-                        reader.skipName() // always "v"
-                        val value = BigDecimal(reader.nextString())
-                        reader.endObject()
-                        currency?.let { rates.add(Rate(it, BigDecimal.ONE.divide(value, MathContext.DECIMAL128))) }
-                    }
-                }
-            }
+        } else {
+            date = readObservationRates(reader, rates)
         }
         if (rates.isNotEmpty())
-            // finally, add CAD...
             rates.add(Rate(Currency.CAD, BigDecimal.ONE))
 
         return ExchangeRates(
@@ -84,6 +67,29 @@ internal class BankOfCanadaRatesAdapter {
             rates = rates,
             provider = ApiProvider.BANK_OF_CANADA
         )
+    }
+
+    private fun readObservationRates(reader: JsonReader, rates: MutableList<Rate>): LocalDate? {
+        var date: LocalDate? = null
+        reader.beginObject()
+        while (reader.hasNext()) {
+            val nextName = reader.nextName()
+            if (nextName == "d") {
+                date = LocalDate.parse(reader.nextString())
+            } else {
+                readRate(reader, nextName)?.let(rates::add)
+            }
+        }
+        return date
+    }
+
+    private fun readRate(reader: JsonReader, name: String): Rate? {
+        val currency = Currency.fromString(name.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
+        reader.beginObject()
+        reader.skipName() // always "v"
+        val value = BigDecimal(reader.nextString())
+        reader.endObject()
+        return currency?.let { Rate(it, BigDecimal.ONE.divide(value, MathContext.DECIMAL128)) }
     }
 
     @Synchronized

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/BankOfCanadaTimelineAdapter.kt
@@ -76,29 +76,18 @@ internal class BankOfCanadaTimelineAdapter(
 
     private fun convertObservation(reader: JsonReader): Pair<LocalDate, Rate>? {
         var date: LocalDate? = null
-
         var baseValue: BigDecimal? = null
         var symbolValue: BigDecimal? = null
 
         reader.beginObject()
         while (reader.hasNext()) {
-            when (val nextName = reader.nextName()) {
-                // date
-                "d" -> date = LocalDate.parse(reader.nextString())
-                // rate
-                else -> {
-                    val currency = Currency.fromString(nextName.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
-                    reader.beginObject()
-                    reader.skipName() // always "v"
-                    val value = BigDecimal(reader.nextString())
-                    reader.endObject()
-                    currency?.let {
-                        if (it == base)
-                            baseValue = value
-                        else if (it == symbol)
-                            symbolValue = value
-                    }
-                }
+            val nextName = reader.nextName()
+            if (nextName == "d") {
+                date = LocalDate.parse(reader.nextString())
+            } else {
+                val (currency, value) = readCurrencyValue(reader, nextName)
+                if (currency == base) baseValue = value
+                else if (currency == symbol) symbolValue = value
             }
             if (date != null && baseValue != null && symbolValue != null) {
                 reader.endObject()
@@ -106,6 +95,15 @@ internal class BankOfCanadaTimelineAdapter(
             }
         }
         return null
+    }
+
+    private fun readCurrencyValue(reader: JsonReader, name: String): Pair<Currency?, BigDecimal> {
+        val currency = Currency.fromString(name.substring(CURRENCY_CODE_START, CURRENCY_CODE_END))
+        reader.beginObject()
+        reader.skipName() // always "v"
+        val value = BigDecimal(reader.nextString())
+        reader.endObject()
+        return currency to value
     }
 
     @Synchronized

--- a/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
@@ -96,53 +96,39 @@ fun String.toHumanReadableNumber(
     suffix: String? = null,
     trim: Boolean = false
 ): String {
-    val sb = StringBuilder()
-
-    // + sign
-    if (showPositiveSign
-        && DecimalFormat.getInstance().parse(this) != null
-        && DecimalFormat.getInstance().parse(this)!!.toDouble() >= 0.0
-    )
-        sb.append("+ ")
-
-    // format number
-    sb.append(this
-        // round, if wished; also converts scientific to natural (123456789.123456789 instead of 1.23456789123456789E8)
-        .let {
-            if (decimalPlaces != null)
-                it.toBigDecimal()
-                    // round with bankers' rounding
-                    .setScale(decimalPlaces, RoundingMode.HALF_EVEN)
-                    // convert back to string
-                    .toPlainString()
-            else
-                it
-        }
-        // remove trailing .0000
-        .let {
-            if (trim)
-                it.replace("(?!^)\\.?0+$".toRegex(), "")
-            else
-                it
-        }
-        // group number blocks
-        .let {
-            if (it.contains('.')) {
-                val split = it.split('.')
-                split[0].groupNumbers(context) + getDecimalSeparator(context) + split[1]
-            } else {
-                it.groupNumbers(context)
-            }
-        }
-        // add space to negative sign
+    val formatted = this
+        .let { roundIfNeeded(it, decimalPlaces) }
+        .let { if (trim) trimTrailingZeros(it) else it }
+        .let { applyGrouping(it, context) }
         .replace("-", "- ")
-    )
+    return buildString {
+        if (showPositiveSign && isNonNegative(this@toHumanReadableNumber))
+            append("+ ")
+        append(formatted)
+        if (suffix != null) append(" $suffix")
+    }
+}
 
-    // suffix
-    if (suffix != null)
-        sb.append(" $suffix")
+private fun roundIfNeeded(value: String, decimalPlaces: Int?): String {
+    if (decimalPlaces == null) return value
+    // also converts scientific to natural (123456789.123 instead of 1.23456789E8)
+    return value.toBigDecimal()
+        .setScale(decimalPlaces, RoundingMode.HALF_EVEN)
+        .toPlainString()
+}
 
-    return sb.toString()
+private fun trimTrailingZeros(value: String): String =
+    value.replace("(?!^)\\.?0+$".toRegex(), "")
+
+private fun applyGrouping(value: String, context: Context): String {
+    if (!value.contains('.')) return value.groupNumbers(context)
+    val (intPart, fracPart) = value.split('.', limit = 2).let { it[0] to it[1] }
+    return intPart.groupNumbers(context) + getDecimalSeparator(context) + fracPart
+}
+
+private fun isNonNegative(raw: String): Boolean {
+    val parsed = DecimalFormat.getInstance().parse(raw) ?: return false
+    return parsed.toDouble() >= 0.0
 }
 
 private fun String.groupNumbers(context: Context): String {


### PR DESCRIPTION
## Summary
- Extract helpers from `String.toHumanReadableNumber` to reduce cyclomatic complexity (task #19)
- Split BankOfCanada rates/timeline adapters' observation parsing into smaller helpers to reduce nested block depth (task #18)
- `BankRossii.getTimeline` already meets the 60-line limit and its throws already carry messages (task #25 verified)

## Test plan
- [ ] `Build fdroid debug APK` and detekt workflows pass
- [ ] Number formatting unchanged (regression check via app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)