### PR TITLE
i18n: fill da/en_GB/et/fa/zh_TW language labels across all locales

### DIFF
--- a/app/src/main/res/values-ar/strings_preference.xml
+++ b/app/src/main/res/values-ar/strings_preference.xml
@@ -28,6 +28,7 @@
     <string name="language_bn">اللغة البنغالية</string>
     <string name="language_ca">الكتالونية</string>
     <string name="language_cs">التشيكية</string>
+    <string name="language_da">الدنماركية</string>
     <string name="language_de">اللغة الألمانية</string>
     <string name="language_el">يونانية</string>
     <string name="language_en">الإنجليزية</string>

--- a/app/src/main/res/values-bg/strings_preference.xml
+++ b/app/src/main/res/values-bg/strings_preference.xml
@@ -23,6 +23,11 @@
     <string name="pure_black_enabled_summary">Използвай чисто черно в тъмен режим</string>
     <!-- languages -->
     <string name="language_title">Език на приложението</string>
+    <string name="language_da">Датски</string>
+    <string name="language_en_GB">Английски (Британски)</string>
+    <string name="language_et">Естонски</string>
+    <string name="language_fa">Персийски</string>
+    <string name="language_zh_TW">Китайски (традиционен)</string>
 
 
 

--- a/app/src/main/res/values-bn/strings_preference.xml
+++ b/app/src/main/res/values-bn/strings_preference.xml
@@ -28,12 +28,14 @@
     <string name="language_bn">বাংলা</string>
     <string name="language_ca">কাতালান</string>
     <string name="language_cs">চেক</string>
+    <string name="language_da">ডেনিশ</string>
     <string name="language_de">জর্মন</string>
     <string name="language_el">গ্রিক</string>
     <string name="language_en">ইংরেজি</string>
     <string name="language_en_GB">ইংরেজি (যুক্তরাজ্য)</string>
     <string name="language_eo">এস্পেরান্তো</string>
     <string name="language_es">স্পেনীয়</string>
+    <string name="language_et">এস্তোনীয়</string>
     <string name="language_fa">ফারসি</string>
     <string name="language_fr">ফরাসি</string>
     <string name="language_hr">ক্রোয়েসীয়</string>

--- a/app/src/main/res/values-ca/strings_preference.xml
+++ b/app/src/main/res/values-ca/strings_preference.xml
@@ -32,8 +32,10 @@
     <string name="language_de">Alemany</string>
     <string name="language_el">Grec</string>
     <string name="language_en">Anglès</string>
+    <string name="language_en_GB">Anglès (Britànic)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Castellà</string>
+    <string name="language_et">Estonià</string>
     <string name="language_fa">Persa</string>
     <string name="language_fr">Francès</string>
     <string name="language_hr">Croat</string>

--- a/app/src/main/res/values-el/strings_preference.xml
+++ b/app/src/main/res/values-el/strings_preference.xml
@@ -28,11 +28,14 @@
     <string name="language_bn">Μπενγκάλι</string>
     <string name="language_ca">Καταλανικά</string>
     <string name="language_cs">Τσέχικα</string>
+    <string name="language_da">Δανικά</string>
     <string name="language_de">Γερμανικά</string>
     <string name="language_el">Ελληνικά</string>
     <string name="language_en">Αγγλικά</string>
+    <string name="language_en_GB">Αγγλικά (Βρετανικά)</string>
     <string name="language_eo">Εσπεράντο</string>
     <string name="language_es">Ισπανικά</string>
+    <string name="language_et">Εσθονικά</string>
     <string name="language_fa">Περσικά</string>
     <string name="language_fr">Γαλλικά</string>
     <string name="language_hr">Κροατικά</string>

--- a/app/src/main/res/values-eo/strings_preference.xml
+++ b/app/src/main/res/values-eo/strings_preference.xml
@@ -32,8 +32,11 @@
     <string name="language_de">Germana</string>
     <string name="language_el">Greka</string>
     <string name="language_en">Angla</string>
+    <string name="language_en_GB">Angla (Brita)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Hispana</string>
+    <string name="language_et">Estona</string>
+    <string name="language_fa">Persa</string>
     <string name="language_fr">Franca</string>
     <string name="language_hr">Kroata</string>
     <string name="language_hu">Hungara</string>

--- a/app/src/main/res/values-fa/strings_preference.xml
+++ b/app/src/main/res/values-fa/strings_preference.xml
@@ -28,11 +28,14 @@
     <string name="language_bn">بنگالی</string>
     <string name="language_ca">کاتالان</string>
     <string name="language_cs">چک</string>
+    <string name="language_da">دانمارکی</string>
     <string name="language_de">المانی</string>
     <string name="language_el">یونانی</string>
     <string name="language_en">اینگلیسی</string>
+    <string name="language_en_GB">انگلیسی (بریتانیایی)</string>
     <string name="language_eo">اسپرانتو</string>
     <string name="language_es">اسپانیایی</string>
+    <string name="language_et">استونیایی</string>
     <string name="language_fa">فارسی</string>
     <string name="language_fr">فرانسوی</string>
     <string name="language_hr">کرواتی</string>

--- a/app/src/main/res/values-hu/strings_preference.xml
+++ b/app/src/main/res/values-hu/strings_preference.xml
@@ -23,6 +23,11 @@
     <string name="pure_black_enabled_summary">Tiszta fekete használata sötét módban</string>
     <!-- languages -->
     <string name="language_title">Az alkalmazás nyelve</string>
+    <string name="language_da">Dán</string>
+    <string name="language_en_GB">Angol (brit)</string>
+    <string name="language_et">Észt</string>
+    <string name="language_fa">Perzsa</string>
+    <string name="language_zh_TW">Kínai (hagyományos)</string>
 
 
 

--- a/app/src/main/res/values-in/strings_preference.xml
+++ b/app/src/main/res/values-in/strings_preference.xml
@@ -32,8 +32,11 @@
     <string name="language_de">Jerman</string>
     <string name="language_el">Yunani</string>
     <string name="language_en">Inggris</string>
+    <string name="language_en_GB">Inggris (Britania)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Spanyol</string>
+    <string name="language_et">Estonia</string>
+    <string name="language_fa">Persia</string>
     <string name="language_fr">Prancis</string>
     <string name="language_hr">Kroasia</string>
     <string name="language_hu">Hongaria</string>
@@ -50,6 +53,7 @@
     <string name="language_tr">Turki</string>
     <string name="language_uk">Ukraina</string>
     <string name="language_vi">Vietnam</string>
+    <string name="language_zh_TW">Tionghoa (Tradisional)</string>
 
 
     <!-- api -->

--- a/app/src/main/res/values-is/strings_preference.xml
+++ b/app/src/main/res/values-is/strings_preference.xml
@@ -32,8 +32,11 @@
     <string name="language_de">Þýska</string>
     <string name="language_el">Gríska</string>
     <string name="language_en">Enska</string>
+    <string name="language_en_GB">Enska (bresk)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Spænska</string>
+    <string name="language_et">Eistneska</string>
+    <string name="language_fa">Persneska</string>
     <string name="language_fr">Franska</string>
     <string name="language_hr">Króatíska</string>
     <string name="language_hu">Ungverska</string>
@@ -51,6 +54,7 @@
     <string name="language_uk">Úkraínska</string>
     <string name="language_vi">Víetnamska</string>
     <string name="language_zh_CN">Einfölduð kínverska</string>
+    <string name="language_zh_TW">Hefðbundin kínverska</string>
 
     <!-- api -->
     <string name="category_api">Gengi</string>

--- a/app/src/main/res/values-nb/strings_preference.xml
+++ b/app/src/main/res/values-nb/strings_preference.xml
@@ -32,8 +32,11 @@
     <string name="language_de">Tysk</string>
     <string name="language_el">Gresk</string>
     <string name="language_en">Engelsk</string>
+    <string name="language_en_GB">Engelsk (britisk)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Spansk</string>
+    <string name="language_et">Estisk</string>
+    <string name="language_fa">Persisk</string>
     <string name="language_fr">Fransk</string>
     <string name="language_hr">Kroatisk</string>
     <string name="language_hu">Ungarsk</string>
@@ -50,6 +53,7 @@
     <string name="language_tr">Tyrkisk</string>
     <string name="language_uk">Ukrainsk</string>
     <string name="language_vi">Vietnamesisk</string>
+    <string name="language_zh_TW">Kinesisk (tradisjonell)</string>
 
 
     <!-- api -->

--- a/app/src/main/res/values-pl/strings_preference.xml
+++ b/app/src/main/res/values-pl/strings_preference.xml
@@ -32,8 +32,11 @@
     <string name="language_de">Niemiecki</string>
     <string name="language_el">Grecki</string>
     <string name="language_en">Angielski</string>
+    <string name="language_en_GB">Angielski (brytyjski)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">Hiszpański</string>
+    <string name="language_et">Estoński</string>
+    <string name="language_fa">Perski</string>
     <string name="language_fr">Francuski</string>
     <string name="language_hr">Croatian</string>
     <string name="language_hu">Węgierski</string>

--- a/app/src/main/res/values-pt-rBR/strings_preference.xml
+++ b/app/src/main/res/values-pt-rBR/strings_preference.xml
@@ -23,6 +23,11 @@
     <string name="pure_black_enabled_summary">Usar modo escuro puro no modo escuro</string>
     <!-- languages -->
     <string name="language_title">Idioma do app</string>
+    <string name="language_da">Dinamarquês</string>
+    <string name="language_en_GB">Inglês (Britânico)</string>
+    <string name="language_et">Estoniano</string>
+    <string name="language_fa">Persa</string>
+    <string name="language_zh_TW">Chinês (Tradicional)</string>
 
 
 

--- a/app/src/main/res/values-ru/strings_preference.xml
+++ b/app/src/main/res/values-ru/strings_preference.xml
@@ -28,11 +28,14 @@
     <string name="language_bn">Бенгальский</string>
     <string name="language_ca">Каталанский</string>
     <string name="language_cs">Чешский</string>
+    <string name="language_da">Датский</string>
     <string name="language_de">Немецкий</string>
     <string name="language_el">Греческий</string>
     <string name="language_en">Английский</string>
+    <string name="language_en_GB">Английский (британский)</string>
     <string name="language_eo">Эсперанто</string>
     <string name="language_es">Испанский</string>
+    <string name="language_et">Эстонский</string>
     <string name="language_fa">Персидский</string>
     <string name="language_fr">Французский</string>
     <string name="language_hr">Хорватский</string>

--- a/app/src/main/res/values-sv/strings_preference.xml
+++ b/app/src/main/res/values-sv/strings_preference.xml
@@ -33,8 +33,10 @@
     <string name="language_el">Grekiska</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_en">Engelska</string>
+    <string name="language_en_GB">Engelska (brittisk)</string>
 
     <string name="language_es">Spanska</string>
+    <string name="language_et">Estniska</string>
     <string name="language_fa">Persiska</string>
     <string name="language_fr">Franska</string>
     <string name="language_hr">Kroatiska</string>

--- a/app/src/main/res/values-tr/strings_preference.xml
+++ b/app/src/main/res/values-tr/strings_preference.xml
@@ -28,11 +28,15 @@
     <string name="language_bn">Bengalce</string>
     <string name="language_ca">Katalanca</string>
     <string name="language_cs">Çek</string>
+    <string name="language_da">Danca</string>
     <string name="language_de">Almanca</string>
     <string name="language_el">Yunanca</string>
     <string name="language_en">İngilizce</string>
+    <string name="language_en_GB">İngilizce (Britanya)</string>
     <string name="language_eo">Esperanto</string>
     <string name="language_es">İspanyolca</string>
+    <string name="language_et">Estonca</string>
+    <string name="language_fa">Farsça</string>
     <string name="language_fr">Fransızca</string>
     <string name="language_hr">Hırvatça</string>
     <string name="language_hu">Macarca</string>

--- a/app/src/main/res/values-uk/strings_preference.xml
+++ b/app/src/main/res/values-uk/strings_preference.xml
@@ -28,6 +28,7 @@
     <string name="language_bn">Бенгальська</string>
     <string name="language_ca">Каталонська</string>
     <string name="language_cs">Чеська</string>
+    <string name="language_da">Данська</string>
     <string name="language_de">Німецька</string>
     <string name="language_el">Грецька</string>
     <string name="language_en">Англійська</string>

--- a/app/src/main/res/values-vi/strings_preference.xml
+++ b/app/src/main/res/values-vi/strings_preference.xml
@@ -28,11 +28,15 @@
     <string name="language_bn">Tiếng Bengal</string>
     <string name="language_ca">Tiếng Catalunya</string>
     <string name="language_cs">Tiếng Séc</string>
+    <string name="language_da">Tiếng Đan Mạch</string>
     <string name="language_de">Tiếng Đức</string>
     <string name="language_el">Tiếng Hy Lạp</string>
     <string name="language_en">Tiếng Anh</string>
+    <string name="language_en_GB">Tiếng Anh (Anh)</string>
     <string name="language_eo">Tiếng Quốc tế ngữ</string>
     <string name="language_es">Tiếng Tây Ban Nha</string>
+    <string name="language_et">Tiếng Estonia</string>
+    <string name="language_fa">Tiếng Ba Tư</string>
 
     <string name="language_fr">Tiếng Pháp</string>
     <string name="language_hr">Tiếng Croatia</string>
@@ -51,6 +55,7 @@
     <string name="language_uk">Tiếng Ukraina</string>
     <string name="language_vi">Tiếng Việt</string>
     <string name="language_zh_CN">Tiếng Trung giản thể</string>
+    <string name="language_zh_TW">Tiếng Trung phồn thể</string>
 
     <!-- api -->
     <string name="category_api">Tỉ lệ chuyển đổi</string>

--- a/app/src/main/res/values-zh-rCN/strings_preference.xml
+++ b/app/src/main/res/values-zh-rCN/strings_preference.xml
@@ -28,6 +28,7 @@
     <string name="language_bn">孟加拉语</string>
     <string name="language_ca">加泰罗尼亚语</string>
     <string name="language_cs">捷克语</string>
+    <string name="language_da">丹麦语</string>
     <string name="language_de">德语</string>
     <string name="language_el">希腊语</string>
     <string name="language_en">英语</string>

--- a/app/src/main/res/values-zh-rTW/strings_preference.xml
+++ b/app/src/main/res/values-zh-rTW/strings_preference.xml
@@ -27,11 +27,14 @@
     <string name="language_bn">孟加拉文</string>
     <string name="language_ca">加泰隆尼亞語</string>
     <string name="language_cs">捷克文</string>
+    <string name="language_da">丹麥文</string>
     <string name="language_de">德文</string>
     <string name="language_el">希臘文</string>
     <string name="language_en">英文</string>
+    <string name="language_en_GB">英文 (英國)</string>
     <string name="language_eo">世界語</string>
     <string name="language_es">西班牙文</string>
+    <string name="language_et">愛沙尼亞文</string>
     <string name="language_fa">波斯語</string>
     <string name="language_fr">法文</string>
     <string name="language_hr">克羅埃西亞文</string>


### PR DESCRIPTION
## Summary

Fills the five previously-missing language name entries (`language_da`, `language_en_GB`, `language_et`, `language_fa`, `language_zh_TW`) into every translated locale that was missing one or more, bringing coverage to **100%** for these keys across all 30 locales.

**20 locales modified**, 63 new entries added:

| Missing count | Locales |
|---|---|
| 5 | bg, hu, pt-rBR, vi |
| 4 | in, is, nb, tr |
| 3 | el, eo, fa, pl, ru, zh-rTW |
| 2 | bn, ca, sv |
| 1 | ar, uk, zh-rCN |

## Caveat

Translations are **machine-generated** (I don't speak most of these languages natively). Flagged for community/native-speaker review. Ordinarily these would go through Weblate per `docs/markDown/contributing.md`, but the maintainer requested an in-repo PR to close the gap quickly — feedback and corrections welcome.

## Test plan

- [ ] `./gradlew assembleFdroidDebug` builds without errors
- [ ] Language picker in Settings renders all 30 entries in every locale
- [ ] Native speakers review wording (see caveat above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)