### PR TITLE
docs: add CLAUDE.md branching rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Repo instructions for Claude Code
+
+Read the project docs before making changes. Contributor rules — including branching, code style, PR checklist, and commit conventions — live in [`docs/markDown/contributing.md`](docs/markDown/contributing.md).
+
+Other reference docs are in [`docs/markDown/`](docs/markDown/):
+
+- [`overview.md`](docs/markDown/overview.md) — project overview
+- [`architecture.md`](docs/markDown/architecture.md) — architecture
+- [`build-and-flavors.md`](docs/markDown/build-and-flavors.md) — build variants
+- [`api-providers.md`](docs/markDown/api-providers.md) — exchange rate providers
+- [`ci-cd.md`](docs/markDown/ci-cd.md) — CI/CD pipelines
+- [`security.md`](docs/markDown/security.md) — security posture
+
+Follow the guidance in those files. If a docs update is needed, edit the relevant `.md` there.

--- a/docs/markDown/contributing.md
+++ b/docs/markDown/contributing.md
@@ -25,6 +25,17 @@ Translations are managed on [Weblate](https://translate.codeberg.org/engage/curr
 3. JDK 21 is required.
 4. `./gradlew assembleFdroidDebug` should build without errors.
 
+### Branching Base
+
+Every new branch must be forked from **remote master** (`origin/master`), not from the local current branch:
+
+```sh
+git fetch origin master
+git switch -c <new-branch> origin/master
+```
+
+This ensures the branch starts from the latest upstream state and does not inherit stale local work or unrelated in-progress commits from another feature. If a PR intentionally depends on another unmerged branch, state that dependency explicitly.
+
 ### Branch Naming
 
 Use descriptive branch names. The CI `apk-artifact.yaml` workflow runs on any non-master push and uploads a debug APK as an artifact for easy review.


### PR DESCRIPTION
## Summary
Adds a `CLAUDE.md` at the repo root instructing Claude Code to always fork new branches from `origin/master` (after fetching) rather than from the local current branch.

Motivation: avoids stacking on stale local work and prevents inheriting unrelated in-progress commits from another feature branch.

## Test plan
- [ ] Read `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)