### PR TITLE
feat(fees): long-press shortcut to Fees settings + full i18n

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -293,6 +293,14 @@ class MainActivity : BaseActivity() {
             }
             viewModel.setFeeSide(next)
         }
+        btnFeeSide.setOnLongClickListener {
+            haptic(it)
+            startActivity(
+                Intent(this, PreferenceActivity::class.java)
+                    .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
+            )
+            true
+        }
     }
 
     private fun copyToClipboard(copyText: String) {

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceActivity.kt
@@ -10,6 +10,10 @@ import de.salomax.currencies.view.BaseActivity
 
 class PreferenceActivity: BaseActivity() {
 
+    companion object {
+        const val EXTRA_OPEN_FEES = "EXTRA_OPEN_FEES"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -28,6 +32,13 @@ class PreferenceActivity: BaseActivity() {
         // title bar
         setTitle(R.string.title_preferences)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        if (savedInstanceState == null && intent.getBooleanExtra(EXTRA_OPEN_FEES, false)) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.preferences_fragment, FeeManagerFragment())
+                .addToBackStack(null)
+                .commit()
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/values-ar/strings_preference.xml
+++ b/app/src/main/res/values-ar/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">الاعدادات العامة</string>
     <string name="fee_title">رسوم المعاملات الخارجية</string>
-    <string name="fee_summary">اعتمادًا على اتفاقية بطاقة الائتمان الخاصة بك ، قد يفرض البنك الذي تتعامل معه رسومًا على جميع معاملات الصرف الأجنبي. هنا يمكنك إدخال تلك الرسوم. ستتم إضافته أعلى الحساب ، حتى تعرف مقدار ما تدفعه <i> حقًا </i>.</string>
+    <string name="fee_summary">إدارة رسوم الصرف والبنك/البطاقة والرسوم الخاصة بأزواج العملات</string>
+    <string name="fee_manager_title">الرسوم</string>
+    <string name="fee_side_label">جانب الرسوم</string>
+    <string name="fee_side_original">الأصلي</string>
+    <string name="fee_side_converted">المحوَّل</string>
+    <string name="fee_section_global_exchange">رسوم الصرف العامة</string>
+    <string name="fee_section_global_bank">رسوم البنك/البطاقة العامة</string>
+    <string name="fee_section_specific_pair">رسوم صرف زوج عملات محدد</string>
+    <string name="fee_add">إضافة رسوم</string>
+    <string name="fee_delete">حذف</string>
+    <string name="fee_edit_percent">نسبة مئوية</string>
+    <string name="fee_pair_both_ways">كلا الاتجاهين</string>
+    <string name="fee_pair_from">من</string>
+    <string name="fee_pair_to">إلى</string>
+    <string name="fee_pair_pick_currency">اختر عملة</string>
+    <string name="fee_true_cost_prefix">"التكلفة الحقيقية: "</string>
+    <string name="fee_side_summary_original">يبقى المبلغ المحوَّل المعروض بسعر السوق الأوسط؛ وتُعرض الرسوم بشكل منفصل باسم \"التكلفة الحقيقية\".</string>
+    <string name="fee_side_summary_converted">الرسوم مضمَّنة في المبلغ المحوَّل المعروض.</string>
+    <string name="fee_empty">لا توجد رسوم بعد</string>
     <string name="previewConversion_title">معاينة التحويل</string>
     <string name="previewConversion_summary">اعرض التحويل الحالي لكل سعر في منتقي العملات.</string>
     <string name="keyboard_title">لوحة المفاتيح</string>

--- a/app/src/main/res/values-bg/strings_preference.xml
+++ b/app/src/main/res/values-bg/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Общи настройки</string>
-    <string name="fee_title">Чужда такса за транзакцията</string>
-    <string name="fee_summary">В зависимост от договора ви за кредитна карта, вашата банка може да ви таксува за всички чуждо валутни транзакции. Тук може да въведете тази такса. Тя ще бъде добавена при всяко пресмятане, за да знаете колко ще платите <i>реално</i>.</string>
+    <string name="fee_title">Такса за чуждестранна транзакция</string>
+    <string name="fee_summary">Управление на обменни, банкови/картови такси и такси за конкретни валутни двойки</string>
+    <string name="fee_manager_title">Такси</string>
+    <string name="fee_side_label">Страна на таксата</string>
+    <string name="fee_side_original">Оригинална</string>
+    <string name="fee_side_converted">Конвертирана</string>
+    <string name="fee_section_global_exchange">Глобална обменна такса</string>
+    <string name="fee_section_global_bank">Глобална банкова/картова такса</string>
+    <string name="fee_section_specific_pair">Такса за конкретна валутна двойка</string>
+    <string name="fee_add">Добави такса</string>
+    <string name="fee_delete">Изтрий</string>
+    <string name="fee_edit_percent">Процент</string>
+    <string name="fee_pair_both_ways">И в двете посоки</string>
+    <string name="fee_pair_from">От</string>
+    <string name="fee_pair_to">До</string>
+    <string name="fee_pair_pick_currency">Избери валута</string>
+    <string name="fee_true_cost_prefix">"Реална цена: "</string>
+    <string name="fee_side_summary_original">Показаната конвертирана сума остава на средния пазарен курс; таксите се показват отделно като \"реална цена\".</string>
+    <string name="fee_side_summary_converted">Таксите са включени в показаната конвертирана сума.</string>
+    <string name="fee_empty">Все още няма такси</string>
     <string name="previewConversion_title">Преглед на конвертирането</string>
     <string name="previewConversion_summary">Покажи текущото конвертиране за всеки курс при избиране на валута.</string>
     <string name="keyboard_title">Клавиатура</string>

--- a/app/src/main/res/values-bn/strings_preference.xml
+++ b/app/src/main/res/values-bn/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">সাধারণ পছন্দসমূহ</string>
     <string name="fee_title">বিদেশি লেনদেন ফি</string>
-    <string name="fee_summary">তোমার ক্রেডিট কার্ড চুক্তির ওপর ভিত্তি করে, তোমার ব্যাংক বিদেশি লেনদেনের ওপর ফি নিতে পারে। এখানে সেই ফি এর পরিমান দিতে পারো। এটা হিসাবের ওপরে যোগ হবে, যাতে তুমি জানো তোমাকে <i>আসলেই</i> কত টাকা দিতে হবে।</string>
+    <string name="fee_summary">বিনিময়, ব্যাংক/কার্ড এবং নির্দিষ্ট জোড়ার ফি পরিচালনা করো</string>
+    <string name="fee_manager_title">ফি</string>
+    <string name="fee_side_label">ফি এর দিক</string>
+    <string name="fee_side_original">মূল</string>
+    <string name="fee_side_converted">রূপান্তরিত</string>
+    <string name="fee_section_global_exchange">বিশ্বব্যাপী বিনিময় ফি</string>
+    <string name="fee_section_global_bank">বিশ্বব্যাপী ব্যাংক/কার্ড ফি</string>
+    <string name="fee_section_specific_pair">নির্দিষ্ট মুদ্রা জোড়ার বিনিময় ফি</string>
+    <string name="fee_add">ফি যোগ করো</string>
+    <string name="fee_delete">মুছে ফেলো</string>
+    <string name="fee_edit_percent">শতাংশ</string>
+    <string name="fee_pair_both_ways">উভয় দিক</string>
+    <string name="fee_pair_from">থেকে</string>
+    <string name="fee_pair_to">প্রতি</string>
+    <string name="fee_pair_pick_currency">মুদ্রা নির্বাচন করো</string>
+    <string name="fee_true_cost_prefix">"প্রকৃত খরচ: "</string>
+    <string name="fee_side_summary_original">প্রদর্শিত রূপান্তরিত পরিমাণ মধ্য-বাজার হারে থাকে; ফি আলাদাভাবে \"প্রকৃত খরচ\" হিসেবে দেখানো হয়।</string>
+    <string name="fee_side_summary_converted">ফি প্রদর্শিত রূপান্তরিত পরিমাণে অন্তর্ভুক্ত থাকে।</string>
+    <string name="fee_empty">এখনো কোনো ফি নেই</string>
     <string name="previewConversion_title">রূপান্তরের প্রাকদর্শন</string>
     <string name="previewConversion_summary">অর্থ রূপান্তরের প্রত্যেকটি হার অর্থ নির্বাচকে দেখাও</string>
     <string name="keyboard_title">কীবোর্ড</string>

--- a/app/src/main/res/values-ca/strings_preference.xml
+++ b/app/src/main/res/values-ca/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Configuració general</string>
     <string name="fee_title">Comissió per transacció amb l’estranger</string>
-    <string name="fee_summary">El vostre banc pot cobrar una comissió a les transaccions fetes a l\'estranger depenent del contracte de la targeta de crèdit. Introduïu aquí el valor d\'aquesta comissió. Aquesta s\'afegeix al càlcul per tal de determinar quant es pagarà <i>realment</i>.</string>
+    <string name="fee_summary">Gestiona comissions de canvi, banc/targeta i específiques per parell</string>
+    <string name="fee_manager_title">Comissions</string>
+    <string name="fee_side_label">Costat de la comissió</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Convertit</string>
+    <string name="fee_section_global_exchange">Comissió global de canvi</string>
+    <string name="fee_section_global_bank">Comissió global de banc/targeta</string>
+    <string name="fee_section_specific_pair">Comissió per parell de monedes específic</string>
+    <string name="fee_add">Afegeix comissió</string>
+    <string name="fee_delete">Suprimeix</string>
+    <string name="fee_edit_percent">Percentatge</string>
+    <string name="fee_pair_both_ways">Ambdues direccions</string>
+    <string name="fee_pair_from">De</string>
+    <string name="fee_pair_to">A</string>
+    <string name="fee_pair_pick_currency">Selecciona moneda</string>
+    <string name="fee_true_cost_prefix">"Cost real: "</string>
+    <string name="fee_side_summary_original">L\'import convertit mostrat es manté al canvi mitjà de mercat; les comissions es mostren per separat com a \"cost real\".</string>
+    <string name="fee_side_summary_converted">Les comissions s\'inclouen dins de l\'import convertit mostrat.</string>
+    <string name="fee_empty">Encara no hi ha comissions</string>
     <string name="previewConversion_title">Previsualització de la conversió</string>
     <string name="previewConversion_summary">Mostra la conversió actual per a cada taxa de canvi en el selector de monedes.</string>
     <string name="keyboard_title">Teclat</string>

--- a/app/src/main/res/values-cs/strings_preference.xml
+++ b/app/src/main/res/values-cs/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Obecná nastavení</string>
-    <string name="fee_title">Neznámý poplatek za převod</string>
-    <string name="fee_summary">V závislosti na smlouvě o kreditní kartě si může vaše banka účtovat poplatek za všechny devizové transakce. Zde můžete zadat tento poplatek. Bude připočten k výpočtu, abyste věděli, kolik <i>skutečně</i> zaplatíte.</string>
+    <string name="fee_title">Poplatek za zahraniční transakci</string>
+    <string name="fee_summary">Spravujte směnné, bankovní/kartové a specifické poplatky pro měnové páry</string>
+    <string name="fee_manager_title">Poplatky</string>
+    <string name="fee_side_label">Strana poplatku</string>
+    <string name="fee_side_original">Původní</string>
+    <string name="fee_side_converted">Převedená</string>
+    <string name="fee_section_global_exchange">Globální směnný poplatek</string>
+    <string name="fee_section_global_bank">Globální bankovní/kartový poplatek</string>
+    <string name="fee_section_specific_pair">Poplatek pro konkrétní měnový pár</string>
+    <string name="fee_add">Přidat poplatek</string>
+    <string name="fee_delete">Smazat</string>
+    <string name="fee_edit_percent">Procent</string>
+    <string name="fee_pair_both_ways">Oba směry</string>
+    <string name="fee_pair_from">Z</string>
+    <string name="fee_pair_to">Na</string>
+    <string name="fee_pair_pick_currency">Vyberte měnu</string>
+    <string name="fee_true_cost_prefix">"Skutečná cena: "</string>
+    <string name="fee_side_summary_original">Zobrazená převedená částka zůstává ve středním tržním kurzu; poplatky jsou zobrazeny samostatně jako \"skutečná cena\".</string>
+    <string name="fee_side_summary_converted">Poplatky jsou zahrnuty v zobrazené převedené částce.</string>
+    <string name="fee_empty">Zatím žádné poplatky</string>
     <string name="previewConversion_title">Náhled převodu</string>
     <string name="previewConversion_summary">Zobrazí aktuální převod u každého kurzu ve výběru měny.</string>
     <string name="keyboard_title">Klávesnice</string>

--- a/app/src/main/res/values-da/strings_preference.xml
+++ b/app/src/main/res/values-da/strings_preference.xml
@@ -4,6 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Generelle indstillinger</string>
     <string name="fee_title">Gebyr for udenlandske transaktioner</string>
+    <string name="fee_summary">Administrer veksel-, bank-/kortgebyrer og gebyrer for specifikke valutapar</string>
+    <string name="fee_manager_title">Gebyrer</string>
+    <string name="fee_side_label">Gebyrside</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Konverteret</string>
+    <string name="fee_section_global_exchange">Globalt vekselgebyr</string>
+    <string name="fee_section_global_bank">Globalt bank-/kortgebyr</string>
+    <string name="fee_section_specific_pair">Vekselgebyr for specifikt valutapar</string>
+    <string name="fee_add">Tilføj gebyr</string>
+    <string name="fee_delete">Slet</string>
+    <string name="fee_edit_percent">Procent</string>
+    <string name="fee_pair_both_ways">Begge retninger</string>
+    <string name="fee_pair_from">Fra</string>
+    <string name="fee_pair_to">Til</string>
+    <string name="fee_pair_pick_currency">Vælg valuta</string>
+    <string name="fee_true_cost_prefix">"Reel pris: "</string>
+    <string name="fee_side_summary_original">Den viste konverterede værdi bliver ved mellemkursen; gebyrer vises separat som \"reel pris\".</string>
+    <string name="fee_side_summary_converted">Gebyrer er indregnet i den viste konverterede værdi.</string>
+    <string name="fee_empty">Ingen gebyrer endnu</string>
 
     <string name="previewConversion_title">Forhåndsvisning af konvertering</string>
     <string name="previewConversion_summary">Vis den nuværende konverteringsrate for hver valuta i valutavælgeren.</string>

--- a/app/src/main/res/values-de/strings_preference.xml
+++ b/app/src/main/res/values-de/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Haupteinstellungen</string>
     <string name="fee_title">Fremdwährungsgebühr</string>
-    <string name="fee_summary">In den Konditionen mancher Kreditkarten sind Gebühren für den Einsatz im Ausland bzw. mit Fremdwährungen enthalten. Hier kannst du die Gebühr deiner Karte eintragen. Sie wird dann auf alle Umrechnungen aufgeschlagen, damit du weißt, wie viel du <i>wirklich</i> zahlst.</string>
+    <string name="fee_summary">Wechsel-, Bank-/Karten- und paarspezifische Gebühren verwalten</string>
+    <string name="fee_manager_title">Gebühren</string>
+    <string name="fee_side_label">Gebührenseite</string>
+    <string name="fee_side_original">Ursprünglich</string>
+    <string name="fee_side_converted">Umgerechnet</string>
+    <string name="fee_section_global_exchange">Globale Wechselgebühr</string>
+    <string name="fee_section_global_bank">Globale Bank-/Kartengebühr</string>
+    <string name="fee_section_specific_pair">Gebühr für spezifisches Währungspaar</string>
+    <string name="fee_add">Gebühr hinzufügen</string>
+    <string name="fee_delete">Löschen</string>
+    <string name="fee_edit_percent">Prozent</string>
+    <string name="fee_pair_both_ways">Beide Richtungen</string>
+    <string name="fee_pair_from">Von</string>
+    <string name="fee_pair_to">Nach</string>
+    <string name="fee_pair_pick_currency">Währung auswählen</string>
+    <string name="fee_true_cost_prefix">"Tatsächliche Kosten: "</string>
+    <string name="fee_side_summary_original">Der angezeigte umgerechnete Betrag bleibt beim Mittelkurs; Gebühren werden separat als \"tatsächliche Kosten\" angezeigt.</string>
+    <string name="fee_side_summary_converted">Gebühren sind bereits im angezeigten umgerechneten Betrag enthalten.</string>
+    <string name="fee_empty">Noch keine Gebühren</string>
     <string name="previewConversion_title">Umrechnungsvorschau</string>
     <string name="previewConversion_summary">Im Währungsauswahldialog die aktuelle Umrechnung für jeden Kurs anzeigen.</string>
     <string name="keyboard_title">Tastatur</string>

--- a/app/src/main/res/values-el/strings_preference.xml
+++ b/app/src/main/res/values-el/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Γενικές Ρυθμίσεις</string>
     <string name="fee_title">Προμήθεια συναλλαγής εξωτερικού</string>
-    <string name="fee_summary">Ανάλογα με το συμβόλαιο της πιστωτικής σας κάρτας, η τράπεζα σας μπορεί να χρεώνει προμήθεια για όλες τις συναλλαγές συναλλάγματος. Εδώ μπορείτε να εισάγετε αυτό το τέλος. Θα προστεθεί στον υπολογισμό, ώστε να γνωρίζετε πόσα <i>πραγματικά</i> πληρώνετε.</string>
+    <string name="fee_summary">Διαχείριση προμηθειών συναλλάγματος, τράπεζας/κάρτας και ανά ζεύγος νομισμάτων</string>
+    <string name="fee_manager_title">Προμήθειες</string>
+    <string name="fee_side_label">Πλευρά προμήθειας</string>
+    <string name="fee_side_original">Αρχικό</string>
+    <string name="fee_side_converted">Μετατραπέν</string>
+    <string name="fee_section_global_exchange">Καθολική προμήθεια συναλλάγματος</string>
+    <string name="fee_section_global_bank">Καθολική προμήθεια τράπεζας/κάρτας</string>
+    <string name="fee_section_specific_pair">Προμήθεια συγκεκριμένου ζεύγους νομισμάτων</string>
+    <string name="fee_add">Προσθήκη προμήθειας</string>
+    <string name="fee_delete">Διαγραφή</string>
+    <string name="fee_edit_percent">Ποσοστό</string>
+    <string name="fee_pair_both_ways">Και οι δύο κατευθύνσεις</string>
+    <string name="fee_pair_from">Από</string>
+    <string name="fee_pair_to">Προς</string>
+    <string name="fee_pair_pick_currency">Επιλέξτε νόμισμα</string>
+    <string name="fee_true_cost_prefix">"Πραγματικό κόστος: "</string>
+    <string name="fee_side_summary_original">Το εμφανιζόμενο μετατραπέν ποσό παραμένει στη μέση τιμή αγοράς· οι προμήθειες εμφανίζονται ξεχωριστά ως \"πραγματικό κόστος\".</string>
+    <string name="fee_side_summary_converted">Οι προμήθειες περιλαμβάνονται στο εμφανιζόμενο μετατραπέν ποσό.</string>
+    <string name="fee_empty">Δεν υπάρχουν ακόμη προμήθειες</string>
     <string name="previewConversion_title">Προεπισκόπηση ισοτιμίας</string>
     <string name="previewConversion_summary">Εμφάνιση της ισοτιμίας κάθε νομίσματος στον επιλογέα νομισμάτων.</string>
     <string name="keyboard_title">Πληκτρολόγιο</string>

--- a/app/src/main/res/values-eo/strings_preference.xml
+++ b/app/src/main/res/values-eo/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Ĝeneralaj Agordoj</string>
     <string name="fee_title">Eksterlanda transakcia kotizo</string>
-    <string name="fee_summary">Depende de via kreditkarta interkonsento, via banko povas kosti kotizon por ĉiuj eksterlandaj transakcioj. Ĉi tie vi povas enigi tiun kotizon. Ĝi estos aldonita al la kalkulo, do vi sciu kiom vi <i>vere</i> pagas.</string>
+    <string name="fee_summary">Administri interŝanĝajn, bankajn/kartajn kaj para-specifajn kotizojn</string>
+    <string name="fee_manager_title">Kotizoj</string>
+    <string name="fee_side_label">Flanko de la kotizo</string>
+    <string name="fee_side_original">Originala</string>
+    <string name="fee_side_converted">Konvertita</string>
+    <string name="fee_section_global_exchange">Ĝenerala interŝanĝa kotizo</string>
+    <string name="fee_section_global_bank">Ĝenerala banka/karta kotizo</string>
+    <string name="fee_section_specific_pair">Kotizo por specifa valuta paro</string>
+    <string name="fee_add">Aldoni kotizon</string>
+    <string name="fee_delete">Forigi</string>
+    <string name="fee_edit_percent">Procento</string>
+    <string name="fee_pair_both_ways">Ambaŭ direktoj</string>
+    <string name="fee_pair_from">De</string>
+    <string name="fee_pair_to">Al</string>
+    <string name="fee_pair_pick_currency">Elekti valuton</string>
+    <string name="fee_true_cost_prefix">"Vera kosto: "</string>
+    <string name="fee_side_summary_original">La montrata konvertita sumo restas ĉe la mez-merkata kurzo; kotizoj estas montrataj aparte kiel \"vera kosto\".</string>
+    <string name="fee_side_summary_converted">Kotizoj estas inkluzivitaj en la montrata konvertita sumo.</string>
+    <string name="fee_empty">Neniuj kotizoj ankoraŭ</string>
     <string name="previewConversion_title">Antaŭrigardo de konvertiĝo</string>
     <string name="previewConversion_summary">Montri la nunan konvertiĝon por ĉiu kurzo en la valutelektilo.</string>
     <string name="keyboard_title">Klavaro</string>

--- a/app/src/main/res/values-es/strings_preference.xml
+++ b/app/src/main/res/values-es/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Configuración general</string>
-    <string name="fee_title">Tasa de transacción extranjera</string>
-    <string name="fee_summary">Dependiendo del acuerdo de su tarjeta de crédito, su banco puede cobrar una comisión por todas las transacciones de cambio de divisas. Aquí puedes introducir esa comisión. Se añadirá al cálculo, para que sepas cuánto pagas <i>realmente</i>.</string>
+    <string name="fee_title">Comisión por transacción extranjera</string>
+    <string name="fee_summary">Administra comisiones de cambio, banco/tarjeta y específicas por par</string>
+    <string name="fee_manager_title">Comisiones</string>
+    <string name="fee_side_label">Lado de la comisión</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Convertido</string>
+    <string name="fee_section_global_exchange">Comisión global de cambio</string>
+    <string name="fee_section_global_bank">Comisión global de banco/tarjeta</string>
+    <string name="fee_section_specific_pair">Comisión de cambio de par específico</string>
+    <string name="fee_add">Añadir comisión</string>
+    <string name="fee_delete">Eliminar</string>
+    <string name="fee_edit_percent">Porcentaje</string>
+    <string name="fee_pair_both_ways">Ambas direcciones</string>
+    <string name="fee_pair_from">De</string>
+    <string name="fee_pair_to">A</string>
+    <string name="fee_pair_pick_currency">Selecciona moneda</string>
+    <string name="fee_true_cost_prefix">"Coste real: "</string>
+    <string name="fee_side_summary_original">El importe convertido mostrado se mantiene al tipo medio de mercado; las comisiones se muestran por separado como \"coste real\".</string>
+    <string name="fee_side_summary_converted">Las comisiones están incluidas en el importe convertido mostrado.</string>
+    <string name="fee_empty">Aún no hay comisiones</string>
     <string name="previewConversion_title">Vista previa de la conversión</string>
     <string name="previewConversion_summary">Mostrar la conversión actual para cada tipo de cambio en el selector de moneda.</string>
     <string name="keyboard_title">Teclado</string>

--- a/app/src/main/res/values-et/strings_preference.xml
+++ b/app/src/main/res/values-et/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Üldised seadistused</string>
     <string name="fee_title">Valuutavahetuse teenustasu</string>
-    <string name="fee_summary">Valuutavahetuse kontor või krediitkaardi teenusepakkuja võivad kasutada eri vääringute konverteerimisel teenustasusid, mida sa saad siinkohal lisada. Kasutame seda valuutakursside arvutamisel ja seega saa tead, kui palju sa <i>tegelikult</i> maksad.</string>
+    <string name="fee_summary">Halda vahetus-, panga-/kaarditasusid ja konkreetsete valuutapaaride tasusid</string>
+    <string name="fee_manager_title">Teenustasud</string>
+    <string name="fee_side_label">Teenustasu pool</string>
+    <string name="fee_side_original">Algne</string>
+    <string name="fee_side_converted">Konverteeritud</string>
+    <string name="fee_section_global_exchange">Üldine vahetustasu</string>
+    <string name="fee_section_global_bank">Üldine panga-/kaarditasu</string>
+    <string name="fee_section_specific_pair">Konkreetse valuutapaari vahetustasu</string>
+    <string name="fee_add">Lisa teenustasu</string>
+    <string name="fee_delete">Kustuta</string>
+    <string name="fee_edit_percent">Protsent</string>
+    <string name="fee_pair_both_ways">Mõlemad suunad</string>
+    <string name="fee_pair_from">Kust</string>
+    <string name="fee_pair_to">Kuhu</string>
+    <string name="fee_pair_pick_currency">Vali valuuta</string>
+    <string name="fee_true_cost_prefix">"Tegelik hind: "</string>
+    <string name="fee_side_summary_original">Kuvatav konverteeritud summa jääb keskturukursile; teenustasud kuvatakse eraldi kui \"tegelik hind\".</string>
+    <string name="fee_side_summary_converted">Teenustasud on kuvatavasse konverteeritud summasse juba arvestatud.</string>
+    <string name="fee_empty">Teenustasusid veel pole</string>
     <string name="previewConversion_title">Konverteerimise eelvaade</string>
     <string name="previewConversion_summary">Näita valuutavalijas iga vääringu kohta viimast vahetuskurssi.</string>
     <string name="keyboard_title">Klaviatuur</string>

--- a/app/src/main/res/values-fa/strings_preference.xml
+++ b/app/src/main/res/values-fa/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">تنظیمات عمومی</string>
-    <string name="fee_title">کارمزد تراکنش های خارجی</string>
-    <string name="fee_summary">بسته به قرارداد کارت اعتباری شما، بانک شما ممکن است برای تمام تراکنش های ارزی کارمزدی دریافت کند. در اینجا می توانید آن هزینه را وارد کنید. به محاسبات اضافه می شود، بنابراین می دانید که <i>واقعاً</i> چقدر می پردازید.</string>
+    <string name="fee_title">کارمزد تراکنش‌های خارجی</string>
+    <string name="fee_summary">مدیریت کارمزدهای تبدیل، بانک/کارت و جفت‌ارزهای خاص</string>
+    <string name="fee_manager_title">کارمزدها</string>
+    <string name="fee_side_label">سمت کارمزد</string>
+    <string name="fee_side_original">اصلی</string>
+    <string name="fee_side_converted">تبدیل‌شده</string>
+    <string name="fee_section_global_exchange">کارمزد کلی تبدیل</string>
+    <string name="fee_section_global_bank">کارمزد کلی بانک/کارت</string>
+    <string name="fee_section_specific_pair">کارمزد تبدیل جفت‌ارز خاص</string>
+    <string name="fee_add">افزودن کارمزد</string>
+    <string name="fee_delete">حذف</string>
+    <string name="fee_edit_percent">درصد</string>
+    <string name="fee_pair_both_ways">هر دو جهت</string>
+    <string name="fee_pair_from">از</string>
+    <string name="fee_pair_to">به</string>
+    <string name="fee_pair_pick_currency">انتخاب ارز</string>
+    <string name="fee_true_cost_prefix">"هزینه واقعی: "</string>
+    <string name="fee_side_summary_original">مبلغ تبدیل‌شده نمایش داده شده در نرخ میانگین بازار می‌ماند؛ کارمزدها به‌طور جداگانه به‌عنوان \"هزینه واقعی\" نشان داده می‌شوند.</string>
+    <string name="fee_side_summary_converted">کارمزدها در مبلغ تبدیل‌شده نمایش داده شده لحاظ شده‌اند.</string>
+    <string name="fee_empty">هنوز کارمزدی وجود ندارد</string>
     <string name="previewConversion_title">پیش نمایش تبدیل</string>
     <string name="previewConversion_summary">تبدیل فعلی برای هر نرخ را در انتخابگر ارز نشان دهید.</string>
     <string name="keyboard_title">صفحه‌کلید</string>

--- a/app/src/main/res/values-fr/strings_preference.xml
+++ b/app/src/main/res/values-fr/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Paramètres généraux</string>
     <string name="fee_title">Frais de transaction à l\'étranger</string>
-    <string name="fee_summary">Selon votre contrat de carte de crédit, votre banque peut facturer des frais sur toutes les transactions de change. Vous pouvez saisir ici ces frais. Elle sera ajoutée en plus du calcul, afin que vous sachiez combien vous <i>réellement</i> payez.</string>
+    <string name="fee_summary">Gérer les frais de change, de banque/carte et spécifiques à une paire</string>
+    <string name="fee_manager_title">Frais</string>
+    <string name="fee_side_label">Côté des frais</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Converti</string>
+    <string name="fee_section_global_exchange">Frais de change globaux</string>
+    <string name="fee_section_global_bank">Frais bancaires/de carte globaux</string>
+    <string name="fee_section_specific_pair">Frais de change pour une paire spécifique</string>
+    <string name="fee_add">Ajouter des frais</string>
+    <string name="fee_delete">Supprimer</string>
+    <string name="fee_edit_percent">Pourcentage</string>
+    <string name="fee_pair_both_ways">Les deux sens</string>
+    <string name="fee_pair_from">De</string>
+    <string name="fee_pair_to">Vers</string>
+    <string name="fee_pair_pick_currency">Choisir une devise</string>
+    <string name="fee_true_cost_prefix">"Coût réel : "</string>
+    <string name="fee_side_summary_original">Le montant converti affiché reste au taux du marché moyen ; les frais sont affichés séparément comme \"coût réel\".</string>
+    <string name="fee_side_summary_converted">Les frais sont inclus dans le montant converti affiché.</string>
+    <string name="fee_empty">Aucun frais pour le moment</string>
     <string name="previewConversion_title">Aperçu de la conversion</string>
     <string name="previewConversion_summary">Afficher la conversion actuelle pour chaque taux dans le sélecteur de devises.</string>
     <string name="keyboard_title">Clavier</string>

--- a/app/src/main/res/values-hr/strings_preference.xml
+++ b/app/src/main/res/values-hr/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Opće postavke</string>
-    <string name="fee_title">Mjenjačka provizija</string>
-    <string name="fee_summary">Vaša banka može naplaćivati mjenjačku proviziju na sve transakcije u stranim valutama. Ovdje možete postaviti iznos provizije. Ta će se vrijednost nadodati preračunatom iznosu i tako vam prikazati koliko ćete <i>zaista</i> platiti.</string>
+    <string name="fee_title">Provizija za inozemne transakcije</string>
+    <string name="fee_summary">Upravljanje mjenjačkim, bankovnim/kartičnim provizijama i onima za pojedine parove</string>
+    <string name="fee_manager_title">Provizije</string>
+    <string name="fee_side_label">Strana provizije</string>
+    <string name="fee_side_original">Izvorna</string>
+    <string name="fee_side_converted">Preračunata</string>
+    <string name="fee_section_global_exchange">Globalna mjenjačka provizija</string>
+    <string name="fee_section_global_bank">Globalna bankovna/kartična provizija</string>
+    <string name="fee_section_specific_pair">Provizija za određeni valutni par</string>
+    <string name="fee_add">Dodaj proviziju</string>
+    <string name="fee_delete">Obriši</string>
+    <string name="fee_edit_percent">Postotak</string>
+    <string name="fee_pair_both_ways">Oba smjera</string>
+    <string name="fee_pair_from">Iz</string>
+    <string name="fee_pair_to">U</string>
+    <string name="fee_pair_pick_currency">Odaberi valutu</string>
+    <string name="fee_true_cost_prefix">"Stvarna cijena: "</string>
+    <string name="fee_side_summary_original">Prikazani preračunati iznos ostaje po srednjem tržišnom tečaju; provizije se prikazuju odvojeno kao \"stvarna cijena\".</string>
+    <string name="fee_side_summary_converted">Provizije su uključene u prikazani preračunati iznos.</string>
+    <string name="fee_empty">Još nema provizija</string>
     <string name="previewConversion_title">Pretpregled konverzije</string>
     <string name="previewConversion_summary">Prikazuje tečaj konverzije za svaku valutu u izborniku valuta.</string>
     <string name="keyboard_title">Tipkovnica</string>

--- a/app/src/main/res/values-hu/strings_preference.xml
+++ b/app/src/main/res/values-hu/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Általános beállítások</string>
-    <string name="fee_title">Tranzakciós díj</string>
-    <string name="fee_summary">Hitelkártya-szerződésedtől függően bankod díjat számíthat fel minden devizatranzakció után. Itt adhatod meg ezt a díjat. Ez hozzáadódik a számításhoz, így tudod, hogy mennyit fizetsz <i>de ténylegesen</i>.</string>
+    <string name="fee_title">Devizatranzakciós díj</string>
+    <string name="fee_summary">Váltási, banki/kártya- és pénznempár-specifikus díjak kezelése</string>
+    <string name="fee_manager_title">Díjak</string>
+    <string name="fee_side_label">Díj oldala</string>
+    <string name="fee_side_original">Eredeti</string>
+    <string name="fee_side_converted">Átváltott</string>
+    <string name="fee_section_global_exchange">Globális váltási díj</string>
+    <string name="fee_section_global_bank">Globális banki/kártyadíj</string>
+    <string name="fee_section_specific_pair">Adott pénznempár váltási díja</string>
+    <string name="fee_add">Díj hozzáadása</string>
+    <string name="fee_delete">Törlés</string>
+    <string name="fee_edit_percent">Százalék</string>
+    <string name="fee_pair_both_ways">Mindkét irány</string>
+    <string name="fee_pair_from">Innen</string>
+    <string name="fee_pair_to">Ide</string>
+    <string name="fee_pair_pick_currency">Válassz pénznemet</string>
+    <string name="fee_true_cost_prefix">"Valós költség: "</string>
+    <string name="fee_side_summary_original">A megjelenített átváltott összeg a középárfolyamon marad; a díjak külön jelennek meg \"valós költség\" néven.</string>
+    <string name="fee_side_summary_converted">A díjak bele vannak számítva a megjelenített átváltott összegbe.</string>
+    <string name="fee_empty">Még nincsenek díjak</string>
     <string name="previewConversion_title">Konverziós előnézet</string>
     <string name="previewConversion_summary">Az aktuális átváltás megjelenítése minden egyes árfolyamhoz a pénznemválasztóban.</string>
     <string name="keyboard_title">Billentyűzet</string>

--- a/app/src/main/res/values-in/strings_preference.xml
+++ b/app/src/main/res/values-in/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Pengaturan Umum</string>
     <string name="fee_title">Biaya transaksi luar negeri</string>
-    <string name="fee_summary">Tergantung kebijakan kartu kredit Anda, bank Anda mungkin mengenakan biaya untuk semua transaksi luar negeri. Di sini Anda dapat memasukkan biayanya. Ini akan ditambahkan ke hasil perhitungan, sehingga Anda tahu berapa yang <i>sebenarnya</i> Anda bayar.</string>
+    <string name="fee_summary">Kelola biaya penukaran, bank/kartu, dan biaya pasangan mata uang tertentu</string>
+    <string name="fee_manager_title">Biaya</string>
+    <string name="fee_side_label">Sisi biaya</string>
+    <string name="fee_side_original">Asli</string>
+    <string name="fee_side_converted">Dikonversi</string>
+    <string name="fee_section_global_exchange">Biaya penukaran global</string>
+    <string name="fee_section_global_bank">Biaya bank/kartu global</string>
+    <string name="fee_section_specific_pair">Biaya penukaran pasangan mata uang tertentu</string>
+    <string name="fee_add">Tambah biaya</string>
+    <string name="fee_delete">Hapus</string>
+    <string name="fee_edit_percent">Persen</string>
+    <string name="fee_pair_both_ways">Kedua arah</string>
+    <string name="fee_pair_from">Dari</string>
+    <string name="fee_pair_to">Ke</string>
+    <string name="fee_pair_pick_currency">Pilih mata uang</string>
+    <string name="fee_true_cost_prefix">"Biaya sebenarnya: "</string>
+    <string name="fee_side_summary_original">Jumlah konversi yang ditampilkan tetap pada kurs tengah pasar; biaya ditampilkan terpisah sebagai \"biaya sebenarnya\".</string>
+    <string name="fee_side_summary_converted">Biaya sudah termasuk dalam jumlah konversi yang ditampilkan.</string>
+    <string name="fee_empty">Belum ada biaya</string>
     <string name="previewConversion_title">Pratinjau konversi</string>
     <string name="previewConversion_summary">Tampilkan konversi yang dilakukan untuk setiap nilai tukar pada pemilihan mata uang.</string>
     <string name="keyboard_title">Keyboard</string>

--- a/app/src/main/res/values-is/strings_preference.xml
+++ b/app/src/main/res/values-is/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Almennar stillingar</string>
     <string name="fee_title">Gjaldeyrisviðskiptagjald</string>
-    <string name="fee_summary">Bankinn þinn gæti innheimt gjald fyrir öll gjaldeyrisviðskipti. Hér er hægt að slá því inn svo þú veist hversu mikið þú borgar <i>í raun</i> .</string>
+    <string name="fee_summary">Umsjón með skipti-, banka-/kortagjöldum og gjöldum fyrir tiltekin gjaldmiðlapör</string>
+    <string name="fee_manager_title">Gjöld</string>
+    <string name="fee_side_label">Hlið gjalds</string>
+    <string name="fee_side_original">Upprunalegt</string>
+    <string name="fee_side_converted">Umreiknað</string>
+    <string name="fee_section_global_exchange">Almennt skiptigjald</string>
+    <string name="fee_section_global_bank">Almennt banka-/kortagjald</string>
+    <string name="fee_section_specific_pair">Skiptigjald fyrir tiltekið gjaldmiðlapar</string>
+    <string name="fee_add">Bæta við gjaldi</string>
+    <string name="fee_delete">Eyða</string>
+    <string name="fee_edit_percent">Prósent</string>
+    <string name="fee_pair_both_ways">Báðar áttir</string>
+    <string name="fee_pair_from">Frá</string>
+    <string name="fee_pair_to">Til</string>
+    <string name="fee_pair_pick_currency">Veldu gjaldmiðil</string>
+    <string name="fee_true_cost_prefix">"Raunverulegur kostnaður: "</string>
+    <string name="fee_side_summary_original">Sýnd umreiknuð upphæð helst á miðgengi; gjöld eru sýnd sérstaklega sem \"raunverulegur kostnaður\".</string>
+    <string name="fee_side_summary_converted">Gjöld eru innifalin í sýndri umreiknaðri upphæð.</string>
+    <string name="fee_empty">Engin gjöld ennþá</string>
     <string name="previewConversion_title">Skiptisforskoðun</string>
     <string name="previewConversion_summary">Sýna núverandi gjaldmiðlaskipti fyrir hvert gengi í gjaldeyrisvalinu.</string>
     <string name="keyboard_title">Lyklaborð</string>

--- a/app/src/main/res/values-it/strings_preference.xml
+++ b/app/src/main/res/values-it/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Impostazioni generali</string>
-    <string name="fee_title">Tassa per transazioni estere</string>
-    <string name="fee_summary">A seconda del contratto della vostra carta di credito, la vostra banca potrebbe addebitare una commissione su tutte le transazioni in valuta estera. Qui puoi inserire questa tassa. Verrà aggiunta in cima al calcolo, così saprai quanto <i>realmente</i> paghi.</string>
+    <string name="fee_title">Commissione per transazioni estere</string>
+    <string name="fee_summary">Gestisci commissioni di cambio, banca/carta e specifiche per coppia</string>
+    <string name="fee_manager_title">Commissioni</string>
+    <string name="fee_side_label">Lato della commissione</string>
+    <string name="fee_side_original">Originale</string>
+    <string name="fee_side_converted">Convertito</string>
+    <string name="fee_section_global_exchange">Commissione di cambio globale</string>
+    <string name="fee_section_global_bank">Commissione banca/carta globale</string>
+    <string name="fee_section_specific_pair">Commissione per coppia di valute specifica</string>
+    <string name="fee_add">Aggiungi commissione</string>
+    <string name="fee_delete">Elimina</string>
+    <string name="fee_edit_percent">Percentuale</string>
+    <string name="fee_pair_both_ways">Entrambe le direzioni</string>
+    <string name="fee_pair_from">Da</string>
+    <string name="fee_pair_to">A</string>
+    <string name="fee_pair_pick_currency">Seleziona valuta</string>
+    <string name="fee_true_cost_prefix">"Costo reale: "</string>
+    <string name="fee_side_summary_original">L\'importo convertito mostrato resta al tasso medio di mercato; le commissioni sono mostrate separatamente come \"costo reale\".</string>
+    <string name="fee_side_summary_converted">Le commissioni sono già incluse nell\'importo convertito mostrato.</string>
+    <string name="fee_empty">Ancora nessuna commissione</string>
     <string name="previewConversion_title">Anteprima di conversione</string>
     <string name="previewConversion_summary">Mostra la conversione corrente per ogni tasso nel selezionatore di valuta.</string>
     <string name="keyboard_title">Tastiera</string>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -20,7 +20,7 @@
     <string name="fee_pair_to">אל</string>
     <string name="fee_pair_pick_currency">בחר מטבע</string>
     <string name="fee_true_cost_prefix">"עלות אמיתית: "</string>
-    <string name="fee_side_summary_original">הסכום המומר המוצג נשאר בשער האמצע של השוק; העמלות מוצגות בנפרד בתור \"עלות אמיתית\".</string>
+    <string name="fee_side_summary_original">הסכום המומר המוצג נשאר בשער היציג; העמלות מוצגות בנפרד בתור \"עלות אמיתית\".</string>
     <string name="fee_side_summary_converted">העמלות כלולות בסכום המומר המוצג.</string>
     <string name="fee_empty">אין עמלות עדיין</string>
     <string name="previewConversion_title">תצוגה מקדימה להמרה</string>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">הגדרות כלליות</string>
-    <string name="fee_title">עמלת עסקה זרה</string>
-    <string name="fee_summary">בהתאם להסכמים על כרטיס האשראי שלך, הבנק שלך עלול לחייב עמלה על כל עסקאות החליפין הזרות. כאן ניתן למלא את העמלה הזאת. היא תתווסף לחישוב כדי לאפשר לך לדעת כמה התשלום <i>באמת</i>.</string>
+    <string name="fee_title">עמלת עסקה במטבע זר</string>
+    <string name="fee_summary">ניהול עמלות המרה, בנק/כרטיס ועמלות לזוגות מטבעות ספציפיים</string>
+    <string name="fee_manager_title">עמלות</string>
+    <string name="fee_side_label">צד העמלה</string>
+    <string name="fee_side_original">מקורי</string>
+    <string name="fee_side_converted">מומר</string>
+    <string name="fee_section_global_exchange">עמלת המרה גלובלית</string>
+    <string name="fee_section_global_bank">עמלת בנק/כרטיס גלובלית</string>
+    <string name="fee_section_specific_pair">עמלת המרה לזוג מטבעות ספציפי</string>
+    <string name="fee_add">הוסף עמלה</string>
+    <string name="fee_delete">מחק</string>
+    <string name="fee_edit_percent">אחוז</string>
+    <string name="fee_pair_both_ways">שני הכיוונים</string>
+    <string name="fee_pair_from">מ־</string>
+    <string name="fee_pair_to">אל</string>
+    <string name="fee_pair_pick_currency">בחר מטבע</string>
+    <string name="fee_true_cost_prefix">"עלות אמיתית: "</string>
+    <string name="fee_side_summary_original">הסכום המומר המוצג נשאר בשער האמצע של השוק; העמלות מוצגות בנפרד בתור \"עלות אמיתית\".</string>
+    <string name="fee_side_summary_converted">העמלות כלולות בסכום המומר המוצג.</string>
+    <string name="fee_empty">אין עמלות עדיין</string>
     <string name="previewConversion_title">תצוגה מקדימה להמרה</string>
     <string name="previewConversion_summary">הצגת ההמרה הנוכחית לכל שער בבורר המטבעות.</string>
     <string name="keyboard_title">מקלדת</string>

--- a/app/src/main/res/values-ml/strings_preference.xml
+++ b/app/src/main/res/values-ml/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">പൊതു ക്രമീകരണങ്ങൾ</string>
     <string name="fee_title">വിദേശ ഇടപാട് ഫീസ്</string>
-    <string name="fee_summary">നിങ്ങളുടെ ക്രെഡിറ്റ് കാർഡ് കരാർ അനുസരിച്ച്, നിങ്ങളുടെ ബാങ്ക് എല്ലാ വിദേശ വിനിമയ ഇടപാടുകൾക്കും ഒരു ഫീസ് ഈടാക്കിയേക്കാം. ഇവിടെ നിങ്ങൾക്ക് ആ ഫീസ് നൽകാം. അത് കണക്കുകൂട്ടലിനു മുകളിൽ ചേർക്കപ്പെടും, അതിനാൽ നിങ്ങൾ <i>യഥാർത്ഥത്തിൽ</i> എത്ര നൽകുന്നുവെന്ന് നിങ്ങൾക്കറിയാം.</string>
+    <string name="fee_summary">വിനിമയ, ബാങ്ക്/കാർഡ്, കറൻസി ജോഡി അടിസ്ഥാനത്തിലുള്ള ഫീസുകൾ കൈകാര്യം ചെയ്യുക</string>
+    <string name="fee_manager_title">ഫീസുകൾ</string>
+    <string name="fee_side_label">ഫീസ് വശം</string>
+    <string name="fee_side_original">യഥാർത്ഥം</string>
+    <string name="fee_side_converted">പരിവർത്തിതം</string>
+    <string name="fee_section_global_exchange">ആഗോള വിനിമയ ഫീസ്</string>
+    <string name="fee_section_global_bank">ആഗോള ബാങ്ക്/കാർഡ് ഫീസ്</string>
+    <string name="fee_section_specific_pair">നിർദ്ദിഷ്ട കറൻസി ജോഡിയുടെ വിനിമയ ഫീസ്</string>
+    <string name="fee_add">ഫീസ് ചേർക്കുക</string>
+    <string name="fee_delete">ഇല്ലാതാക്കുക</string>
+    <string name="fee_edit_percent">ശതമാനം</string>
+    <string name="fee_pair_both_ways">ഇരു ദിശകളും</string>
+    <string name="fee_pair_from">നിന്ന്</string>
+    <string name="fee_pair_to">ലേക്ക്</string>
+    <string name="fee_pair_pick_currency">കറൻസി തിരഞ്ഞെടുക്കുക</string>
+    <string name="fee_true_cost_prefix">"യഥാർത്ഥ ചെലവ്: "</string>
+    <string name="fee_side_summary_original">പ്രദർശിപ്പിച്ച പരിവർത്തിത തുക മധ്യ-വിപണി നിരക്കിൽ തുടരും; ഫീസുകൾ പ്രത്യേകമായി \"യഥാർത്ഥ ചെലവ്\" ആയി കാണിക്കുന്നു.</string>
+    <string name="fee_side_summary_converted">ഫീസുകൾ പ്രദർശിപ്പിച്ച പരിവർത്തിത തുകയിൽ ഉൾപ്പെടുത്തിയിരിക്കുന്നു.</string>
+    <string name="fee_empty">ഇതുവരെ ഫീസുകളില്ല</string>
     <string name="previewConversion_title">പരിവർത്തന പ്രിവ്യൂ</string>
     <string name="previewConversion_summary">കറൻസി പിക്കറിൽ ഓരോ നിരക്കിന്റെയും നിലവിലെ പരിവർത്തനം കാണിക്കുക.</string>
     <string name="keyboard_title">കീബോർഡ്</string>

--- a/app/src/main/res/values-nb/strings_preference.xml
+++ b/app/src/main/res/values-nb/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Generelle innstillinger</string>
     <string name="fee_title">Valutagebyr</string>
-    <string name="fee_summary">Avhengig av avtalen for ditt bankkort kan banken din ta en avgift for alle vekslinger i utenlandsk valuta. Her kan du skrive inn dette gebyret. Det vil bli lagt til på toppen av utregningen, slik at du vet hvor mye du <i>virkelig</i> betaler.</string>
+    <string name="fee_summary">Administrer veksel-, bank-/kortgebyrer og gebyrer for spesifikke valutapar</string>
+    <string name="fee_manager_title">Gebyrer</string>
+    <string name="fee_side_label">Gebyrside</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Konvertert</string>
+    <string name="fee_section_global_exchange">Globalt vekslingsgebyr</string>
+    <string name="fee_section_global_bank">Globalt bank-/kortgebyr</string>
+    <string name="fee_section_specific_pair">Vekslingsgebyr for spesifikt valutapar</string>
+    <string name="fee_add">Legg til gebyr</string>
+    <string name="fee_delete">Slett</string>
+    <string name="fee_edit_percent">Prosent</string>
+    <string name="fee_pair_both_ways">Begge retninger</string>
+    <string name="fee_pair_from">Fra</string>
+    <string name="fee_pair_to">Til</string>
+    <string name="fee_pair_pick_currency">Velg valuta</string>
+    <string name="fee_true_cost_prefix">"Reell kostnad: "</string>
+    <string name="fee_side_summary_original">Det viste konverterte beløpet holder seg til midtkurs; gebyrer vises separat som \"reell kostnad\".</string>
+    <string name="fee_side_summary_converted">Gebyrer er inkludert i det viste konverterte beløpet.</string>
+    <string name="fee_empty">Ingen gebyrer ennå</string>
     <string name="previewConversion_title">Vekslingsoverslag</string>
     <string name="previewConversion_summary">Nåværende vekslingssats for hver kurs i valutavelgeren.</string>
     <string name="keyboard_title">Tastatur</string>

--- a/app/src/main/res/values-nl/strings_preference.xml
+++ b/app/src/main/res/values-nl/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Algemene instellingen</string>
     <string name="fee_title">Buitenlandse transactiekosten</string>
-    <string name="fee_summary">Afhankelijk van uw creditcard overeenkomst kan uw bank kosten in rekening brengen voor alle valuta transacties. Hier kunt u die kosten invullen. Deze worden bij de berekening opgeteld, zodat u weet hoeveel u <i>echt</i> betaalt.</string>
+    <string name="fee_summary">Beheer wissel-, bank-/kaartkosten en kosten voor specifieke valutaparen</string>
+    <string name="fee_manager_title">Kosten</string>
+    <string name="fee_side_label">Kant van de kosten</string>
+    <string name="fee_side_original">Origineel</string>
+    <string name="fee_side_converted">Geconverteerd</string>
+    <string name="fee_section_global_exchange">Globale wisselkosten</string>
+    <string name="fee_section_global_bank">Globale bank-/kaartkosten</string>
+    <string name="fee_section_specific_pair">Wisselkosten voor specifiek valutapaar</string>
+    <string name="fee_add">Kosten toevoegen</string>
+    <string name="fee_delete">Verwijderen</string>
+    <string name="fee_edit_percent">Percentage</string>
+    <string name="fee_pair_both_ways">Beide richtingen</string>
+    <string name="fee_pair_from">Van</string>
+    <string name="fee_pair_to">Naar</string>
+    <string name="fee_pair_pick_currency">Selecteer valuta</string>
+    <string name="fee_true_cost_prefix">"Werkelijke kosten: "</string>
+    <string name="fee_side_summary_original">Het weergegeven geconverteerde bedrag blijft op de middenkoers; kosten worden apart weergegeven als \"werkelijke kosten\".</string>
+    <string name="fee_side_summary_converted">Kosten zijn verwerkt in het weergegeven geconverteerde bedrag.</string>
+    <string name="fee_empty">Nog geen kosten</string>
     <string name="previewConversion_title">Conversie voorbeeld</string>
     <string name="previewConversion_summary">Toon de huidige conversie voor elke koers in de valutakiezer.</string>
     <string name="keyboard_title">Toetsenbord</string>

--- a/app/src/main/res/values-pl/strings_preference.xml
+++ b/app/src/main/res/values-pl/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Ustawienia ogólne</string>
     <string name="fee_title">Opłata za transakcję zagraniczną</string>
-    <string name="fee_summary">W zależności od umowy dotyczącej Twojej karty kredytowej, Twój bank może pobrać dodatkową opłatę za wszelkie transakcje zagraniczne. Tutaj możesz podać jej wysokość. Zostanie ona dodana do sumy do zapłaty, dzięki czemu będziesz wiedzieć ile <i>rzeczywiście</i> zapłacisz.</string>
+    <string name="fee_summary">Zarządzaj opłatami wymiany, bankowymi/kartowymi oraz specyficznymi dla par walut</string>
+    <string name="fee_manager_title">Opłaty</string>
+    <string name="fee_side_label">Strona opłaty</string>
+    <string name="fee_side_original">Oryginalna</string>
+    <string name="fee_side_converted">Przeliczona</string>
+    <string name="fee_section_global_exchange">Globalna opłata za wymianę</string>
+    <string name="fee_section_global_bank">Globalna opłata bankowa/kartowa</string>
+    <string name="fee_section_specific_pair">Opłata za wymianę dla określonej pary walut</string>
+    <string name="fee_add">Dodaj opłatę</string>
+    <string name="fee_delete">Usuń</string>
+    <string name="fee_edit_percent">Procent</string>
+    <string name="fee_pair_both_ways">Oba kierunki</string>
+    <string name="fee_pair_from">Z</string>
+    <string name="fee_pair_to">Na</string>
+    <string name="fee_pair_pick_currency">Wybierz walutę</string>
+    <string name="fee_true_cost_prefix">"Rzeczywisty koszt: "</string>
+    <string name="fee_side_summary_original">Wyświetlana przeliczona kwota pozostaje po średnim kursie rynkowym; opłaty są pokazywane osobno jako \"rzeczywisty koszt\".</string>
+    <string name="fee_side_summary_converted">Opłaty są uwzględnione w wyświetlanej przeliczonej kwocie.</string>
+    <string name="fee_empty">Brak opłat</string>
     <string name="previewConversion_title">Podgląd konwersji</string>
     <string name="previewConversion_summary">Pokaż obecny kurs w ekranie wyboru waluty.</string>
     <string name="keyboard_title">Klawiatura</string>

--- a/app/src/main/res/values-pt-rBR/strings_preference.xml
+++ b/app/src/main/res/values-pt-rBR/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Configurações Gerais</string>
     <string name="fee_title">Taxa de transação estrangeira</string>
-    <string name="fee_summary">Dependendo do seu contrato de cartão de crédito, seu banco pode cobrar uma taxa em todas as transações de câmbio. Aqui você pode inserir essa taxa. Ele será adicionado no topo do cálculo, para que você saiba quanto você <i>realmente</i> paga.</string>
+    <string name="fee_summary">Gerencie taxas de câmbio, banco/cartão e específicas por par de moedas</string>
+    <string name="fee_manager_title">Taxas</string>
+    <string name="fee_side_label">Lado da taxa</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Convertido</string>
+    <string name="fee_section_global_exchange">Taxa global de câmbio</string>
+    <string name="fee_section_global_bank">Taxa global de banco/cartão</string>
+    <string name="fee_section_specific_pair">Taxa de câmbio para par específico</string>
+    <string name="fee_add">Adicionar taxa</string>
+    <string name="fee_delete">Excluir</string>
+    <string name="fee_edit_percent">Porcentagem</string>
+    <string name="fee_pair_both_ways">Ambas as direções</string>
+    <string name="fee_pair_from">De</string>
+    <string name="fee_pair_to">Para</string>
+    <string name="fee_pair_pick_currency">Selecionar moeda</string>
+    <string name="fee_true_cost_prefix">"Custo real: "</string>
+    <string name="fee_side_summary_original">O valor convertido exibido permanece na taxa média de mercado; as taxas são mostradas separadamente como \"custo real\".</string>
+    <string name="fee_side_summary_converted">As taxas estão incluídas no valor convertido exibido.</string>
+    <string name="fee_empty">Ainda não há taxas</string>
     <string name="previewConversion_title">Previsão da conversão</string>
     <string name="previewConversion_summary">Mostrar a conversão atual para cada taxa no selecionador de moeda.</string>
     <string name="keyboard_title">Teclado</string>

--- a/app/src/main/res/values-ru/strings_preference.xml
+++ b/app/src/main/res/values-ru/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Основные настройки</string>
     <string name="fee_title">Комиссия за международный перевод</string>
-    <string name="fee_summary">В зависимости от вашего договора по кредитной карте, ваш банк может взымать комиссию за все международные переводы. Здесь вы можете ввести эту комиссию. Она будет добавлена в итоговую сумму, чтобы вы знали, сколько вы <i>действительно</i> заплатите.</string>
+    <string name="fee_summary">Управление комиссиями обмена, банка/карты и по конкретным парам валют</string>
+    <string name="fee_manager_title">Комиссии</string>
+    <string name="fee_side_label">Сторона комиссии</string>
+    <string name="fee_side_original">Исходная</string>
+    <string name="fee_side_converted">Конвертированная</string>
+    <string name="fee_section_global_exchange">Общая комиссия за обмен</string>
+    <string name="fee_section_global_bank">Общая комиссия банка/карты</string>
+    <string name="fee_section_specific_pair">Комиссия за обмен конкретной пары валют</string>
+    <string name="fee_add">Добавить комиссию</string>
+    <string name="fee_delete">Удалить</string>
+    <string name="fee_edit_percent">Процент</string>
+    <string name="fee_pair_both_ways">Оба направления</string>
+    <string name="fee_pair_from">Из</string>
+    <string name="fee_pair_to">В</string>
+    <string name="fee_pair_pick_currency">Выбрать валюту</string>
+    <string name="fee_true_cost_prefix">"Реальная стоимость: "</string>
+    <string name="fee_side_summary_original">Отображаемая конвертированная сумма остаётся по среднерыночному курсу; комиссии показываются отдельно как \"реальная стоимость\".</string>
+    <string name="fee_side_summary_converted">Комиссии уже включены в отображаемую конвертированную сумму.</string>
+    <string name="fee_empty">Комиссий пока нет</string>
     <string name="previewConversion_title">Предпросмотр обменных курсов</string>
     <string name="previewConversion_summary">Показывать текущий обменный курс для каждой валюты в меню выбора валют.</string>
     <string name="keyboard_title">Клавиатура</string>

--- a/app/src/main/res/values-sv/strings_preference.xml
+++ b/app/src/main/res/values-sv/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Allmänna inställningar</string>
-    <string name="fee_title">Växlingspåslag</string>
-    <string name="fee_summary">Beroende på ditt avtal för ditt betalkort, så kan din bank ta ut en avgift på transaktioner i utländsk valuta. Här kan du ange vilken avgift du har. Den kommer att läggas på ovanpå kursberäkningarna, så att du vet hur mycket du <i>faktiskt</i> får betala.</string>
+    <string name="fee_title">Utländsk transaktionsavgift</string>
+    <string name="fee_summary">Hantera växlings-, bank-/kortavgifter och avgifter för specifika valutapar</string>
+    <string name="fee_manager_title">Avgifter</string>
+    <string name="fee_side_label">Avgiftssida</string>
+    <string name="fee_side_original">Original</string>
+    <string name="fee_side_converted">Konverterad</string>
+    <string name="fee_section_global_exchange">Global växlingsavgift</string>
+    <string name="fee_section_global_bank">Global bank-/kortavgift</string>
+    <string name="fee_section_specific_pair">Växlingsavgift för specifikt valutapar</string>
+    <string name="fee_add">Lägg till avgift</string>
+    <string name="fee_delete">Ta bort</string>
+    <string name="fee_edit_percent">Procent</string>
+    <string name="fee_pair_both_ways">Båda riktningarna</string>
+    <string name="fee_pair_from">Från</string>
+    <string name="fee_pair_to">Till</string>
+    <string name="fee_pair_pick_currency">Välj valuta</string>
+    <string name="fee_true_cost_prefix">"Faktisk kostnad: "</string>
+    <string name="fee_side_summary_original">Det visade konverterade beloppet är kvar till mittkursen; avgifter visas separat som \"faktisk kostnad\".</string>
+    <string name="fee_side_summary_converted">Avgifter är inräknade i det visade konverterade beloppet.</string>
+    <string name="fee_empty">Inga avgifter ännu</string>
     <string name="previewConversion_title">Förhandsvisa konverteringar</string>
     <string name="previewConversion_summary">Visa konvertering för varje valuta i valutaväljaren.</string>
     <string name="keyboard_title">Tangentbord</string>

--- a/app/src/main/res/values-tr/strings_preference.xml
+++ b/app/src/main/res/values-tr/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">General Ayala</string>
     <string name="fee_title">Döviz işlem ücreti</string>
-    <string name="fee_summary">Bankan, kredi kartı sözleşmene bağlı olarak tüm döviz işlemlerinden bir işlem ücreti alabilir. Bu ücreti buraya girebilirsin. Bu miktar hesaplamaya eklenecek, böylece <i>tam olarak</i> ne kadar ödeme yapacağını öğrenebilirsin.</string>
+    <string name="fee_summary">Kur, banka/kart ve belirli para birimi çiftlerine özel ücretleri yönet</string>
+    <string name="fee_manager_title">Ücretler</string>
+    <string name="fee_side_label">Ücret tarafı</string>
+    <string name="fee_side_original">Orijinal</string>
+    <string name="fee_side_converted">Dönüştürülmüş</string>
+    <string name="fee_section_global_exchange">Genel kur ücreti</string>
+    <string name="fee_section_global_bank">Genel banka/kart ücreti</string>
+    <string name="fee_section_specific_pair">Belirli para birimi çifti için kur ücreti</string>
+    <string name="fee_add">Ücret ekle</string>
+    <string name="fee_delete">Sil</string>
+    <string name="fee_edit_percent">Yüzde</string>
+    <string name="fee_pair_both_ways">Her iki yön</string>
+    <string name="fee_pair_from">Kimden</string>
+    <string name="fee_pair_to">Kime</string>
+    <string name="fee_pair_pick_currency">Para birimi seç</string>
+    <string name="fee_true_cost_prefix">"Gerçek maliyet: "</string>
+    <string name="fee_side_summary_original">Gösterilen dönüştürülmüş tutar orta piyasa kurunda kalır; ücretler ayrı olarak \"gerçek maliyet\" şeklinde gösterilir.</string>
+    <string name="fee_side_summary_converted">Ücretler gösterilen dönüştürülmüş tutara dahil edilmiştir.</string>
+    <string name="fee_empty">Henüz ücret yok</string>
     <string name="previewConversion_title">Kur oranı önizlemesi</string>
     <string name="previewConversion_summary">Para birimi seçme ekranında mevcut kur oranlarını göster.</string>
     <string name="keyboard_title">Klavye</string>

--- a/app/src/main/res/values-uk/strings_preference.xml
+++ b/app/src/main/res/values-uk/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">Загальні налаштування</string>
-    <string name="fee_title">Комісія за міжнарожні тразакції</string>
-    <string name="fee_summary">Залежно від угоди вашої кредитної картки, ваш банк може стягувати комісію за всі операції обміну валюти. Тут ви можете ввести її розмір. Його буде додано до розрахунку, щоб ви знали, скільки ви <i>насправді</i> платите.</string>
+    <string name="fee_title">Комісія за міжнародні транзакції</string>
+    <string name="fee_summary">Керуйте комісіями обміну, банку/картки та специфічними для пар валют</string>
+    <string name="fee_manager_title">Комісії</string>
+    <string name="fee_side_label">Сторона комісії</string>
+    <string name="fee_side_original">Вихідна</string>
+    <string name="fee_side_converted">Конвертована</string>
+    <string name="fee_section_global_exchange">Глобальна комісія за обмін</string>
+    <string name="fee_section_global_bank">Глобальна комісія банку/картки</string>
+    <string name="fee_section_specific_pair">Комісія за обмін конкретної пари валют</string>
+    <string name="fee_add">Додати комісію</string>
+    <string name="fee_delete">Видалити</string>
+    <string name="fee_edit_percent">Відсоток</string>
+    <string name="fee_pair_both_ways">Обидва напрямки</string>
+    <string name="fee_pair_from">З</string>
+    <string name="fee_pair_to">На</string>
+    <string name="fee_pair_pick_currency">Виберіть валюту</string>
+    <string name="fee_true_cost_prefix">"Реальна вартість: "</string>
+    <string name="fee_side_summary_original">Показана конвертована сума залишається за середнім ринковим курсом; комісії відображаються окремо як \"реальна вартість\".</string>
+    <string name="fee_side_summary_converted">Комісії вже враховані в показаній конвертованій сумі.</string>
+    <string name="fee_empty">Комісій ще немає</string>
     <string name="previewConversion_title">Попередній перегляд обміну</string>
     <string name="previewConversion_summary">Показувати поточні ставки в списку валют.</string>
     <string name="keyboard_title">Клавіатура</string>

--- a/app/src/main/res/values-vi/strings_preference.xml
+++ b/app/src/main/res/values-vi/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">Cài đặt chung</string>
     <string name="fee_title">Phí giao dịch nước ngoài</string>
-    <string name="fee_summary">Tùy vào thỏa thuận thẻ tín dụng của bạn, ngân hàng của bạn có thể thu phí giao dịch trao đổi nước ngoài. Ở đây bạn có thể nhập phí đó. Nó sẽ được thêm vào phép tính, để bạn biết bạn <i>thực sự</i> trả bao nhiêu tiền.</string>
+    <string name="fee_summary">Quản lý phí chuyển đổi, ngân hàng/thẻ và phí cho cặp tiền tệ cụ thể</string>
+    <string name="fee_manager_title">Phí</string>
+    <string name="fee_side_label">Bên tính phí</string>
+    <string name="fee_side_original">Gốc</string>
+    <string name="fee_side_converted">Đã chuyển đổi</string>
+    <string name="fee_section_global_exchange">Phí chuyển đổi chung</string>
+    <string name="fee_section_global_bank">Phí ngân hàng/thẻ chung</string>
+    <string name="fee_section_specific_pair">Phí chuyển đổi cho cặp tiền tệ cụ thể</string>
+    <string name="fee_add">Thêm phí</string>
+    <string name="fee_delete">Xóa</string>
+    <string name="fee_edit_percent">Phần trăm</string>
+    <string name="fee_pair_both_ways">Cả hai chiều</string>
+    <string name="fee_pair_from">Từ</string>
+    <string name="fee_pair_to">Đến</string>
+    <string name="fee_pair_pick_currency">Chọn tiền tệ</string>
+    <string name="fee_true_cost_prefix">"Chi phí thực: "</string>
+    <string name="fee_side_summary_original">Số tiền chuyển đổi hiển thị giữ ở tỷ giá thị trường trung bình; phí được hiển thị riêng dưới dạng \"chi phí thực\".</string>
+    <string name="fee_side_summary_converted">Phí đã được tính sẵn trong số tiền chuyển đổi hiển thị.</string>
+    <string name="fee_empty">Chưa có phí nào</string>
     <string name="previewConversion_title">Xem trước chuyển đổi</string>
     <string name="previewConversion_summary">Hiện việc chuyển đổi hiện tại cho mỗi tỉ lệ ở trình chọn tiền tệ.</string>
     <string name="keyboard_title">Bàn phím</string>

--- a/app/src/main/res/values-zh-rCN/strings_preference.xml
+++ b/app/src/main/res/values-zh-rCN/strings_preference.xml
@@ -3,8 +3,26 @@
 <resources>
     <!-- main settings -->
     <string name="category_settings">常规设置</string>
-    <string name="fee_title">兑换手续费</string>
-    <string name="fee_summary">根据您的信用卡协议，您的银行可能对所有外汇交易收取费用。这个比例会被直接加上，这样能知道<i>最终</i>支付了多少钱。</string>
+    <string name="fee_title">外汇交易手续费</string>
+    <string name="fee_summary">管理汇兑、银行/银行卡以及特定货币对的手续费</string>
+    <string name="fee_manager_title">手续费</string>
+    <string name="fee_side_label">手续费一侧</string>
+    <string name="fee_side_original">原始</string>
+    <string name="fee_side_converted">已换算</string>
+    <string name="fee_section_global_exchange">全局汇兑手续费</string>
+    <string name="fee_section_global_bank">全局银行/银行卡手续费</string>
+    <string name="fee_section_specific_pair">特定货币对汇兑手续费</string>
+    <string name="fee_add">添加手续费</string>
+    <string name="fee_delete">删除</string>
+    <string name="fee_edit_percent">百分比</string>
+    <string name="fee_pair_both_ways">双向</string>
+    <string name="fee_pair_from">从</string>
+    <string name="fee_pair_to">到</string>
+    <string name="fee_pair_pick_currency">选择货币</string>
+    <string name="fee_true_cost_prefix">"实际成本："</string>
+    <string name="fee_side_summary_original">显示的换算金额保持中间市场汇率；手续费单独显示为\"实际成本\"。</string>
+    <string name="fee_side_summary_converted">手续费已计入显示的换算金额中。</string>
+    <string name="fee_empty">暂无手续费</string>
     <string name="previewConversion_title">预览</string>
     <string name="previewConversion_summary">在选择货币页面显示当前汇率。</string>
     <string name="keyboard_title">键盘</string>

--- a/app/src/main/res/values-zh-rTW/strings_preference.xml
+++ b/app/src/main/res/values-zh-rTW/strings_preference.xml
@@ -4,7 +4,25 @@
     <!-- main settings -->
     <string name="category_settings">一般設定</string>
     <string name="fee_title">外匯手續費</string>
-    <string name="fee_summary">根據您的信用卡合約，您的銀行可能會收取外匯手續費。這裡可以輸入，手續費會直接加上去，所以您會知道<i>實際</i>要付多少錢。</string>
+    <string name="fee_summary">管理匯兌、銀行/信用卡以及特定貨幣對的手續費</string>
+    <string name="fee_manager_title">手續費</string>
+    <string name="fee_side_label">手續費一側</string>
+    <string name="fee_side_original">原始</string>
+    <string name="fee_side_converted">已換算</string>
+    <string name="fee_section_global_exchange">全域匯兌手續費</string>
+    <string name="fee_section_global_bank">全域銀行/信用卡手續費</string>
+    <string name="fee_section_specific_pair">特定貨幣對匯兌手續費</string>
+    <string name="fee_add">新增手續費</string>
+    <string name="fee_delete">刪除</string>
+    <string name="fee_edit_percent">百分比</string>
+    <string name="fee_pair_both_ways">雙向</string>
+    <string name="fee_pair_from">從</string>
+    <string name="fee_pair_to">到</string>
+    <string name="fee_pair_pick_currency">選擇貨幣</string>
+    <string name="fee_true_cost_prefix">"實際成本："</string>
+    <string name="fee_side_summary_original">顯示的換算金額維持在中間市場匯率；手續費會單獨顯示為\"實際成本\"。</string>
+    <string name="fee_side_summary_converted">手續費已計入顯示的換算金額中。</string>
+    <string name="fee_empty">尚無手續費</string>
     <string name="previewConversion_title">匯率預覽</string>
     <string name="previewConversion_summary">在選擇貨幣頁面顯示目前匯率</string>
     <string name="keyboard_title">���盤</string>


### PR DESCRIPTION
## Summary
- Long-press on the fee-side arrow in the main screen now opens the Fees settings page directly (via a new `EXTRA_OPEN_FEES` intent extra on `PreferenceActivity`).
- Added translations for all 20 `fee_*` strings across every locale folder that ships a `strings_preference.xml` (31 locales). Where an existing `fee_title`/`fee_summary` translation carried the old credit-card-fee wording, it was replaced to match the new meaning.

## Test plan
- [ ] Long-press the up/down fee-side arrow on the main screen → Fees settings opens directly, back button returns to main.
- [ ] Short-tap the arrow still toggles Original ↔ Converted as before.
- [ ] Switch device language to a few of: de, fr, es, iw, ar, zh-rCN → Settings → Fees shows translated section headers, dialog labels, and true-cost prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)