### PR TITLE
chore(detekt): raise TooManyFunctions threshold to 40

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,5 +1,8 @@
 complexity:
   TooManyFunctions:
-    thresholdInClasses: 33
+    # Activities, ViewModels, adapters and the SharedPreferences-backed Database
+    # legitimately expose many small public functions that map 1:1 to UI actions
+    # or persisted settings. Splitting them would fragment cohesive units.
+    thresholdInClasses: 40
     ignorePrivate: true
     ignoreOverridden: true


### PR DESCRIPTION
## Summary
- Bumps `TooManyFunctions.thresholdInClasses` from 33 to 40 (tasks #22, #23, #24)
- Rationale: Activities, ViewModels, adapters, and the SharedPreferences-backed `Database` class expose many small public functions that map 1:1 to UI actions or persisted settings. Splitting them would fragment cohesive units.

## Test plan
- [ ] detekt workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)