### PR TITLE
i18n: add Malayalam support and update translations for decimal accuracy

### DIFF
--- a/app/src/main/res/values-ar/strings_preference.xml
+++ b/app/src/main/res/values-ar/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">لوحة المفاتيح</string>
     <string name="keyboard_option_default">افتراضي</string>
     <string name="keyboard_option_expanded">موسّعة</string>
+    <string name="decimal_places_title">دقة عشرية</string>
+    <string name="decimal_places_summary">عدد المنازل العشرية المعروضة للقيم المحولة.</string>
     <string name="haptic_feedback_title">اهتزاز اللمس</string>
     <string name="haptic_feedback_summary">اهتزاز عند الضغط على مفتاح\nيتبع إعداد النظام</string>
     <string name="category_appearance">المظهر</string>

--- a/app/src/main/res/values-bg/strings_preference.xml
+++ b/app/src/main/res/values-bg/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Клавиатура</string>
     <string name="keyboard_option_default">По подразбиране</string>
     <string name="keyboard_option_expanded">Разширена</string>
+    <string name="decimal_places_title">Десетична точност</string>
+    <string name="decimal_places_summary">Брой десетични знаци, показвани за конвертираните стойности.</string>
     <string name="haptic_feedback_title">Тактилна обратна връзка</string>
     <string name="haptic_feedback_summary">Вибрация при натискане на клавиш\nСледва системната настройка</string>
     <string name="category_appearance">Изглед</string>

--- a/app/src/main/res/values-bn/strings_preference.xml
+++ b/app/src/main/res/values-bn/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">কীবোর্ড</string>
     <string name="keyboard_option_default">ডিফল্ট</string>
     <string name="keyboard_option_expanded">প্রসারিত</string>
+    <string name="decimal_places_title">দশমিক নির্ভুলতা</string>
+    <string name="decimal_places_summary">রূপান্তরিত মানের জন্য প্রদর্শিত দশমিক স্থানের সংখ্যা।</string>
     <string name="haptic_feedback_title">হ্যাপটিক ফিডব্যাক</string>
     <string name="haptic_feedback_summary">কী চাপলে কম্পন\nসিস্টেম সেটিং অনুসরণ করে</string>
     <string name="category_appearance">অবয়ব</string>

--- a/app/src/main/res/values-ca/strings_preference.xml
+++ b/app/src/main/res/values-ca/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Teclat</string>
     <string name="keyboard_option_default">Per defecte</string>
     <string name="keyboard_option_expanded">Expandit</string>
+    <string name="decimal_places_title">Precisió decimal</string>
+    <string name="decimal_places_summary">Nombre de decimals a mostrar per als valors convertits.</string>
     <string name="haptic_feedback_title">Resposta tàctil</string>
     <string name="haptic_feedback_summary">Vibra en prémer una tecla\nSegueix la configuració del sistema</string>
     <string name="category_appearance">Aparença</string>

--- a/app/src/main/res/values-cs/strings_preference.xml
+++ b/app/src/main/res/values-cs/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Klávesnice</string>
     <string name="keyboard_option_default">Výchozí</string>
     <string name="keyboard_option_expanded">Rozšířená</string>
+    <string name="decimal_places_title">Desetinná přesnost</string>
+    <string name="decimal_places_summary">Počet desetinných míst zobrazených u převedených hodnot.</string>
     <string name="haptic_feedback_title">Haptická odezva</string>
     <string name="haptic_feedback_summary">Vibrace při stisknutí klávesy\nŘídí se systémovým nastavením</string>
     <string name="category_appearance">Vzhled</string>

--- a/app/src/main/res/values-da/strings_preference.xml
+++ b/app/src/main/res/values-da/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tastatur</string>
     <string name="keyboard_option_default">Standard</string>
     <string name="keyboard_option_expanded">Udvidet</string>
+    <string name="decimal_places_title">Decimalnøjagtighed</string>
+    <string name="decimal_places_summary">Antal decimaler, der vises for konverterede værdier.</string>
     <string name="haptic_feedback_title">Haptisk feedback</string>
     <string name="haptic_feedback_summary">Vibrer ved tastetryk\nFølger systemindstillingen</string>
     <string name="category_appearance">Udseende</string>

--- a/app/src/main/res/values-de/strings_preference.xml
+++ b/app/src/main/res/values-de/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tastatur</string>
     <string name="keyboard_option_default">Standard</string>
     <string name="keyboard_option_expanded">Erweitert</string>
+    <string name="decimal_places_title">Dezimalgenauigkeit</string>
+    <string name="decimal_places_summary">Anzahl der Nachkommastellen bei umgerechneten Werten.</string>
     <string name="haptic_feedback_title">Haptisches Feedback</string>
     <string name="haptic_feedback_summary">Vibration bei Tastendruck\nRichtet sich nach der Systemeinstellung</string>
     <string name="category_appearance">Aussehen</string>

--- a/app/src/main/res/values-el/strings_preference.xml
+++ b/app/src/main/res/values-el/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Πληκτρολόγιο</string>
     <string name="keyboard_option_default">Προεπιλογή</string>
     <string name="keyboard_option_expanded">Αναπτυγμένο</string>
+    <string name="decimal_places_title">Δεκαδική ακρίβεια</string>
+    <string name="decimal_places_summary">Αριθμός δεκαδικών ψηφίων που εμφανίζονται για τις μετατραπείσες τιμές.</string>
     <string name="haptic_feedback_title">Απτική ανάδραση</string>
     <string name="haptic_feedback_summary">Δόνηση κατά το πάτημα πλήκτρου\nΑκολουθεί τη ρύθμιση συστήματος</string>
     <string name="category_appearance">Εμφάνιση</string>

--- a/app/src/main/res/values-eo/strings_preference.xml
+++ b/app/src/main/res/values-eo/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Klavaro</string>
     <string name="keyboard_option_default">Implicita</string>
     <string name="keyboard_option_expanded">Etendita</string>
+    <string name="decimal_places_title">Decimala precizeco</string>
+    <string name="decimal_places_summary">Nombro de decimalaj lokoj montrataj por konvertitaj valoroj.</string>
     <string name="haptic_feedback_title">Hapta reago</string>
     <string name="haptic_feedback_summary">Vibru ĉe klav-premo\nSekvas sisteman agordon</string>
     <string name="category_appearance">Aspekto</string>

--- a/app/src/main/res/values-es/strings_preference.xml
+++ b/app/src/main/res/values-es/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Teclado</string>
     <string name="keyboard_option_default">Predeterminado</string>
     <string name="keyboard_option_expanded">Expandido</string>
+    <string name="decimal_places_title">Precisión decimal</string>
+    <string name="decimal_places_summary">Número de decimales a mostrar en los valores convertidos.</string>
     <string name="haptic_feedback_title">Vibración táctil</string>
     <string name="haptic_feedback_summary">Vibrar al pulsar una tecla\nSigue la configuración del sistema</string>
     <string name="category_appearance">Apariencia</string>

--- a/app/src/main/res/values-et/strings_preference.xml
+++ b/app/src/main/res/values-et/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Klaviatuur</string>
     <string name="keyboard_option_default">Vaikimisi</string>
     <string name="keyboard_option_expanded">Laiendatud</string>
+    <string name="decimal_places_title">Kümnendtäpsus</string>
+    <string name="decimal_places_summary">Kuvatavate kümnendkohtade arv teisendatud väärtustel.</string>
     <string name="haptic_feedback_title">Haptiline tagasiside</string>
     <string name="haptic_feedback_summary">Vibratsioon klahvivajutuse korral\nJärgib süsteemi seadet</string>
     <string name="category_appearance">Välimus</string>

--- a/app/src/main/res/values-fa/strings_preference.xml
+++ b/app/src/main/res/values-fa/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">صفحه‌کلید</string>
     <string name="keyboard_option_default">پیش‌فرض</string>
     <string name="keyboard_option_expanded">گسترده</string>
+    <string name="decimal_places_title">دقت اعشار</string>
+    <string name="decimal_places_summary">تعداد ارقام اعشاری نمایش‌داده‌شده برای مقادیر تبدیل‌شده.</string>
     <string name="haptic_feedback_title">بازخورد لمسی</string>
     <string name="haptic_feedback_summary">لرزش هنگام فشردن کلید\nبر اساس تنظیمات سیستم</string>
     <string name="category_appearance">ظاهر</string>

--- a/app/src/main/res/values-fr/strings_preference.xml
+++ b/app/src/main/res/values-fr/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Clavier</string>
     <string name="keyboard_option_default">Par défaut</string>
     <string name="keyboard_option_expanded">Étendu</string>
+    <string name="decimal_places_title">Précision décimale</string>
+    <string name="decimal_places_summary">Nombre de décimales à afficher pour les valeurs converties.</string>
     <string name="haptic_feedback_title">Retour haptique</string>
     <string name="haptic_feedback_summary">Vibrer à chaque touche\nSuit le réglage système</string>
     <string name="category_appearance">Apparition</string>

--- a/app/src/main/res/values-hr/strings_preference.xml
+++ b/app/src/main/res/values-hr/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tipkovnica</string>
     <string name="keyboard_option_default">Zadano</string>
     <string name="keyboard_option_expanded">Proširena</string>
+    <string name="decimal_places_title">Decimalna preciznost</string>
+    <string name="decimal_places_summary">Broj decimala prikazanih za pretvorene vrijednosti.</string>
     <string name="haptic_feedback_title">Haptička povratna informacija</string>
     <string name="haptic_feedback_summary">Vibracija pri pritisku tipke\nPrati postavku sustava</string>
     <string name="category_appearance">Izgled</string>

--- a/app/src/main/res/values-hu/strings_preference.xml
+++ b/app/src/main/res/values-hu/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Billentyűzet</string>
     <string name="keyboard_option_default">Alapértelmezett</string>
     <string name="keyboard_option_expanded">Kibővített</string>
+    <string name="decimal_places_title">Tizedes pontosság</string>
+    <string name="decimal_places_summary">A megjelenített tizedesjegyek száma az átváltott értékeknél.</string>
     <string name="haptic_feedback_title">Haptikus visszajelzés</string>
     <string name="haptic_feedback_summary">Rezgés billentyűnyomáskor\nA rendszerbeállítást követi</string>
     <string name="category_appearance">Megjelenítés</string>

--- a/app/src/main/res/values-in/strings_preference.xml
+++ b/app/src/main/res/values-in/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Keyboard</string>
     <string name="keyboard_option_default">Bawaan</string>
     <string name="keyboard_option_expanded">Diperluas</string>
+    <string name="decimal_places_title">Akurasi desimal</string>
+    <string name="decimal_places_summary">Jumlah tempat desimal yang ditampilkan untuk nilai yang dikonversi.</string>
     <string name="haptic_feedback_title">Umpan balik haptic</string>
     <string name="haptic_feedback_summary">Getar saat tombol ditekan\nMengikuti pengaturan sistem</string>
     <string name="category_appearance">Tampilan</string>

--- a/app/src/main/res/values-is/strings_preference.xml
+++ b/app/src/main/res/values-is/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Lyklaborð</string>
     <string name="keyboard_option_default">Sjálfgefið</string>
     <string name="keyboard_option_expanded">Stækkað</string>
+    <string name="decimal_places_title">Tugabrotanákvæmni</string>
+    <string name="decimal_places_summary">Fjöldi aukastafa sem birtast fyrir umbreytt gildi.</string>
     <string name="haptic_feedback_title">Haptísk endurgjöf</string>
     <string name="haptic_feedback_summary">Titra við lyklakipp\nFylgir kerfisstillingu</string>
     <string name="category_appearance">Útlit</string>

--- a/app/src/main/res/values-it/strings_preference.xml
+++ b/app/src/main/res/values-it/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tastiera</string>
     <string name="keyboard_option_default">Predefinito</string>
     <string name="keyboard_option_expanded">Espansa</string>
+    <string name="decimal_places_title">Precisione decimale</string>
+    <string name="decimal_places_summary">Numero di decimali da mostrare per i valori convertiti.</string>
     <string name="haptic_feedback_title">Feedback tattile</string>
     <string name="haptic_feedback_summary">Vibrazione alla pressione del tasto\nSegue le impostazioni di sistema</string>
     <string name="category_appearance">Aspetto</string>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">מקלדת</string>
     <string name="keyboard_option_default">ברירת מחדל</string>
     <string name="keyboard_option_expanded">מורחבת</string>
+    <string name="decimal_places_title">דיוק עשרוני</string>
+    <string name="decimal_places_summary">מספר הספרות שאחרי הנקודה שיוצגו עבור ערכים מומרים.</string>
     <string name="haptic_feedback_title">רטט מגע</string>
     <string name="haptic_feedback_summary">רטט בלחיצה על מקש\nבהתאם להגדרות המערכת</string>
     <string name="category_appearance">מראה</string>

--- a/app/src/main/res/values-ml/locale.xml
+++ b/app/src/main/res/values-ml/locale.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <string name="locale_language">ml</string>
+    <string name="locale_country" />
+</resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="desc_toggle_currencies">കറൻസികൾ മാറ്റുക</string>
+    <string name="info_conversion">%1$s %2$s ≈ %3$s %4$s</string>
+    <string name="info_date_latest">&lt;b>%1$s&lt;/b>-ലെ നിരക്കുകൾ, &lt;b>%2$s&lt;/b> നൽകിയത്</string>
+    <string name="info_date_historical">&lt;b>%1$s&lt;/b>-ന്റെ ചരിത്ര നിരക്കുകൾ, &lt;b>%2$s&lt;/b> നൽകിയത്</string>
+    <string name="copied_to_clipboard">&lt;b>%s&lt;/b> ക്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി</string>
+
+    <string name="historical_rates_dialog_title">ചരിത്ര നിരക്കുകൾ</string>
+    <string name="historical_rates_dialog_toggle">ഒരു നിർദ്ദിഷ്ട തീയതിയിലെ വിനിമയ നിരക്കുകൾ ഉപയോഗിക്കുക. എപ്പോഴും ഏറ്റവും പുതിയവ എടുക്കാൻ പ്രവർത്തനരഹിതമാക്കുക.</string>
+
+    <string name="error">പിശക്: %s</string>
+    <string name="error_generic">അജ്ഞാത പ്രശ്നം.</string>
+    <string name="error_http">സെർവർ HTTP %d ഉപയോഗിച്ച് പ്രതികരിച്ചു.</string>
+    <string name="error_timeout">സെർവർ സമയബന്ധിതമായി പ്രതികരിച്ചില്ല അല്ലെങ്കിൽ എത്തിച്ചേരാനാവുന്നില്ല.</string>
+    <string name="error_no_data">സെർവറിലേക്ക് കണക്റ്റുചെയ്യാൻ കഴിഞ്ഞില്ല.</string>
+    <string name="error_empty_response">ഈ അഭ്യർത്ഥനയ്ക്ക് സെർവറിൽ ഡാറ്റയില്ല.</string>
+    <string name="error_api_error">ഒരു API പിശക് സംഭവിച്ചു. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</string>
+    <string name="error_try_another_api">എന്നിരുന്നാലും, ക്രമീകരണങ്ങളിൽ നിന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാവുന്ന മറ്റ് ഡാറ്റ ദാതാക്കളുണ്ട്. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!</string>
+    <string name="error_no_api_key">ഈ ഉറവിടം ഉപയോഗിക്കാൻ, ഒരു സാധുവായ API കീ സജ്ജീകരിക്കണം.</string>
+    <string name="error_invalid_api_key">HTTP 401 – ദയവായി നിങ്ങളുടെ API കീ പരിശോധിക്കുക.</string>
+    <string name="error_unsupported_timeline">ഈ API-യിൽ ടൈംലൈൻ ഡാറ്റ പിന്തുണയ്ക്കുന്നില്ല.</string>
+
+    <string name="menu_settings">ക്രമീകരണങ്ങൾ</string>
+    <string name="menu_refresh">നിരക്കുകൾ പുതുക്കുക</string>
+    <string name="menu_timeline">വിനിമയ നിരക്ക് ചാർട്ട്</string>
+
+    <string name="tooltip_filter_starred">നക്ഷത്രമുള്ള കറൻസികൾ മാത്രം കാണിക്കുക.</string>
+    <string name="currency_dropdown_api_hint">എന്തെങ്കിലും കാണാനില്ലേ? വ്യത്യസ്ത ഡാറ്റ ദാതാക്കൾ വ്യത്യസ്ത കറൻസികൾ വാഗ്ദാനം ചെയ്യുന്നു. മറ്റൊന്ന് പരീക്ഷിക്കാൻ ക്രമീകരണങ്ങളിലേക്ക് പോകുക!\u00A0\uD83E\uDD17</string>
+</resources>

--- a/app/src/main/res/values-ml/strings_apis.xml
+++ b/app/src/main/res/values-ml/strings_apis.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="api_bankOfCanada_descriptionFull"><a href="https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates/"><b>ബാങ്ക് ഓഫ് കാനഡ</b></a>-യുടെ ദൈനംദിന ശരാശരി വിനിമയ നിരക്കുകൾ.\n<b>ഏകദേശം 23 കറൻസികൾ ഉൾപ്പെടുന്നു.</b></string>
+    <string name="api_bankOfCanada_descriptionShort">ഏകദേശം 23 വിനിമയ നിരക്കുകൾ\nഉറവിടം: കാനഡയുടെ കേന്ദ്ര ബാങ്ക്</string>
+    <string name="api_bankOfCanada_descriptionUpdateInterval">നിരക്കുകൾ ഓരോ പ്രവൃത്തി ദിനത്തിലും 16:30 ET-ന് പ്രസിദ്ധീകരിക്കുന്നു</string>
+
+    <string name="api_bankRossii_descriptionFull">റഷ്യൻ കേന്ദ്ര ബാങ്ക് <a href="https://cbr.ru/eng/currency_base/daily/"><b>ബാങ്ക് റോസ്സി</b></a> നൽകുന്ന വിനിമയ നിരക്കുകൾ. നിലവിലെ ഉപരോധങ്ങളോടെ, റഷ്യൻ റൂബിളിന് ഏറ്റവും വിശ്വസനീയമായ വിനിമയ നിരക്കുകൾ ഈ ഉറവിടം നൽകാൻ സാധ്യതയുണ്ട്.\n<b>ബാങ്ക് റോസ്സി ഏകദേശം 44 വിനിമയ നിരക്കുകൾ പട്ടികപ്പെടുത്തുന്നു.</b></string>
+    <string name="api_bankRossii_descriptionShort">ഏകദേശം 44 വിനിമയ നിരക്കുകൾ\nഉറവിടം: റഷ്യയുടെ കേന്ദ്ര ബാങ്ക്</string>
+    <string name="api_bankRossii_descriptionUpdateInterval">നിരക്കുകൾ ദിവസേന അപ്ഡേറ്റ് ചെയ്യുന്നു, <a href="https://cbr.ru/eng/other/holidays/">റഷ്യയിലെ പൊതു അവധി ദിവസങ്ങൾ</a> ഒഴികെ.</string>
+
+    <string name="api_exchangerateHost_descriptionFull"><a href="https://exchangerate.host/"><b>Exchangerate.host</b></a> യൂറോപ്യൻ കേന്ദ്ര ബാങ്ക് ഉൾപ്പെടെ വിവിധ സാമ്പത്തിക ഡാറ്റ ദാതാക്കളിൽ നിന്നും ബാങ്കുകളിൽ നിന്നും കറൻസി നിരക്കുകൾ ശേഖരിക്കുന്നു. എല്ലാ വിനിമയ നിരക്ക് ഡാറ്റയും മിഡ്‌പോയിന്റ് ഡാറ്റയായി നൽകപ്പെടുന്നു. Bid, Ask നിരക്കുകളുടെ ശരാശരി മീഡിയൻ കണക്കാക്കി മിഡ്‌പോയിന്റ് നിരക്കുകൾ നിർണയിക്കുന്നു.\n<b>ഏകദേശം 160 കറൻസികൾ ഉൾപ്പെടുന്നു.</b></string>
+    <string name="api_exchangerateHost_descriptionUpdateInterval">വിനിമയ നിരക്കുകൾ ഓരോ പ്രവൃത്തിദിനത്തിലും ഏകദേശം അർദ്ധരാത്രി UTC-ന് അപ്ഡേറ്റ് ചെയ്യുന്നു.</string>
+
+    <string name="api_ferEe_descriptionFull"><a href="https://fer.ee/"><b>Fer.ee</b></a> താരതമ്യേന പുതിയ ഒരു സേവനമാണ്, ഇത് (Frankfurter.app പോലെ) യൂറോപ്യൻ കേന്ദ്ര ബാങ്ക് പ്രസിദ്ധീകരിക്കുന്ന റഫറൻസ് വിനിമയ (forex) നിരക്കുകൾ ട്രാക്ക് ചെയ്യുന്നു.\n<b>ഏകദേശം 30 കറൻസികൾ ഉൾപ്പെടുന്നു.</b></string>
+    <string name="api_ferEe_descriptionUpdateInterval">നിരക്കുകൾ ഓരോ പ്രവൃത്തി ദിനത്തിലും അപ്ഡേറ്റ് ചെയ്യുന്നു.</string>
+
+    <string name="api_frankfurterApp_descriptionFull"><a href="https://www.frankfurter.app/"><b>Frankfurter.app</b></a> യൂറോപ്യൻ കേന്ദ്ര ബാങ്ക് പ്രസിദ്ധീകരിക്കുന്ന റഫറൻസ് വിനിമയ (forex) നിരക്കുകൾ ട്രാക്ക് ചെയ്യുന്നു.\n<b>ഏകദേശം 30 കറൻസികൾ ഉൾപ്പെടുന്നു.</b></string>
+    <string name="api_frankfurterApp_descriptionShort">ഏകദേശം 30 വിനിമയ നിരക്കുകൾ\nഉറവിടം: യൂറോപ്യൻ കേന്ദ്ര ബാങ്ക്</string>
+    <string name="api_frankfurterApp_descriptionUpdateInterval">ഓരോ പ്രവൃത്തി ദിനത്തിലും ഏകദേശം 16:00 CET-ന് ഡാറ്റ അപ്ഡേറ്റ് ചെയ്യുന്നു.</string>
+
+    <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_en"><b>InforEuro</b></a> യൂറോപ്യൻ കമ്മീഷന്റെ യൂറോയ്ക്കായുള്ള ഔദ്യോഗിക പ്രതിമാസ അക്കൗണ്ടിംഗ് നിരക്കും ധനകാര്യ നിയന്ത്രണത്തിന്റെ ആർട്ടിക്കിൾ 19-ന് അനുസൃതമായി യൂറോപ്യൻ കമ്മീഷന്റെ അക്കൗണ്ടിംഗ് ഓഫീസർ സ്ഥാപിച്ച പരിവർത്തന നിരക്കുകളും നൽകുന്നു.\nയൂറോപ്യൻ കമ്മീഷന്റെ അഭ്യർത്ഥന പ്രകാരം മീറ്റിംഗുകൾ, അഭിമുഖങ്ങൾ തുടങ്ങിയവയിൽ പങ്കെടുക്കുന്ന ബാഹ്യ ജനങ്ങൾക്ക് ചെലവുകൾ, യാത്ര അല്ലെങ്കിൽ ജീവനാംശ ചെലവുകൾ എന്നിവയുടെ റീഇംബേഴ്‌സ്‌മെന്റ് കണക്കാക്കാൻ ഈ നിരക്കുകൾ ഉപയോഗിക്കുന്നു.\n<b>ഏകദേശം 150 കറൻസികൾ ഉൾപ്പെടുന്നു.</b></string>
+    <string name="api_inforEuro_descriptionShort">ഏകദേശം 150 വിനിമയ നിരക്കുകൾ\nഉറവിടം: യൂറോപ്യൻ കമ്മീഷൻ</string>
+    <string name="api_inforEuro_descriptionUpdateInterval">സൂചിപ്പിക്കുന്ന നിരക്കുകൾ, യൂറോപ്യൻ കേന്ദ്ര ബാങ്ക് ഉദ്ധരിച്ചതുപോലെ അല്ലെങ്കിൽ ലഭ്യതയനുസരിച്ച് ആ തീയതിക്ക് അടുത്തുള്ള പ്രതിനിധി സംഘങ്ങളോ മറ്റ് ഉചിതമായ ഉറവിടങ്ങളോ നൽകുന്നതുപോലെ, മുൻ മാസത്തിലെ അവസാനത്തിനു തൊട്ടു മുൻപുള്ള ദിവസത്തെ വിപണി നിരക്കുകളാണ്.</string>
+    <string name="api_inforEuro_hint">നിരക്കുകൾ മാസത്തിലൊരിക്കൽ മാത്രമേ അപ്ഡേറ്റ് ചെയ്യുന്നുള്ളൂ!</string>
+
+    <string name="api_norgesBank_descriptionFull">നോർവീജിയൻ കേന്ദ്ര ബാങ്ക് <a href="https://www.norges-bank.no/en/topics/Statistics/exchange_rates/"><b>നോർജസ് ബാങ്ക്</b></a> നൽകുന്ന വിനിമയ നിരക്കുകൾ.\n<b>നോർജസ് ബാങ്ക് ഏകദേശം 40 വിനിമയ നിരക്കുകൾ പട്ടികപ്പെടുത്തുന്നു.</b></string>
+    <string name="api_norgesBank_descriptionShort">ഏകദേശം 40 വിനിമയ നിരക്കുകൾ\nഉറവിടം: നോർവേയുടെ കേന്ദ്ര ബാങ്ക്</string>
+    <string name="api_norgesBank_descriptionUpdateInterval">ദൈനംദിന വിനിമയ നിരക്കുകളുടെ പ്രസിദ്ധീകരണ സമയം ഏകദേശം 16:00 CET ആണ്.</string>
+    <string name="api_norgesBank_hint">സേവനത്തിന് സ്ഥിരമായി തടസ്സങ്ങളുണ്ട് (HTTP 503), അക്കാലത്ത് നിരക്കുകൾ പുതുക്കാൻ കഴിയില്ല!</string>
+
+    <string name="api_openExchangeRates_descriptionFull">ഒന്നിലധികം വിശ്വസനീയമായ ഉറവിടങ്ങളിൽ നിന്ന് ഡാറ്റ ട്രാക്ക് ചെയ്ത് സംയോജിപ്പിക്കുന്നു, പക്ഷപാതരഹിതമായ നിരക്കുകൾ ഉറപ്പാക്കുന്നു. കൂടുതൽ വിവരങ്ങൾക്ക് <a href="https://openexchangerates.org/"><b>openexchangerates.org</b></a> കാണുക.\n<b>Open Exchange Rates ഏകദേശം 160 വിനിമയ നിരക്കുകൾ നൽകുന്നു.\n<i>ഈ ഉറവിടം ഉപയോഗിക്കാൻ, നിങ്ങളുടെ വ്യക്തിഗത API കീ നൽകണം!</i></b></string>
+    <string name="api_openExchangeRates_descriptionShort">ഏകദേശം 160 വിനിമയ നിരക്കുകൾ\nഉറവിടം: ഒന്നിലധികം വിശ്വസനീയമായ ദാതാക്കളുടെ സംയോജനം.</string>
+    <string name="api_openExchangeRates_descriptionUpdateInterval">മണിക്കൂറിലൊരിക്കൽ അപ്ഡേറ്റുകൾ.</string>
+    <string name="api_openExchangeRates_hint">ഈ ഉറവിടം ഉപയോഗിക്കാൻ, നിങ്ങളുടെ വ്യക്തിഗത API കീ സൃഷ്ടിക്കണം!</string>
+</resources>

--- a/app/src/main/res/values-ml/strings_preference.xml
+++ b/app/src/main/res/values-ml/strings_preference.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE resources [<!ENTITY nbsp "&#160;">]>
+<resources>
+    <!-- main settings -->
+    <string name="category_settings">പൊതു ക്രമീകരണങ്ങൾ</string>
+    <string name="fee_title">വിദേശ ഇടപാട് ഫീസ്</string>
+    <string name="fee_summary">നിങ്ങളുടെ ക്രെഡിറ്റ് കാർഡ് കരാർ അനുസരിച്ച്, നിങ്ങളുടെ ബാങ്ക് എല്ലാ വിദേശ വിനിമയ ഇടപാടുകൾക്കും ഒരു ഫീസ് ഈടാക്കിയേക്കാം. ഇവിടെ നിങ്ങൾക്ക് ആ ഫീസ് നൽകാം. അത് കണക്കുകൂട്ടലിനു മുകളിൽ ചേർക്കപ്പെടും, അതിനാൽ നിങ്ങൾ <i>യഥാർത്ഥത്തിൽ</i> എത്ര നൽകുന്നുവെന്ന് നിങ്ങൾക്കറിയാം.</string>
+    <string name="previewConversion_title">പരിവർത്തന പ്രിവ്യൂ</string>
+    <string name="previewConversion_summary">കറൻസി പിക്കറിൽ ഓരോ നിരക്കിന്റെയും നിലവിലെ പരിവർത്തനം കാണിക്കുക.</string>
+    <string name="keyboard_title">കീബോർഡ്</string>
+    <string name="keyboard_option_default">സ്ഥിരസ്ഥിതി</string>
+    <string name="keyboard_option_expanded">വിപുലീകൃതം</string>
+    <string name="decimal_places_title">ദശാംശ കൃത്യത</string>
+    <string name="decimal_places_summary">പരിവർത്തനം ചെയ്ത മൂല്യങ്ങൾക്ക് കാണിക്കേണ്ട ദശാംശ സ്ഥാനങ്ങളുടെ എണ്ണം.</string>
+    <string name="haptic_feedback_title">ഹാപ്റ്റിക് ഫീഡ്‌ബാക്ക്</string>
+    <string name="haptic_feedback_summary">കീ അമർത്തുമ്പോൾ വൈബ്രേറ്റ് ചെയ്യുക\nസിസ്റ്റം ക്രമീകരണം പിന്തുടരുന്നു</string>
+    <string name="category_appearance">ദൃശ്യരൂപം</string>
+    <string name="system_default">സിസ്റ്റം സ്ഥിരസ്ഥിതി</string>
+    <string name="theme_title">രൂപകൽപ്പന</string>
+    <string name="theme_option_light">ലൈറ്റ്</string>
+    <string name="theme_option_dark">ഡാർക്ക്</string>
+    <string name="pure_black_enabled_title">OLED കറുപ്പ്</string>
+    <string name="pure_black_enabled_summary">ഡാർക്ക് മോഡിൽ പൂർണ കറുപ്പ് ഉപയോഗിക്കുക</string>
+    <!-- languages -->
+    <string name="language_title">ആപ്പ് ഭാഷ</string>
+    <string name="language_ar">അറബിക്</string>
+    <string name="language_bg">ബൾഗേറിയൻ</string>
+    <string name="language_bn">ബംഗാളി</string>
+    <string name="language_ca">കാറ്റലൻ</string>
+    <string name="language_cs">ചെക്</string>
+    <string name="language_da">ഡാനിഷ്</string>
+    <string name="language_de">ജർമ്മൻ</string>
+    <string name="language_el">ഗ്രീക്ക്</string>
+    <string name="language_en">ഇംഗ്ലീഷ്</string>
+    <string name="language_en_GB">ഇംഗ്ലീഷ് (യുണൈറ്റഡ് കിംഗ്ഡം)</string>
+    <string name="language_eo">എസ്‌പെറാന്റോ</string>
+    <string name="language_es">സ്പാനിഷ്</string>
+    <string name="language_et">എസ്റ്റോണിയൻ</string>
+    <string name="language_fa">പേർഷ്യൻ</string>
+    <string name="language_fr">ഫ്രഞ്ച്</string>
+    <string name="language_hr">ക്രൊയേഷ്യൻ</string>
+    <string name="language_hu">ഹംഗേറിയൻ</string>
+    <string name="language_in">ഇന്തോനേഷ്യൻ</string>
+    <string name="language_is">ഐസ്‌ലാൻഡിക്</string>
+    <string name="language_it">ഇറ്റാലിയൻ</string>
+    <string name="language_iw">ഹീബ്രു</string>
+    <string name="language_nb">നോർവീജിയൻ</string>
+    <string name="language_nl">ഡച്ച്</string>
+    <string name="language_pl">പോളിഷ്</string>
+    <string name="language_pt_BR">പോർച്ചുഗീസ് (ബ്രസീൽ)</string>
+    <string name="language_ru">റഷ്യൻ</string>
+    <string name="language_sv">സ്വീഡിഷ്</string>
+    <string name="language_tr">ടർക്കിഷ്</string>
+    <string name="language_uk">ഉക്രേനിയൻ</string>
+    <string name="language_vi">വിയറ്റ്നാമീസ്</string>
+    <string name="language_zh_CN">ചൈനീസ് (ലളിതം)</string>
+    <string name="language_zh_TW">ചൈനീസ് (പരമ്പരാഗതം)</string>
+    <!-- api -->
+    <string name="category_api">വിനിമയ നിരക്കുകൾ</string>
+    <string name="api_title">ഡാറ്റ ദാതാവ്</string>
+    <string name="api_open_exchangerates_api_key_title">Open Exchangerates API കീ</string>
+    <string name="api_open_exchangerates_api_key_message">ഈ ഉറവിടം ഉപയോഗിക്കാൻ, നിങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത API കീ സൃഷ്ടിക്കണം.\n\nഅതിനായി, https://openexchangerates.org/signup/free-ലേക്ക് പോയി ഒരു സൗജന്യ അക്കൗണ്ട് സൃഷ്ടിക്കുക.\nഅവസാനം, നിങ്ങളുടെ ഡാഷ്‌ബോർഡിനുള്ളിൽ ഒരു പുതിയ App ID സൃഷ്ടിച്ച് ഇവിടെ നൽകുക:</string>
+    <string name="api_open_exchangerates_api_key_missing"><i>API കീ ആവശ്യമാണ്</i></string>
+    <string name="api_about_title">%s കുറിച്ച്</string>
+    <string name="api_refreshPeriod_title">പുതുക്കൽ കാലയളവ്</string>
+    <!-- about -->
+    <string name="category_about">ഈ ആപ്പിനെക്കുറിച്ച്</string>
+    <string name="disclaimer_title">നിരാകരണം</string>
+    <string name="disclaimer_summary">ഈ ആപ്പ് വളരെ സൂക്ഷ്മമായി എഴുതി പരീക്ഷിച്ചിട്ടുണ്ടെങ്കിലും, <b>അത് കാണിക്കുന്ന ഡാറ്റ ശരിയാണെന്ന് ഒരു ഉറപ്പുമില്ല</b>. വിനിമയ നിരക്കുകൾ ഒരു മൂന്നാം കക്ഷിയാൽ നൽകപ്പെടുന്നു, ഈ ആപ്പിന് ഡാറ്റ ശരിയാണെന്നും കാലാനുസൃതമാണെന്നും ഉറപ്പു നൽകാൻ കഴിയില്ല.\nകൂടാതെ, നൽകിയ നിരക്കുകൾ - ശരിയാണെങ്കിലും - നിങ്ങളുടെ ബാങ്ക് ഉപയോഗിക്കുന്നവയിൽ നിന്ന് വ്യത്യാസപ്പെട്ടേക്കാം.\nഅവസാനമായി: തെറ്റുകൾ സംഭവിക്കാം. ആരെയും അന്ധമായി വിശ്വസിക്കരുത്! എന്നിരുന്നാലും, ഈ ആപ്പ് ഉദ്ദേശിച്ചതുപോലെ പ്രവർത്തിക്കുന്നു എന്ന് സംശയമുണ്ടെങ്കിൽ ഞാൻ ഇത് പുറത്തിറക്കുമായിരുന്നില്ല.</string>
+    <string name="sourcecode_title">സോഴ്‌സ് കോഡ്</string>
+    <string name="sourcecode_summary">ഈ ആപ്പ് ഓപ്പൺ സോഴ്‌സ് ആണ്. ഇഷ്യൂകൾ തുറക്കാനും, സംഭാവന ചെയ്യുന്നതെങ്ങനെയെന്നറിയാനും, അല്ലെങ്കിൽ സോഴ്‌സുകൾ ഒന്നു കാണാനുമായി കോഡ് റെപ്പോസിറ്ററിയിലേക്ക് പോകുക.</string>
+    <string name="donate_title">ഡെവലപ്പറെ പിന്തുണയ്ക്കുക</string>
+    <string name="donate_summary">PayPal വഴി സംഭാവന ചെയ്യുക</string>
+    <string name="rate_title">ഈ ആപ്പ് റേറ്റ് ചെയ്യുക</string>
+    <string name="rate_summary">നിങ്ങൾക്ക് താൽപ്പര്യമുണ്ടെങ്കിൽ, മറ്റുള്ളവർക്ക് Currencies കണ്ടെത്താൻ നിങ്ങൾക്ക് സഹായിക്കാം. Google Play-യിൽ ആപ്പ് റേറ്റ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക.</string>
+    <string name="category_versioninfo">പതിപ്പ് വിവരം</string>
+    <string name="title_changelog">മാറ്റങ്ങളുടെ ചരിത്രം</string>
+</resources>

--- a/app/src/main/res/values-ml/strings_timeline.xml
+++ b/app/src/main/res/values-ml/strings_timeline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="activity_timeline_title">&lt;b>%1$s&lt;/b> മുതൽ &lt;b>%2$s&lt;/b> വരെ</string>
+    <string name="data_provider">&lt;b>%s&lt;/b> നൽകുന്ന ഡാറ്റ</string>
+
+    <string name="rate_average">ശരാശരി</string>
+    <string name="rate_min">കുറഞ്ഞത്</string>
+    <string name="rate_max">കൂടിയത്</string>
+
+    <string name="year">വർഷം</string>
+    <string name="month">മാസം</string>
+    <string name="week">ആഴ്ച</string>
+</resources>

--- a/app/src/main/res/values-nb/strings_preference.xml
+++ b/app/src/main/res/values-nb/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tastatur</string>
     <string name="keyboard_option_default">Standard</string>
     <string name="keyboard_option_expanded">Utvidet</string>
+    <string name="decimal_places_title">Desimalpresisjon</string>
+    <string name="decimal_places_summary">Antall desimaler som vises for konverterte verdier.</string>
     <string name="haptic_feedback_title">Haptisk tilbakemelding</string>
     <string name="haptic_feedback_summary">Vibrer ved tastetrykk\nFølger systeminnstillingen</string>
     <string name="category_appearance">Utseende</string>

--- a/app/src/main/res/values-nl/strings_preference.xml
+++ b/app/src/main/res/values-nl/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Toetsenbord</string>
     <string name="keyboard_option_default">Standaard</string>
     <string name="keyboard_option_expanded">Uitgebreid</string>
+    <string name="decimal_places_title">Decimale nauwkeurigheid</string>
+    <string name="decimal_places_summary">Aantal decimalen dat wordt getoond bij geconverteerde waarden.</string>
     <string name="haptic_feedback_title">Haptische feedback</string>
     <string name="haptic_feedback_summary">Trilling bij toetsaanslag\nVolgt systeeminstelling</string>
     <string name="category_appearance">Uiterlijk</string>

--- a/app/src/main/res/values-pl/strings_preference.xml
+++ b/app/src/main/res/values-pl/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Klawiatura</string>
     <string name="keyboard_option_default">Domyślna</string>
     <string name="keyboard_option_expanded">Rozszerzona</string>
+    <string name="decimal_places_title">Dokładność dziesiętna</string>
+    <string name="decimal_places_summary">Liczba miejsc dziesiętnych wyświetlanych dla przeliczonych wartości.</string>
     <string name="haptic_feedback_title">Wibracje dotykowe</string>
     <string name="haptic_feedback_summary">Wibracja przy naciśnięciu klawisza\nZgodnie z ustawieniami systemu</string>
     <string name="category_appearance">Ekran</string>

--- a/app/src/main/res/values-pt-rBR/strings_preference.xml
+++ b/app/src/main/res/values-pt-rBR/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Teclado</string>
     <string name="keyboard_option_default">Padrão</string>
     <string name="keyboard_option_expanded">Expandido</string>
+    <string name="decimal_places_title">Precisão decimal</string>
+    <string name="decimal_places_summary">Número de casas decimais mostradas para os valores convertidos.</string>
     <string name="haptic_feedback_title">Feedback tátil</string>
     <string name="haptic_feedback_summary">Vibrar ao pressionar tecla\nSegue configuração do sistema</string>
     <string name="category_appearance">Aparência</string>

--- a/app/src/main/res/values-ru/strings_preference.xml
+++ b/app/src/main/res/values-ru/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Клавиатура</string>
     <string name="keyboard_option_default">По умолчанию</string>
     <string name="keyboard_option_expanded">Расширенная</string>
+    <string name="decimal_places_title">Точность десятичных</string>
+    <string name="decimal_places_summary">Количество десятичных знаков, отображаемых для конвертированных значений.</string>
     <string name="haptic_feedback_title">Тактильный отклик</string>
     <string name="haptic_feedback_summary">Вибрация при нажатии клавиши\nСледует системной настройке</string>
     <string name="category_appearance">Внешний вид</string>

--- a/app/src/main/res/values-sv/strings_preference.xml
+++ b/app/src/main/res/values-sv/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Tangentbord</string>
     <string name="keyboard_option_default">Standard</string>
     <string name="keyboard_option_expanded">Ut��kad</string>
+    <string name="decimal_places_title">Decimalnoggrannhet</string>
+    <string name="decimal_places_summary">Antal decimaler som visas för konverterade värden.</string>
     <string name="haptic_feedback_title">Haptisk återkoppling</string>
     <string name="haptic_feedback_summary">Vibrera vid knapptryckning\nFöljer systeminställning</string>
     <string name="category_appearance">Utseende</string>

--- a/app/src/main/res/values-tr/strings_preference.xml
+++ b/app/src/main/res/values-tr/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Klavye</string>
     <string name="keyboard_option_default">Varsayılan</string>
     <string name="keyboard_option_expanded">Genişletilmiş</string>
+    <string name="decimal_places_title">Ondalık doğruluk</string>
+    <string name="decimal_places_summary">Dönüştürülmüş değerler için gösterilecek ondalık basamak sayısı.</string>
     <string name="haptic_feedback_title">Dokunsal geri bildirim</string>
     <string name="haptic_feedback_summary">Tuşa basıldığında titreşim\nSistem ayarını takip eder</string>
     <string name="category_appearance">Görünüm</string>

--- a/app/src/main/res/values-uk/strings_preference.xml
+++ b/app/src/main/res/values-uk/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Клавіатура</string>
     <string name="keyboard_option_default">За замовчуванням</string>
     <string name="keyboard_option_expanded">Розширена</string>
+    <string name="decimal_places_title">Десяткова точність</string>
+    <string name="decimal_places_summary">Кількість десяткових знаків, що показуються для конвертованих значень.</string>
     <string name="haptic_feedback_title">Тактильний відгук</string>
     <string name="haptic_feedback_summary">Вібрація при натисканні клавіші\nВідповідає системному налаштуванню</string>
     <string name="category_appearance">Зовнішній вигляд</string>

--- a/app/src/main/res/values-vi/strings_preference.xml
+++ b/app/src/main/res/values-vi/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">Bàn phím</string>
     <string name="keyboard_option_default">Mặc định</string>
     <string name="keyboard_option_expanded">M��� rộng</string>
+    <string name="decimal_places_title">Độ chính xác thập phân</string>
+    <string name="decimal_places_summary">Số chữ số thập phân hiển thị cho các giá trị đã chuyển đổi.</string>
     <string name="haptic_feedback_title">Phản hồi xúc giác</string>
     <string name="haptic_feedback_summary">Rung khi nhấn phím\nTheo cài đặt hệ th���ng</string>
     <string name="category_appearance">Ngoại hình</string>

--- a/app/src/main/res/values-zh-rCN/strings_preference.xml
+++ b/app/src/main/res/values-zh-rCN/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">键盘</string>
     <string name="keyboard_option_default">默认</string>
     <string name="keyboard_option_expanded">扩展</string>
+    <string name="decimal_places_title">小数精度</string>
+    <string name="decimal_places_summary">转换值显示的小数位数。</string>
     <string name="haptic_feedback_title">触感反馈</string>
     <string name="haptic_feedback_summary">按键时振动\n跟随系统设置</string>
     <string name="category_appearance">外观</string>

--- a/app/src/main/res/values-zh-rTW/strings_preference.xml
+++ b/app/src/main/res/values-zh-rTW/strings_preference.xml
@@ -10,6 +10,8 @@
     <string name="keyboard_title">���盤</string>
     <string name="keyboard_option_default">預設</string>
     <string name="keyboard_option_expanded">擴展</string>
+    <string name="decimal_places_title">小數精度</string>
+    <string name="decimal_places_summary">轉換數值顯示的小數位數。</string>
     <string name="haptic_feedback_title">觸覺回饋</string>
     <string name="haptic_feedback_summary">按鍵時震動\n跟隨系統設定</string>
     <string name="category_appearance">應用程式外觀</string>


### PR DESCRIPTION
## Summary
- Add Malayalam (ml) localization covering all user-facing runtime strings: `locale.xml`, `strings.xml`, `strings_preference.xml`, `strings_apis.xml`, `strings_timeline.xml`. Previously ml had only `strings_currencies.xml`, so preferences, errors, timeline, and API descriptions all fell back to English.
- Update 30 existing locales with translations for the two new decimal-accuracy preference strings (`decimal_places_title`, `decimal_places_summary`).

Note: the two `decimal_places_*` translations reference source strings introduced by the decimal-accuracy feature branch. Merge this after that feature lands, or resolve the missing base string with a placeholder first.

`changelog.xml` intentionally omitted for ml (historical release notes).

## Test plan
- [ ] Build succeeds once base string `decimal_places_title` exists in `values/`.
- [ ] Switch app language to Malayalam and visually verify settings, error dialogs, timeline labels, and API provider descriptions render in Malayalam.
- [ ] Sanity-check the two new strings in a couple of RTL and CJK locales (ar, iw, zh-rCN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)