### PR TITLE
i18n(iw): fill in missing Hebrew translations

### DIFF
--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -11,9 +11,15 @@
     <string name="error_http">תגובת השרת היא HTTP %d</string>
     <string name="error_timeout">השרת לא הגיב בזמן או שאינו נגיש.</string>
     <string name="error_no_data">לא ניתן להתחבר לשרת.</string>
+    <string name="error_empty_response">לשרת אין נתונים עבור בקשה זו.</string>
     <string name="error_api_error">אירעה שגיאת API. נא לנסות שוב בהמשך.</string>
+    <string name="error_try_another_api">עם זאת, יש ספקי נתונים נוספים לבחירה בהגדרות. כדאי לנסות!</string>
+    <string name="error_no_api_key">כדי להשתמש במקור זה, יש להגדיר API Key תקין.</string>
+    <string name="error_invalid_api_key">HTTP 401 – נא לבדוק את ה־API Key שלך.</string>
+    <string name="error_unsupported_timeline">תרשים שערי חליפין אינו נתמך על ידי API זה.</string>
     <string name="menu_settings">הגדרות</string>
     <string name="menu_refresh">רענון השערים</string>
     <string name="menu_timeline">תרשים שערי חליפין</string>
     <string name="tooltip_filter_starred">הצגת מטבעות מסומנים בלבד.</string>
+    <string name="currency_dropdown_api_hint">משהו חסר? ספקי נתונים שונים מציעים מטבעות שונים. אפשר לגשת להגדרות ולנסות ספק אחר!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-iw/strings_apis.xml
+++ b/app/src/main/res/values-iw/strings_apis.xml
@@ -1,6 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="api_bankOfCanada_descriptionFull">שערי חליפין ממוצעים יומיים של <a href="https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates/"><b>Bank of Canada</b></a>.\n<b>כלולים כ־23 מטבעות.</b></string>
+    <string name="api_bankOfCanada_descriptionShort">כ־23 שערי חליפין\nמקור: הבנק המרכזי של קנדה</string>
+    <string name="api_bankOfCanada_descriptionUpdateInterval">השערים מתפרסמים פעם ביום עבודה עד השעה 16:30 ET.</string>
+
+    <string name="api_bankRossii_descriptionFull">שערי חליפין, בחסות הבנק המרכזי הרוסי <a href="https://cbr.ru/eng/currency_base/daily/"><b>Bank Rossii</b></a>. לאור הסנקציות הנוכחיות, מקור זה מספק כנראה את שערי החליפין האמינים ביותר עבור הרובל הרוסי.\n<b>Bank Rossii מציג כ־44 שערי חליפין.</b></string>
+    <string name="api_bankRossii_descriptionShort">כ־44 שערי חליפין\nמקור: הבנק המרכזי של רוסיה</string>
+    <string name="api_bankRossii_descriptionUpdateInterval">השערים מתעדכנים על בסיס יומי, למעט <a href="https://cbr.ru/eng/other/holidays/">חגים לאומיים ברוסיה</a>.</string>
+
+    <string name="api_exchangerateHost_descriptionFull"><a href="https://exchangerate.host/"><b>Exchangerate.host</b></a> מקבל את שערי המטבעות ממגוון ספקי נתונים פיננסיים ובנקים, כולל הבנק המרכזי האירופי. כל נתוני שערי החליפין מסופקים כשערי אמצע. שערי אמצע נקבעים על ידי חישוב חציון של שערי ה־Bid וה־Ask.\n<b>כלולים כ־160 מטבעות.</b></string>
     <string name="api_exchangerateHost_descriptionUpdateInterval">שערי החליפין מעודכנים בסביבות חצות לפי UTC בכל יום עבודה.</string>
+
+    <string name="api_ferEe_descriptionFull"><a href="https://fer.ee/"><b>Fer.ee</b></a> הוא שירות חדש יחסית אשר (בדומה ל־Frankfurter.app) עוקב אחר שערי חליפין (פורקס) שמפרסם הבנק המרכזי האירופי.\n<b>כלולים כ־30 מטבעות.</b></string>
+    <string name="api_ferEe_descriptionShort" translatable="false">@string/api_frankfurterApp_descriptionShort</string>
     <string name="api_ferEe_descriptionUpdateInterval">השערים מתעדכנים בכל יום עבודה.</string>
+
+    <string name="api_frankfurterApp_descriptionFull"><a href="https://www.frankfurter.app/"><b>Frankfurter.app</b></a> עוקב אחר שערי חליפין (פורקס) שמפרסם הבנק המרכזי האירופי.\n<b>כלולים כ־30 מטבעות.</b></string>
+    <string name="api_frankfurterApp_descriptionShort">כ־30 שערי חליפין\nמקור: הבנק המרכזי האירופי</string>
     <string name="api_frankfurterApp_descriptionUpdateInterval">הנתונים מתעדכנים באזור 16:00 CET בכל יום עבודה.</string>
+
+    <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_en"><b>InforEuro</b></a> מספק את שער החשבונאות החודשי הרשמי של הנציבות האירופית עבור האירו ואת שערי ההמרה, כפי שנקבעו על ידי הפקיד החשבונאי של הנציבות האירופית בהתאם לסעיף 19 של התקנון הפיננסי.\nשערים אלה משמשים לחישוב סכומי החזרי הוצאות, נסיעות או קצבאות מחיה עבור גורמים חיצוניים המשתתפים בפגישות, ראיונות וכו\' לבקשת הנציבות האירופית.\n<b>כלולים כ־150 מטבעות.</b></string>
+    <string name="api_inforEuro_descriptionShort">כ־150 שערי חליפין\nמקור: הנציבות האירופית</string>
+    <string name="api_inforEuro_descriptionUpdateInterval">השערים המוצגים הם שערי השוק ליום השני לפני הסוף של החודש הקודם, כפי שצוטטו על ידי הבנק המרכזי האירופי או, בהתאם לזמינות, סופקו על ידי המשלחות או מקורות מתאימים אחרים סמוך לאותו תאריך.</string>
+    <string name="api_inforEuro_hint">השערים מתעדכנים רק פעם בחודש!</string>
+
+    <string name="api_norgesBank_descriptionFull">שערי חליפין, בחסות הבנק המרכזי הנורווגי <a href="https://www.norges-bank.no/en/topics/Statistics/exchange_rates/"><b>Norges Bank</b></a>.\n<b>Norges Bank מציג כ־40 שערי חליפין.</b></string>
+    <string name="api_norgesBank_descriptionShort">כ־40 שערי חליפין\nמקור: הבנק המרכזי של נורווגיה</string>
+    <string name="api_norgesBank_descriptionUpdateInterval">זמן פרסום שערי החליפין היומיים הוא בסביבות 16:00 CET.</string>
+    <string name="api_norgesBank_hint">לשירות יש השבתות תדירות (HTTP 503), במהלכן לא ניתן לרענן את השערים!</string>
+
+    <string name="api_openExchangeRates_descriptionFull">הנתונים נאספים ומשולבים ממגוון מקורות אמינים, כדי להבטיח שערים ללא הטיה. למידע נוסף ראו <a href="https://openexchangerates.org/"><b>openexchangerates.org</b></a>.\n<b>Open Exchange Rates מספק כמות גדולה של כ־160 שערי חליפין.\n<i>כדי להשתמש במקור זה, יש להזין API Key אישי!</i></b></string>
+    <string name="api_openExchangeRates_descriptionShort">כ־160 שערי חליפין\nמקור: שילוב של מספר ספקים אמינים.</string>
+    <string name="api_openExchangeRates_descriptionUpdateInterval">עדכונים שעתיים.</string>
+    <string name="api_openExchangeRates_hint">כדי להשתמש במקור זה, יש ליצור API Key אישי!</string>
 </resources>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -56,16 +56,19 @@
     <string name="api_title">ספק נתונים</string>
     <string name="api_about_title">על %s</string>
     <string name="api_refreshPeriod_title">פער לרענון</string>
+    <string name="api_open_exchangerates_api_key_title">Open Exchangerates API Key</string>
+    <string name="api_open_exchangerates_api_key_message">כדי להשתמש במקור זה, יש ליצור API Key אישי.\n\nלשם כך, יש להיכנס ל־https://openexchangerates.org/signup/free וליצור חשבון חינמי.\nלבסוף, יש להפיק App ID חדש בלוח הבקרה ולהזין אותו כאן:</string>
+    <string name="api_open_exchangerates_api_key_missing"><i>נדרש API Key</i></string>
     <!-- about -->
     <string name="category_about">על היישומון הזה</string>
     <string name="disclaimer_title">כתב ויתור</string>
-
-
-
+    <string name="disclaimer_summary">אף על פי שהיישומון נכתב ונבדק בקפידה רבה, <b>אין כל אחריות שהנתונים המוצגים בו נכונים</b>. שערי החליפין מסופקים על ידי צד שלישי והיישומון אינו יכול להבטיח בשום צורה שהנתונים נכונים ומעודכנים.\nבנוסף, השערים המסופקים – גם אם הם נכונים – עשויים להיות שונים מאלה שהבנק שלך משתמש בהם.\nולסיום: טעויות קורות. אף פעם אל תסמכו על אף אחד באופן עיוור! עם זאת, לא הייתי משחרר את היישומון אילו הייתי מפקפק שהוא פועל כמצופה.</string>
+    <string name="sourcecode_title">קוד מקור</string>
+    <string name="sourcecode_summary">היישומון הזה בקוד פתוח. אפשר לגשת למאגר הקוד כדי לפתוח דיווחים על תקלות, לגלות איך לתרום או פשוט להציץ במקורות.</string>
     <string name="donate_title">תמיכה במתכנת</string>
     <string name="donate_summary">תרומה דרך PayPal</string>
     <string name="rate_title">דירוג היישומון</string>
     <string name="rate_summary">לבחירתך, אפשר לסייע לאחרים להיחשף ליישומון. לחיצה כאן תוביל אותך לדירוג ב־Google Play.</string>
-
-
+    <string name="category_versioninfo">פרטי גרסה</string>
+    <string name="title_changelog">יומן שינויים</string>
 </resources>

--- a/app/src/main/res/values-iw/strings_timeline.xml
+++ b/app/src/main/res/values-iw/strings_timeline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="activity_timeline_title">מ־&lt;b>%1$s&lt;/b> עד &lt;b>%2$s&lt;/b></string>
+    <string name="activity_timeline_title">מ־&lt;b>%1$s&lt;/b> ל־&lt;b>%2$s&lt;/b></string>
     <string name="data_provider">נתונים בחסות &lt;b>%s&lt;/b></string>
 
     <string name="rate_average">ממוצע</string>

--- a/app/src/main/res/values-iw/strings_timeline.xml
+++ b/app/src/main/res/values-iw/strings_timeline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="activity_timeline_title">מ־&lt;b>%1$s&lt;/b> עד &lt;b>%2$s&lt;/b></string>
+    <string name="data_provider">נתונים בחסות &lt;b>%s&lt;/b></string>
+
+    <string name="rate_average">ממוצע</string>
+    <string name="rate_min">מינימום</string>
+    <string name="rate_max">מקסימום</string>
+
+    <string name="year">שנה</string>
+    <string name="month">חודש</string>
+    <string name="week">שבוע</string>
+</resources>


### PR DESCRIPTION
## Summary
- Adds Hebrew translations for strings that were missing under `values-iw/`.
- Covers 6 user-facing strings in `strings.xml` (errors, dropdown hint), the disclaimer/source-code/changelog/version-info/API-key entries in `strings_preference.xml`, all missing provider descriptions in `strings_apis.xml`, and a brand-new `strings_timeline.xml`.
- Per author guidance: provider names, the term "API Key", and emojis are kept in English; the 5 not-yet-translated language labels (`language_da`, `language_en_GB`, `language_et`, `language_fa`, `language_zh_TW`) are intentionally left untouched.

## Test plan
- [ ] Build `./gradlew assembleFdroidDebug` succeeds
- [ ] With device language set to Hebrew, verify the Settings screen shows the new disclaimer/source-code/changelog/version-info entries
- [ ] Verify each API provider's About screen shows the translated description
- [ ] Trigger error paths (no network, invalid API key, unsupported timeline) and confirm the messages are in Hebrew
- [ ] Open the timeline activity and confirm labels ("ממוצע", "מינימום", "מקסימום", "שנה/חודש/שבוע") render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)