### PR TITLE
feat: add decimal accuracy setting (0–6, default 2)

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -181,6 +181,7 @@ class Database(context: Context) {
     private val keyPreviewConversionEnabled = "_previewConversionEnabled"
     private val keyKeyboardType = "_keyboardType"
     private val keyHapticFeedback = "_hapticFeedback"
+    private val keyDecimalPlaces = "_decimalPlaces"
 
     /* api */
 
@@ -306,6 +307,19 @@ class Database(context: Context) {
 
     fun isHapticFeedbackEnabled(): LiveData<Boolean> {
         return SharedPreferenceBooleanLiveData(prefs, keyHapticFeedback, true)
+    }
+
+    /* decimal places */
+
+    fun setDecimalPlaces(places: Int) {
+        prefs.apply {
+            edit().putString(keyDecimalPlaces, places.toString()).apply()
+        }
+    }
+
+    fun getDecimalPlaces(): LiveData<Int> {
+        return SharedPreferenceStringLiveData(prefs, keyDecimalPlaces, "2")
+            .map { (it ?: "2").toIntOrNull()?.coerceIn(0, 6) ?: 2 }
     }
 
 }

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialog.kt
@@ -137,6 +137,10 @@ class SearchableSpinnerDialog(context: Context) : AppCompatDialogFragment(), Sea
         prefViewModel.isPreviewConversionEnabled().observe(this) {
             adapter.setPreviewConversionEnabled(it)
         }
+        // decimal accuracy
+        mainViewModel.getDecimalPlaces().observe(this) {
+            adapter.setDecimalPlaces(it)
+        }
 
         // build dialog
         return AlertDialog.Builder(requireContext())

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerDialogAdapter.kt
@@ -33,6 +33,7 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
     private var isPreviewConversionEnabled: Boolean = false
     private var currentBaseRate: Rate? = null
     private var currentBaseSum: BigDecimal = BigDecimal.ONE
+    private var decimalPlaces: Int = 2
 
     private var filterStarred = false
     private var filterText: String? = null
@@ -160,16 +161,20 @@ class SearchableSpinnerDialogAdapter(private val context: Context) :
         currentBaseSum = currentSum
         update()
     }
+    fun setDecimalPlaces(places: Int) {
+        decimalPlaces = places.coerceIn(0, 6)
+        update()
+    }
 
     private fun buildConversionText(item: Rate): String {
         val sum = if (currentBaseSum.compareTo(BigDecimal.ZERO) == 0) BigDecimal.ONE else currentBaseSum
         val sourceSymbol = currentBaseRate!!.currency.symbol() ?: ""
-        val source = sum.toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
+        val source = sum.toHumanReadableNumber(context, decimalPlaces = decimalPlaces, trim = true)
         val destinationSymbol = item.currency.symbol() ?: ""
         val destination = sum
             .divide(currentBaseRate!!.value, MathContext.DECIMAL128)
             .multiply(item.value)
-            .toHumanReadableNumber(context, decimalPlaces = 2, trim = true)
+            .toHumanReadableNumber(context, decimalPlaces = decimalPlaces, trim = true)
         val left = if (sourceSymbol.isEmpty()) source
             else if (hasAppendedCurrencySymbol(context)) "$source $sourceSymbol"
             else "$sourceSymbol $source"

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -69,6 +69,14 @@ class PreferenceFragment: PreferenceFragmentCompat() {
                 true
             }
         }
+        findPreference<ListPreference>(getString(R.string.decimal_places_key))?.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                viewModel.setDecimalPlaces(
+                    (newValue.toString().toIntOrNull() ?: 2).coerceIn(0, 6)
+                )
+                true
+            }
+        }
         findPreference<SwitchPreferenceCompat>(getString(R.string.haptic_feedback_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
                 viewModel.setHapticFeedbackEnabled(newValue.toString().toBoolean())

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -58,6 +58,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     private var isUpdating: LiveData<Boolean> = repository.isUpdating()
     val isExtendedKeypadEnabled: LiveData<Boolean> = Database(app).getKeyboardType().map { it != 0 }
     val isHapticFeedbackEnabled: LiveData<Boolean> = Database(app).isHapticFeedbackEnabled()
+    private val decimalPlaces: LiveData<Int> = Database(app).getDecimalPlaces()
 
 
     // number input
@@ -450,23 +451,43 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
      * the nicely formatted, total destination value including the currency symbol at the right position.
      */
     internal fun getResultFormatted(): LiveData<SpannableStringBuilder> {
-        return result.combineWith(currentDestinationCurrency) { value, currency ->
-            val number = (value?.toHumanReadableNumber(
-                app,
-                trim = true,
-                decimalPlaces = 2
-            ) ?: "0")
-            val symbol = currency?.symbol()
+        return object : MediatorLiveData<SpannableStringBuilder>() {
+            var resultText: String? = null
+            var currency: Currency? = null
+            var places: Int = 2
 
-            if (hasAppendedCurrencySymbol(app))
-                SpannableStringBuilder() // 123 $
-                    .bold { append(number) }
-                    .append(if (symbol != null) " $symbol" else "")
-            else
-                SpannableStringBuilder() // $ 123
-                    .append(if (symbol != null) "$symbol " else "")
-                    .bold { append(number) }
+            init {
+                addSource(result) { resultText = it; update() }
+                addSource(currentDestinationCurrency) { currency = it; update() }
+                addSource(decimalPlaces) { places = it; update() }
+            }
+
+            fun update() {
+                val number = (resultText?.toHumanReadableNumber(
+                    app,
+                    trim = true,
+                    decimalPlaces = places
+                ) ?: "0")
+                val symbol = currency?.symbol()
+
+                this.value =
+                    if (hasAppendedCurrencySymbol(app))
+                        SpannableStringBuilder() // 123 $
+                            .bold { append(number) }
+                            .append(if (symbol != null) " $symbol" else "")
+                    else
+                        SpannableStringBuilder() // $ 123
+                            .append(if (symbol != null) "$symbol " else "")
+                            .bold { append(number) }
+            }
         }
+    }
+
+    /**
+     * the current decimal-places preference, for output-side rounding.
+     */
+    internal fun getDecimalPlaces(): LiveData<Int> {
+        return decimalPlaces
     }
 
     /*

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
@@ -145,4 +145,8 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app) 
         Database(app).setHapticFeedbackEnabled(enabled)
     }
 
+    fun setDecimalPlaces(places: Int) {
+        Database(app).setDecimalPlaces(places)
+    }
+
 }

--- a/app/src/main/res/values/arrays_preference.xml
+++ b/app/src/main/res/values/arrays_preference.xml
@@ -11,6 +11,17 @@
         <item>1</item>
     </string-array>
 
+    <!-- decimal accuracy settings -->
+    <string-array name="decimal_places_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+    </string-array>
+
     <!-- theme settings -->
     <string-array name="theme_names" translatable="false">
         <item>@string/theme_option_light</item>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -13,6 +13,9 @@
     <string name="keyboard_title">Keyboard</string>
     <string name="keyboard_option_default">Default</string>
     <string name="keyboard_option_expanded">Expanded</string>
+    <string name="decimal_places_key" translatable="false">KEY_DECIMAL_PLACES</string>
+    <string name="decimal_places_title">Decimal accuracy</string>
+    <string name="decimal_places_summary">Number of decimal places to show for converted values.</string>
     <string name="haptic_feedback_key" translatable="false">KEY_HAPTIC_FEEDBACK</string>
     <string name="haptic_feedback_title">Haptic feedback</string>
     <string name="haptic_feedback_summary">Vibrate on key press\nFollows system setting</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -28,6 +28,15 @@
             android:title="@string/keyboard_title"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            android:defaultValue="2"
+            android:entries="@array/decimal_places_values"
+            android:entryValues="@array/decimal_places_values"
+            android:key="@string/decimal_places_key"
+            android:summary="@string/decimal_places_summary"
+            android:title="@string/decimal_places_title"
+            app:useSimpleSummaryProvider="true" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="@string/haptic_feedback_key"


### PR DESCRIPTION
## Summary
- New user preference controlling the number of decimal places shown for converted values. Applied to the main result display and the currency picker's conversion preview — both previously hardcoded to 2.
- Stored as String under `_decimalPlaces`, clamped 0..6 on read.
- `MainViewModel` exposes `decimalPlaces` LiveData; `getResultFormatted` refactored to `MediatorLiveData` so the result reformats live when the setting changes.
- `SearchableSpinnerDialogAdapter` picks up the value via observer on the dialog.

Companion translation PR: #27 (add Malayalam and translate the two new preference strings). Merge this first.

## Test plan
- [ ] Change the setting between 0 and 6 and verify the main result rounds live.
- [ ] Open the currency picker with conversion preview enabled; verify each row rounds to the chosen precision.
- [ ] Confirm default is 2 for fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)