### PR TITLE
feat(quick-conversions): example-amount popup with swap and fees

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -80,6 +80,7 @@ class MainActivity : BaseActivity() {
     private lateinit var tvInfoConversion: TextView
     private lateinit var tvInfoDate: TextView
     private lateinit var tvTrueCost: TextView
+    private lateinit var tvOriginalValue: TextView
     private lateinit var tvFeeBadge: TextView
     private lateinit var btnFeeSide: AppCompatImageButton
 
@@ -105,6 +106,7 @@ class MainActivity : BaseActivity() {
         this.tvInfoConversion = findViewById(R.id.textInfoConversion)
         this.tvInfoDate = findViewById(R.id.textInfoDate)
         this.tvTrueCost = findViewById(R.id.textTrueCost)
+        this.tvOriginalValue = findViewById(R.id.textOriginalValue)
         this.tvFeeBadge = findViewById(R.id.textFeeBadge)
         this.btnFeeSide = findViewById(R.id.btn_fee_side)
 
@@ -355,6 +357,7 @@ class MainActivity : BaseActivity() {
         viewModel.isHapticFeedbackEnabled.observe(this) { hapticEnabled = it }
         viewModel.getFeeSide().observe(this) { observeFeeSide(it) }
         viewModel.getTrueCost().observe(this) { observeTrueCost(it) }
+        viewModel.getOriginalValue().observe(this) { observeOriginalValue(it) }
         viewModel.getTotalStack().observe(this) { observeTotalStack(it) }
     }
 
@@ -396,6 +399,17 @@ class MainActivity : BaseActivity() {
         val amount = value.toHumanReadableNumber(this, decimalPlaces = 2)
         tvTrueCost.text = getString(R.string.fee_true_cost_prefix) + amount + " " + currency
         tvTrueCost.visibility = View.VISIBLE
+    }
+
+    private fun observeOriginalValue(value: BigDecimal?) {
+        if (value == null) {
+            tvOriginalValue.visibility = View.GONE
+            return
+        }
+        val currency = viewModel.getDestinationCurrency().value?.iso4217Alpha().orEmpty()
+        val amount = value.toHumanReadableNumber(this, decimalPlaces = 2)
+        tvOriginalValue.text = getString(R.string.fee_original_value_prefix) + amount + " " + currency
+        tvOriginalValue.visibility = View.VISIBLE
     }
 
     private fun observeExchangeRates(rates: ExchangeRates?) {

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -133,6 +133,13 @@ class MainActivity : BaseActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.settings -> { startActivity(Intent(this, PreferenceActivity().javaClass)); true }
+            R.id.fees -> {
+                startActivity(
+                    Intent(this, PreferenceActivity::class.java)
+                        .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
+                )
+                true
+            }
             R.id.refresh -> { viewModel.forceUpdateExchangeRate(); true }
             R.id.timeline -> openTimelineActivity()
             R.id.quick_conversions -> { openQuickConversionsDialog(); true }
@@ -374,8 +381,10 @@ class MainActivity : BaseActivity() {
         val effective = stack ?: one
         if (effective.compareTo(one) == 0) {
             tvFeeBadge.visibility = View.GONE
+            btnFeeSide.visibility = View.GONE
             return
         }
+        btnFeeSide.visibility = View.VISIBLE
         val deltaPercent = effective
             .subtract(one)
             .multiply(BigDecimal(100))

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -397,7 +397,7 @@ class MainActivity : BaseActivity() {
         }
         val currency = viewModel.getBaseCurrency().value?.iso4217Alpha().orEmpty()
         val amount = value.toHumanReadableNumber(this, decimalPlaces = 2)
-        tvTrueCost.text = getString(R.string.fee_true_cost_prefix) + amount + " " + currency
+        tvTrueCost.text = getString(R.string.fee_true_cost_prefix) + ltrIsolate("$amount $currency")
         tvTrueCost.visibility = View.VISIBLE
     }
 
@@ -408,9 +408,15 @@ class MainActivity : BaseActivity() {
         }
         val currency = viewModel.getDestinationCurrency().value?.iso4217Alpha().orEmpty()
         val amount = value.toHumanReadableNumber(this, decimalPlaces = 2)
-        tvOriginalValue.text = getString(R.string.fee_original_value_prefix) + amount + " " + currency
+        tvOriginalValue.text = getString(R.string.fee_original_value_prefix) + ltrIsolate("$amount $currency")
         tvOriginalValue.visibility = View.VISIBLE
     }
+
+    // Wrap in Unicode LTR isolate (U+2066 … U+2069) so the "<amount> <currency>"
+    // chunk stays glued together as one LTR unit under RTL locales — otherwise
+    // the neutral space between number and currency gets absorbed by the RTL
+    // paragraph and the currency code drifts to the opposite side of the label.
+    private fun ltrIsolate(s: String): String = "\u2066$s\u2069"
 
     private fun observeExchangeRates(rates: ExchangeRates?) {
         rates?.let {

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -133,9 +133,14 @@ class MainActivity : BaseActivity() {
             R.id.settings -> { startActivity(Intent(this, PreferenceActivity().javaClass)); true }
             R.id.refresh -> { viewModel.forceUpdateExchangeRate(); true }
             R.id.timeline -> openTimelineActivity()
+            R.id.quick_conversions -> { openQuickConversionsDialog(); true }
             R.id.date_picker -> { openHistoricalDatePicker(); true }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun openQuickConversionsDialog() {
+        QuickConversionsDialog().show(supportFragmentManager, null)
     }
 
     private fun openTimelineActivity(): Boolean {
@@ -294,6 +299,17 @@ class MainActivity : BaseActivity() {
             viewModel.setFeeSide(next)
         }
         btnFeeSide.setOnLongClickListener {
+            haptic(it)
+            startActivity(
+                Intent(this, PreferenceActivity::class.java)
+                    .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
+            )
+            true
+        }
+
+        // long-press on the main swap arrow also opens the Fees settings,
+        // mirroring the swap arrow inside the quick-conversions dialog.
+        findViewById<View>(R.id.btn_toggle).setOnLongClickListener {
             haptic(it)
             startActivity(
                 Intent(this, PreferenceActivity::class.java)

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
@@ -156,9 +156,8 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             val trueCostView = row.findViewById<TextView>(R.id.text_true_cost)
             if (hasFees && side == FeeSide.ORIGINAL) {
                 val actual = amt.multiply(stack, MathContext.DECIMAL128)
-                trueCostView.text = getString(
-                    R.string.fee_true_cost_prefix
-                ) + "${actual.formatForRow(ctx)} ${from.iso4217Alpha()}"
+                trueCostView.text = getString(R.string.fee_true_cost_prefix) +
+                    ltrIsolate("${actual.formatForRow(ctx)} ${from.iso4217Alpha()}")
                 trueCostView.visibility = View.VISIBLE
             } else {
                 trueCostView.visibility = View.GONE
@@ -166,9 +165,8 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
 
             val originalValueView = row.findViewById<TextView>(R.id.text_original_value)
             if (hasFees && side == FeeSide.CONVERTED) {
-                originalValueView.text = getString(
-                    R.string.fee_original_value_prefix
-                ) + "${fair.formatForRow(ctx)} ${to.iso4217Alpha()}"
+                originalValueView.text = getString(R.string.fee_original_value_prefix) +
+                    ltrIsolate("${fair.formatForRow(ctx)} ${to.iso4217Alpha()}")
                 originalValueView.visibility = View.VISIBLE
             } else {
                 originalValueView.visibility = View.GONE
@@ -188,6 +186,8 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             feeInfo.visibility = View.GONE
         }
     }
+
+    private fun ltrIsolate(s: String): String = "\u2066$s\u2069"
 
     private fun BigDecimal.formatForRow(ctx: android.content.Context): String {
         val abs = this.abs()

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
@@ -49,8 +49,8 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             renderHeader(ctx, flagFrom, labelFrom, from)
             renderHeader(ctx, flagTo, labelTo, to)
             btnFeeSide.setImageResource(
-                if (side == FeeSide.CONVERTED) R.drawable.ic_fee_side_converted
-                else R.drawable.ic_fee_side_original
+                if (side == FeeSide.CONVERTED) R.drawable.ic_fee_side_converted_horizontal
+                else R.drawable.ic_fee_side_original_horizontal
             )
             renderRows(container, feeInfo, viewModel, from, to, rates, side)
         }

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
@@ -1,0 +1,152 @@
+package de.salomax.currencies.view.main
+
+import android.app.Dialog
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.lifecycle.ViewModelProvider
+import de.salomax.currencies.R
+import de.salomax.currencies.model.Currency
+import de.salomax.currencies.model.ExchangeRates
+import de.salomax.currencies.util.toHumanReadableNumber
+import de.salomax.currencies.view.preference.PreferenceActivity
+import de.salomax.currencies.viewmodel.main.MainViewModel
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+class QuickConversionsDialog : AppCompatDialogFragment() {
+
+    private val amounts = listOf("1", "5", "10", "20", "50", "100", "500", "1000")
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val ctx = requireContext()
+        val view = View.inflate(ctx, R.layout.dialog_quick_conversions, null)
+        val viewModel = ViewModelProvider(requireActivity())[MainViewModel::class.java]
+
+        val flagFrom = view.findViewById<ImageView>(R.id.flag_from)
+        val labelFrom = view.findViewById<TextView>(R.id.label_from)
+        val flagTo = view.findViewById<ImageView>(R.id.flag_to)
+        val labelTo = view.findViewById<TextView>(R.id.label_to)
+        val btnSwap = view.findViewById<ImageButton>(R.id.btn_swap)
+        val container = view.findViewById<LinearLayout>(R.id.container_rows)
+        val feeInfo = view.findViewById<TextView>(R.id.text_fee_info)
+
+        fun rebuild() {
+            val from = viewModel.getBaseCurrency().value
+            val to = viewModel.getDestinationCurrency().value
+            val rates = viewModel.getExchangeRates().value
+            renderHeader(ctx, flagFrom, labelFrom, from)
+            renderHeader(ctx, flagTo, labelTo, to)
+            renderRows(container, feeInfo, viewModel, from, to, rates)
+        }
+
+        viewModel.getBaseCurrency().observe(this) { rebuild() }
+        viewModel.getDestinationCurrency().observe(this) { rebuild() }
+        viewModel.getExchangeRates().observe(this) { rebuild() }
+        viewModel.getFees().observe(this) { rebuild() }
+
+        btnSwap.setOnClickListener {
+            (activity as? MainActivity)?.toggleEvent(btnSwap)
+        }
+        btnSwap.setOnLongClickListener {
+            startActivity(
+                Intent(ctx, PreferenceActivity::class.java)
+                    .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
+            )
+            true
+        }
+
+        return AlertDialog.Builder(ctx)
+            .setTitle(R.string.quick_conversions_title)
+            .setView(view)
+            .setPositiveButton(android.R.string.ok, null)
+            .create()
+    }
+
+    private fun renderHeader(
+        ctx: android.content.Context,
+        flag: ImageView,
+        label: TextView,
+        currency: Currency?,
+    ) {
+        if (currency != null) {
+            flag.setImageDrawable(currency.flag(ctx))
+            label.text = currency.iso4217Alpha()
+        } else {
+            flag.setImageDrawable(null)
+            label.text = ""
+        }
+    }
+
+    private fun renderRows(
+        container: LinearLayout,
+        feeInfo: TextView,
+        viewModel: MainViewModel,
+        from: Currency?,
+        to: Currency?,
+        rates: ExchangeRates?,
+    ) {
+        container.removeAllViews()
+        val ctx = container.context
+        val baseRate = rates?.rates?.find { it.currency == from }?.value
+        val destRate = rates?.rates?.find { it.currency == to }?.value
+
+        if (from == null || to == null || baseRate == null || destRate == null) {
+            val tv = TextView(ctx).apply {
+                text = getString(R.string.quick_conversions_no_rates)
+                gravity = android.view.Gravity.CENTER
+                setPadding(0, resources.getDimensionPixelSize(R.dimen.margin2x), 0, 0)
+            }
+            container.addView(tv)
+            feeInfo.visibility = View.GONE
+            return
+        }
+
+        val stack = viewModel.feeStackFor(from, to)
+        val applyFees = stack.compareTo(BigDecimal.ZERO) != 0 &&
+            stack.compareTo(BigDecimal.ONE) != 0
+        val inflater = android.view.LayoutInflater.from(ctx)
+
+        for (amountStr in amounts) {
+            val amt = BigDecimal(amountStr)
+            val fair = amt.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
+            val displayed = if (applyFees) fair.divide(stack, MathContext.DECIMAL128) else fair
+
+            val row = inflater.inflate(R.layout.dialog_quick_conversions_row, container, false)
+            row.findViewById<TextView>(R.id.text_amount_from).text =
+                "$amountStr ${from.iso4217Alpha()}"
+            row.findViewById<TextView>(R.id.text_amount_to).text =
+                "${displayed.formatForRow(ctx)} ${to.iso4217Alpha()}"
+            container.addView(row)
+        }
+
+        if (applyFees) {
+            val percent = (stack.subtract(BigDecimal.ONE))
+                .multiply(BigDecimal(100), MathContext.DECIMAL128)
+                .setScale(2, RoundingMode.HALF_UP)
+            val sign = if (percent.signum() >= 0) "+" else ""
+            feeInfo.text = getString(R.string.quick_conversions_fees_applied, "$sign$percent%")
+            feeInfo.visibility = View.VISIBLE
+        } else {
+            feeInfo.visibility = View.GONE
+        }
+    }
+
+    private fun BigDecimal.formatForRow(ctx: android.content.Context): String {
+        val abs = this.abs()
+        val decimals = when {
+            abs >= BigDecimal(1000) -> 2
+            abs >= BigDecimal(1) -> 2
+            else -> 4
+        }
+        return this.setScale(decimals, RoundingMode.HALF_UP).toHumanReadableNumber(ctx)
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
@@ -164,6 +164,16 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
                 trueCostView.visibility = View.GONE
             }
 
+            val originalValueView = row.findViewById<TextView>(R.id.text_original_value)
+            if (hasFees && side == FeeSide.CONVERTED) {
+                originalValueView.text = getString(
+                    R.string.fee_original_value_prefix
+                ) + "${fair.formatForRow(ctx)} ${to.iso4217Alpha()}"
+                originalValueView.visibility = View.VISIBLE
+            } else {
+                originalValueView.visibility = View.GONE
+            }
+
             container.addView(row)
         }
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/QuickConversionsDialog.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import de.salomax.currencies.R
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
+import de.salomax.currencies.model.FeeSide
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.view.preference.PreferenceActivity
 import de.salomax.currencies.viewmodel.main.MainViewModel
@@ -36,6 +37,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
         val flagTo = view.findViewById<ImageView>(R.id.flag_to)
         val labelTo = view.findViewById<TextView>(R.id.label_to)
         val btnSwap = view.findViewById<ImageButton>(R.id.btn_swap)
+        val btnFeeSide = view.findViewById<ImageButton>(R.id.btn_fee_side)
         val container = view.findViewById<LinearLayout>(R.id.container_rows)
         val feeInfo = view.findViewById<TextView>(R.id.text_fee_info)
 
@@ -43,20 +45,41 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             val from = viewModel.getBaseCurrency().value
             val to = viewModel.getDestinationCurrency().value
             val rates = viewModel.getExchangeRates().value
+            val side = viewModel.getFeeSide().value ?: FeeSide.ORIGINAL
             renderHeader(ctx, flagFrom, labelFrom, from)
             renderHeader(ctx, flagTo, labelTo, to)
-            renderRows(container, feeInfo, viewModel, from, to, rates)
+            btnFeeSide.setImageResource(
+                if (side == FeeSide.CONVERTED) R.drawable.ic_fee_side_converted
+                else R.drawable.ic_fee_side_original
+            )
+            renderRows(container, feeInfo, viewModel, from, to, rates, side)
         }
 
         viewModel.getBaseCurrency().observe(this) { rebuild() }
         viewModel.getDestinationCurrency().observe(this) { rebuild() }
         viewModel.getExchangeRates().observe(this) { rebuild() }
         viewModel.getFees().observe(this) { rebuild() }
+        viewModel.getFeeSide().observe(this) { rebuild() }
 
         btnSwap.setOnClickListener {
             (activity as? MainActivity)?.toggleEvent(btnSwap)
         }
         btnSwap.setOnLongClickListener {
+            startActivity(
+                Intent(ctx, PreferenceActivity::class.java)
+                    .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
+            )
+            true
+        }
+
+        btnFeeSide.setOnClickListener {
+            val next = when (viewModel.getFeeSide().value ?: FeeSide.ORIGINAL) {
+                FeeSide.ORIGINAL -> FeeSide.CONVERTED
+                FeeSide.CONVERTED -> FeeSide.ORIGINAL
+            }
+            viewModel.setFeeSide(next)
+        }
+        btnFeeSide.setOnLongClickListener {
             startActivity(
                 Intent(ctx, PreferenceActivity::class.java)
                     .putExtra(PreferenceActivity.EXTRA_OPEN_FEES, true)
@@ -93,6 +116,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
         from: Currency?,
         to: Currency?,
         rates: ExchangeRates?,
+        side: FeeSide,
     ) {
         container.removeAllViews()
         val ctx = container.context
@@ -111,24 +135,39 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
         }
 
         val stack = viewModel.feeStackFor(from, to)
-        val applyFees = stack.compareTo(BigDecimal.ZERO) != 0 &&
+        val hasFees = stack.compareTo(BigDecimal.ZERO) != 0 &&
             stack.compareTo(BigDecimal.ONE) != 0
         val inflater = android.view.LayoutInflater.from(ctx)
 
         for (amountStr in amounts) {
             val amt = BigDecimal(amountStr)
             val fair = amt.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
-            val displayed = if (applyFees) fair.divide(stack, MathContext.DECIMAL128) else fair
+            val displayed = if (hasFees && side == FeeSide.CONVERTED)
+                fair.divide(stack, MathContext.DECIMAL128)
+            else
+                fair
 
             val row = inflater.inflate(R.layout.dialog_quick_conversions_row, container, false)
             row.findViewById<TextView>(R.id.text_amount_from).text =
                 "$amountStr ${from.iso4217Alpha()}"
             row.findViewById<TextView>(R.id.text_amount_to).text =
                 "${displayed.formatForRow(ctx)} ${to.iso4217Alpha()}"
+
+            val trueCostView = row.findViewById<TextView>(R.id.text_true_cost)
+            if (hasFees && side == FeeSide.ORIGINAL) {
+                val actual = amt.multiply(stack, MathContext.DECIMAL128)
+                trueCostView.text = getString(
+                    R.string.fee_true_cost_prefix
+                ) + "${actual.formatForRow(ctx)} ${from.iso4217Alpha()}"
+                trueCostView.visibility = View.VISIBLE
+            } else {
+                trueCostView.visibility = View.GONE
+            }
+
             container.addView(row)
         }
 
-        if (applyFees) {
+        if (hasFees) {
             val percent = (stack.subtract(BigDecimal.ONE))
                 .multiply(BigDecimal(100), MathContext.DECIMAL128)
                 .setScale(2, RoundingMode.HALF_UP)

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/FeeManagerFragment.kt
@@ -314,7 +314,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
             ).apply {
-                topMargin = resources.getDimensionPixelSize(R.dimen.margin2x)
+                // Extra clearance below the EditText so its text-selection
+                // handle doesn't drop onto the sign toggle.
+                topMargin = resources.getDimensionPixelSize(R.dimen.margin4x)
             },
         )
 
@@ -394,7 +396,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
             ).apply {
-                topMargin = resources.getDimensionPixelSize(R.dimen.margin2x)
+                // Extra clearance below the EditText so its text-selection
+                // handle doesn't drop onto the sign toggle.
+                topMargin = resources.getDimensionPixelSize(R.dimen.margin4x)
             },
         )
 

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -564,6 +564,39 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     internal fun getTrueCost(): LiveData<BigDecimal?> = trueCost
 
     /**
+     * The undiscounted (fair) destination amount when [FeeSide.CONVERTED]
+     * is active and at least one fee applies: `result * totalStack`. `null`
+     * when the total stack is trivial (== 1) or the side is [FeeSide.ORIGINAL].
+     */
+    private val originalValue = object : MediatorLiveData<BigDecimal?>() {
+        var resultVal: BigDecimal = BigDecimal.ZERO
+        var stack: BigDecimal = BigDecimal.ONE
+        var side: FeeSide = FeeSide.ORIGINAL
+        var feeList: List<Fee> = emptyList()
+
+        init {
+            addSource(getResultAsNumber()) { resultVal = it ?: BigDecimal.ZERO; update() }
+            addSource(totalStack) { stack = it ?: BigDecimal.ONE; update() }
+            addSource(feeSide) { side = it ?: FeeSide.ORIGINAL; update() }
+            addSource(fees) { feeList = it.orEmpty(); update() }
+        }
+
+        private fun update() {
+            this.value = when {
+                side != FeeSide.CONVERTED -> null
+                feeList.isEmpty() -> null
+                stack.compareTo(BigDecimal.ONE) == 0 -> null
+                else -> resultVal.multiply(stack, MathContext.DECIMAL128)
+            }
+        }
+    }
+
+    /**
+     * See [originalValue].
+     */
+    internal fun getOriginalValue(): LiveData<BigDecimal?> = originalValue
+
+    /**
      * The combined multiplicative fee factor for the current pair.
      */
     internal fun getTotalStack(): LiveData<BigDecimal> = totalStack

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -501,6 +501,15 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
     }
 
     /**
+     * Public accessor for the fee stack factor of an arbitrary pair,
+     * used by ad-hoc UIs (e.g. the quick-conversions popup) that need to
+     * apply fees outside the main result pipeline.
+     */
+    internal fun feeStackFor(base: Currency?, dest: Currency?): BigDecimal {
+        return computeTotalStack(fees.value.orEmpty(), base, dest)
+    }
+
+    /**
      * The combined multiplicative fee factor for the current pair.
      * Exposed so the UI can render a hint (e.g. badge on the side toggle)
      * when at least one fee is active for the current currencies.

--- a/app/src/main/res/drawable/ic_fee_side_converted_horizontal.xml
+++ b/app/src/main/res/drawable/ic_fee_side_converted_horizontal.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Arrow pointing right: fee applied to CONVERTED (result, right) side -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,12l-7,-6v4H3v4h11v4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_fee_side_original_horizontal.xml
+++ b/app/src/main/res/drawable/ic_fee_side_original_horizontal.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Arrow pointing left: fee applied to ORIGINAL (input, left) side -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,12l7,-6v4h11v4H10v4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_swap_horiz.xml
+++ b/app/src/main/res/drawable/ic_swap_horiz.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.99,11L3,15l3.99,4v-3H14v-2H6.99v-3zM21,9l-3.99,-4v3H10v2h7.01v3L21,9z" />
+</vector>

--- a/app/src/main/res/drawable/ic_table.xml
+++ b/app/src/main/res/drawable/ic_table.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/app/src/main/res/drawable/ic_table.xml
+++ b/app/src/main/res/drawable/ic_table.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,4h18v3H3zM3,10.5h18v3H3zM3,17h18v3H3z" />
+</vector>

--- a/app/src/main/res/layout/dialog_quick_conversions.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions.xml
@@ -58,7 +58,7 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/fee_side_label"
             android:padding="@dimen/margin1x"
-            android:src="@drawable/ic_fee_side_original"
+            android:src="@drawable/ic_fee_side_original_horizontal"
             app:tint="?attr/colorPrimary" />
 
         <LinearLayout

--- a/app/src/main/res/layout/dialog_quick_conversions.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions.xml
@@ -51,6 +51,16 @@
             android:src="@drawable/ic_swap_horiz"
             app:tint="?attr/colorPrimary" />
 
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btn_fee_side"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/fee_side_label"
+            android:padding="@dimen/margin1x"
+            android:src="@drawable/ic_fee_side_original"
+            app:tint="?attr/colorPrimary" />
+
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_quick_conversions.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="@dimen/margin2x"
+    android:paddingTop="@dimen/margin2x">
+
+    <!-- header: FROM  ⇄  TO -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end|center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/flag_from"
+                android:layout_width="28dp"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:contentDescription="@null"
+                tools:src="@drawable/flag_unknown" />
+
+            <TextView
+                android:id="@+id/label_from"
+                style="@style/TextAppearance.Material3.TitleMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin1x"
+                android:textDirection="ltr"
+                tools:text="USD" />
+        </LinearLayout>
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btn_swap"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin1x"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/desc_toggle_currencies"
+            android:padding="@dimen/margin1x"
+            android:src="@drawable/ic_swap_horiz"
+            app:tint="?attr/colorPrimary" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="start|center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/flag_to"
+                android:layout_width="28dp"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:contentDescription="@null"
+                tools:src="@drawable/flag_unknown" />
+
+            <TextView
+                android:id="@+id/label_to"
+                style="@style/TextAppearance.Material3.TitleMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin1x"
+                android:textDirection="ltr"
+                tools:text="EUR" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- fees info -->
+    <TextView
+        android:id="@+id/text_fee_info"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin1x"
+        android:alpha=".7"
+        android:gravity="center"
+        android:textColor="?attr/colorPrimary"
+        android:textDirection="ltr"
+        android:visibility="gone"
+        tools:text="Fees applied: +33.10%"
+        tools:visibility="visible" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="@dimen/margin2x"
+        android:background="?android:attr/listDivider" />
+
+    <!-- rows container -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="@dimen/margin1x">
+
+        <LinearLayout
+            android:id="@+id/container_rows"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_quick_conversions.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions.xml
@@ -59,7 +59,7 @@
             android:contentDescription="@string/fee_side_label"
             android:padding="@dimen/margin1x"
             android:src="@drawable/ic_fee_side_original_horizontal"
-            app:tint="?attr/colorPrimary" />
+            app:tint="?attr/colorError" />
 
         <LinearLayout
             android:layout_width="0dp"
@@ -96,7 +96,7 @@
         android:layout_marginTop="@dimen/margin1x"
         android:alpha=".7"
         android:gravity="center"
-        android:textColor="?attr/colorPrimary"
+        android:textColor="?attr/colorError"
         android:textDirection="ltr"
         android:visibility="gone"
         tools:text="Fees applied: +33.10%"

--- a/app/src/main/res/layout/dialog_quick_conversions_row.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions_row.xml
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:alpha=".7"
             android:gravity="end"
-            android:textColor="?android:attr/textColorSecondary"
+            android:textColor="?attr/colorError"
             android:textDirection="ltr"
             android:visibility="gone"
             tools:text="True cost: 11.20 USD"
@@ -45,13 +45,33 @@
         android:alpha=".5"
         android:text="=" />
 
-    <TextView
-        android:id="@+id/text_amount_to"
-        style="@style/TextAppearance.Material3.BodyLarge"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:gravity="start"
-        android:textDirection="ltr"
-        tools:text="8.76 EUR" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_amount_to"
+            style="@style/TextAppearance.Material3.BodyLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:textDirection="ltr"
+            tools:text="8.76 EUR" />
+
+        <TextView
+            android:id="@+id/text_original_value"
+            style="@style/TextAppearance.Material3.LabelSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:alpha=".7"
+            android:gravity="start"
+            android:textColor="?attr/colorError"
+            android:textDirection="ltr"
+            android:visibility="gone"
+            tools:text="Original value: 8.90 EUR"
+            tools:visibility="visible" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_quick_conversions_row.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions_row.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/margin1x">
+
+    <TextView
+        android:id="@+id/text_amount_from"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="end"
+        android:textDirection="ltr"
+        tools:text="10 USD" />
+
+    <TextView
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin2x"
+        android:alpha=".5"
+        android:text="=" />
+
+    <TextView
+        android:id="@+id/text_amount_to"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="start"
+        android:textDirection="ltr"
+        tools:text="8.76 EUR" />
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_quick_conversions_row.xml
+++ b/app/src/main/res/layout/dialog_quick_conversions_row.xml
@@ -7,15 +7,35 @@
     android:orientation="horizontal"
     android:paddingVertical="@dimen/margin1x">
 
-    <TextView
-        android:id="@+id/text_amount_from"
-        style="@style/TextAppearance.Material3.BodyLarge"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:gravity="end"
-        android:textDirection="ltr"
-        tools:text="10 USD" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_amount_from"
+            style="@style/TextAppearance.Material3.BodyLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:textDirection="ltr"
+            tools:text="10 USD" />
+
+        <TextView
+            android:id="@+id/text_true_cost"
+            style="@style/TextAppearance.Material3.LabelSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:alpha=".7"
+            android:gravity="end"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textDirection="ltr"
+            android:visibility="gone"
+            tools:text="True cost: 11.20 USD"
+            tools:visibility="visible" />
+    </LinearLayout>
 
     <TextView
         style="@style/TextAppearance.Material3.BodyLarge"

--- a/app/src/main/res/layout/main_display.xml
+++ b/app/src/main/res/layout/main_display.xml
@@ -71,7 +71,7 @@
             app:layout_constraintBottom_toBottomOf="@id/btn_toggle"
             app:layout_constraintStart_toEndOf="@id/btn_toggle"
             app:layout_constraintTop_toTopOf="@id/btn_toggle"
-            app:tint="?attr/colorPrimary" />
+            app:tint="?attr/colorError" />
 
         <!-- overall fee badge ******************************************** -->
 
@@ -81,7 +81,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin1x"
-            android:textColor="?attr/colorPrimary"
+            android:textColor="?attr/colorError"
             android:textDirection="ltr"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/btn_fee_side"
@@ -112,7 +112,7 @@
                 android:layout_gravity="end"
                 android:alpha=".7"
                 android:lines="1"
-                android:textColor="?android:attr/textColorSecondary"
+                android:textColor="?attr/colorError"
                 android:textDirection="ltr"
                 android:textSize="12sp"
                 android:visibility="gone"
@@ -228,10 +228,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:scrollbars="none"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/scrollViewOriginalValue"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/spinnerTo"
-            app:layout_constraintTop_toTopOf="@+id/guideline_display">
+            app:layout_constraintTop_toTopOf="@+id/guideline_display"
+            app:layout_constraintVertical_chainStyle="packed">
 
             <TextView
                 android:id="@+id/textTo"
@@ -244,6 +245,35 @@
                 android:padding="@dimen/margin2x"
                 android:textDirection="ltr"
                 tools:text="€ 383.99" />
+        </HorizontalScrollView>
+
+        <HorizontalScrollView
+            android:id="@+id/scrollViewOriginalValue"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin1x"
+            android:layout_marginEnd="@dimen/margin2x"
+            android:scrollbars="none"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/spinnerTo"
+            app:layout_constraintTop_toBottomOf="@id/scrollViewTextTo">
+
+            <TextView
+                android:id="@+id/textOriginalValue"
+                style="@style/TextAppearance.Material3.TitleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:alpha=".7"
+                android:lines="1"
+                android:textColor="?attr/colorError"
+                android:textDirection="ltr"
+                android:textSize="12sp"
+                android:visibility="gone"
+                tools:text="Original value: 100.00 EUR"
+                tools:visibility="visible" />
+
         </HorizontalScrollView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -10,6 +10,13 @@
 
     <item
         android:orderInCategory="1"
+        android:id="@+id/quick_conversions"
+        android:icon="@drawable/ic_table"
+        android:title="@string/menu_quick_conversions"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:orderInCategory="2"
         android:id="@+id/date_picker"
         android:icon="@drawable/ic_history"
         android:title="@string/menu_historical_rates"

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -29,6 +29,12 @@
         app:showAsAction="never" />
 
     <item
+        android:orderInCategory="500"
+        android:id="@+id/fees"
+        android:title="@string/fee_manager_title"
+        app:showAsAction="never" />
+
+    <item
         android:orderInCategory="1000"
         android:id="@+id/settings"
         android:title="@string/menu_settings"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">إعدادات</string>
     <string name="menu_refresh">معدلات التحديث</string>
     <string name="menu_timeline">مخطط سعر الصرف</string>
+    <string name="menu_quick_conversions">تحويلات سريعة</string>
+    <string name="quick_conversions_title">تحويلات سريعة</string>
+    <string name="quick_conversions_no_rates">لم يتم تحميل الأسعار بعد.</string>
+    <string name="quick_conversions_fees_applied">الرسوم المطبقة: %s</string>
     <string name="tooltip_filter_starred">إظهار العملات المميزة بنجمة فقط.</string>
     <string name="currency_dropdown_api_hint">شيء مفقود؟ يقدم موفرو البيانات المختلفون عملات مختلفة. انتقل إلى الإعدادات لتجربة مصدر أخر! 🤗</string>
 </resources>

--- a/app/src/main/res/values-ar/strings_preference.xml
+++ b/app/src/main/res/values-ar/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">إلى</string>
     <string name="fee_pair_pick_currency">اختر عملة</string>
     <string name="fee_true_cost_prefix">"التكلفة الحقيقية: "</string>
+    <string name="fee_original_value_prefix">"القيمة الأصلية: "</string>
     <string name="fee_side_summary_original">يبقى المبلغ المحوَّل المعروض بسعر السوق الأوسط؛ وتُعرض الرسوم بشكل منفصل باسم \"التكلفة الحقيقية\".</string>
     <string name="fee_side_summary_converted">الرسوم مضمَّنة في المبلغ المحوَّل المعروض.</string>
     <string name="fee_empty">لا توجد رسوم بعد</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -15,5 +15,9 @@
     <string name="menu_settings">Настройки</string>
     <string name="menu_refresh">Обнови курсовете</string>
     <string name="menu_timeline">Таблица на обявения курс</string>
+    <string name="menu_quick_conversions">Бързи конверсии</string>
+    <string name="quick_conversions_title">Бързи конверсии</string>
+    <string name="quick_conversions_no_rates">Курсовете все още не са заредени.</string>
+    <string name="quick_conversions_fees_applied">Приложени такси: %s</string>
     <string name="tooltip_filter_starred">Покажи само любимите курсове.</string>
 </resources>

--- a/app/src/main/res/values-bg/strings_preference.xml
+++ b/app/src/main/res/values-bg/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">До</string>
     <string name="fee_pair_pick_currency">Избери валута</string>
     <string name="fee_true_cost_prefix">"Реална цена: "</string>
+    <string name="fee_original_value_prefix">"Първоначална стойност: "</string>
     <string name="fee_side_summary_original">Показаната конвертирана сума остава на средния пазарен курс; таксите се показват отделно като \"реална цена\".</string>
     <string name="fee_side_summary_converted">Таксите са включени в показаната конвертирана сума.</string>
     <string name="fee_empty">Все още няма такси</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">সেটিংস</string>
     <string name="menu_refresh">রিফ্রেশ হার</string>
     <string name="menu_timeline">বিনিময় হার চার্ট</string>
+    <string name="menu_quick_conversions">দ্রুত রূপান্তর</string>
+    <string name="quick_conversions_title">দ্রুত রূপান্তর</string>
+    <string name="quick_conversions_no_rates">হার এখনও লোড হয়নি।</string>
+    <string name="quick_conversions_fees_applied">প্রযোজ্য ফি: %s</string>
     <string name="tooltip_filter_starred">শুধুমাত্র তারকাচিহ্নিত মুদ্রা দেখান।</string>
     <string name="currency_dropdown_api_hint">কোনকিছু পাওয়া যাচ্ছে না? ভিন্ন তথ্য সরবরাহকারী ভিন্ন ভিন্ন অর্থ দেখায়। পছন্দসমূহে গিয়ে আরেকটা চেষ্টা করে দেখো! 🤗</string>
 </resources>

--- a/app/src/main/res/values-bn/strings_preference.xml
+++ b/app/src/main/res/values-bn/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">প্রতি</string>
     <string name="fee_pair_pick_currency">মুদ্রা নির্বাচন করো</string>
     <string name="fee_true_cost_prefix">"প্রকৃত খরচ: "</string>
+    <string name="fee_original_value_prefix">"মূল মান: "</string>
     <string name="fee_side_summary_original">প্রদর্শিত রূপান্তরিত পরিমাণ মধ্য-বাজার হারে থাকে; ফি আলাদাভাবে \"প্রকৃত খরচ\" হিসেবে দেখানো হয়।</string>
     <string name="fee_side_summary_converted">ফি প্রদর্শিত রূপান্তরিত পরিমাণে অন্তর্ভুক্ত থাকে।</string>
     <string name="fee_empty">এখনো কোনো ফি নেই</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Configuració</string>
     <string name="menu_refresh">Actualitza les taxes</string>
     <string name="menu_timeline">Gràfic de la taxa de canvi</string>
+    <string name="menu_quick_conversions">Conversions ràpides</string>
+    <string name="quick_conversions_title">Conversions ràpides</string>
+    <string name="quick_conversions_no_rates">Les taxes encara no s\'han carregat.</string>
+    <string name="quick_conversions_fees_applied">Comissions aplicades: %s</string>
     <string name="tooltip_filter_starred">Mostra només les monedes preferides.</string>
     <string name="currency_dropdown_api_hint">Us falta res? Els diversos proveïdors de dades ofereixen divises diferents. Aneu a la configuració per a provar-ne d\'altres! 🤗</string>
 </resources>

--- a/app/src/main/res/values-ca/strings_preference.xml
+++ b/app/src/main/res/values-ca/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">A</string>
     <string name="fee_pair_pick_currency">Selecciona moneda</string>
     <string name="fee_true_cost_prefix">"Cost real: "</string>
+    <string name="fee_original_value_prefix">"Valor original: "</string>
     <string name="fee_side_summary_original">L\'import convertit mostrat es manté al canvi mitjà de mercat; les comissions es mostren per separat com a \"cost real\".</string>
     <string name="fee_side_summary_converted">Les comissions s\'inclouen dins de l\'import convertit mostrat.</string>
     <string name="fee_empty">Encara no hi ha comissions</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Nastavení</string>
     <string name="menu_refresh">Obnovit kurzy</string>
     <string name="menu_timeline">Tabulka kurzů</string>
+    <string name="menu_quick_conversions">Rychlé převody</string>
+    <string name="quick_conversions_title">Rychlé převody</string>
+    <string name="quick_conversions_no_rates">Kurzy zatím nejsou načteny.</string>
+    <string name="quick_conversions_fees_applied">Použité poplatky: %s</string>
     <string name="tooltip_filter_starred">Zobrazit pouze oblíbené měny.</string>
     <string name="currency_dropdown_api_hint">Chybí tu něco? Různí poskytovatelé dat poskytují různé měny. Zajděte do nastavení a vyzkoušejte jiného!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-cs/strings_preference.xml
+++ b/app/src/main/res/values-cs/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Na</string>
     <string name="fee_pair_pick_currency">Vyberte měnu</string>
     <string name="fee_true_cost_prefix">"Skutečná cena: "</string>
+    <string name="fee_original_value_prefix">"Původní hodnota: "</string>
     <string name="fee_side_summary_original">Zobrazená převedená částka zůstává ve středním tržním kurzu; poplatky jsou zobrazeny samostatně jako \"skutečná cena\".</string>
     <string name="fee_side_summary_converted">Poplatky jsou zahrnuty v zobrazené převedené částce.</string>
     <string name="fee_empty">Zatím žádné poplatky</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Indstillinger</string>
     <string name="menu_refresh">Opdatér valutakurser</string>
     <string name="menu_timeline">Valutakursdiagram</string>
+    <string name="menu_quick_conversions">Hurtige omregninger</string>
+    <string name="quick_conversions_title">Hurtige omregninger</string>
+    <string name="quick_conversions_no_rates">Kurser er ikke indlæst endnu.</string>
+    <string name="quick_conversions_fees_applied">Anvendte gebyrer: %s</string>
     <string name="tooltip_filter_starred">Vis kun stjernemarkeret valutaer.</string>
     <string name="currency_dropdown_api_hint">Noget der mangler? Forskellige dataudbydere tilbyder forskellige valutaer. Gå til indstillingerne for at prøve en anden! 🤗</string>
 </resources>

--- a/app/src/main/res/values-da/strings_preference.xml
+++ b/app/src/main/res/values-da/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Til</string>
     <string name="fee_pair_pick_currency">Vælg valuta</string>
     <string name="fee_true_cost_prefix">"Reel pris: "</string>
+    <string name="fee_original_value_prefix">"Oprindelig værdi: "</string>
     <string name="fee_side_summary_original">Den viste konverterede værdi bliver ved mellemkursen; gebyrer vises separat som \"reel pris\".</string>
     <string name="fee_side_summary_converted">Gebyrer er indregnet i den viste konverterede værdi.</string>
     <string name="fee_empty">Ingen gebyrer endnu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,6 +21,10 @@
     <string name="menu_settings">Einstellungen</string>
     <string name="menu_refresh">Kurse aktualisieren</string>
     <string name="menu_timeline">Wechselkursverlauf</string>
+    <string name="menu_quick_conversions">Schnellumrechnung</string>
+    <string name="quick_conversions_title">Schnellumrechnung</string>
+    <string name="quick_conversions_no_rates">Kurse noch nicht geladen.</string>
+    <string name="quick_conversions_fees_applied">Angewendete Gebühren: %s</string>
     <string name="tooltip_filter_starred">Nur favorisierte Währungen anzeigen.</string>
     <string name="currency_dropdown_api_hint">Fehlt etwas? Unterschiedliche Datenquellen bieten unterschiedliche Währungen an. In die Einstellungen gehen, um eine andere auszuprobieren!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-de/strings_preference.xml
+++ b/app/src/main/res/values-de/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Nach</string>
     <string name="fee_pair_pick_currency">Währung auswählen</string>
     <string name="fee_true_cost_prefix">"Tatsächliche Kosten: "</string>
+    <string name="fee_original_value_prefix">"Ursprünglicher Wert: "</string>
     <string name="fee_side_summary_original">Der angezeigte umgerechnete Betrag bleibt beim Mittelkurs; Gebühren werden separat als \"tatsächliche Kosten\" angezeigt.</string>
     <string name="fee_side_summary_converted">Gebühren sind bereits im angezeigten umgerechneten Betrag enthalten.</string>
     <string name="fee_empty">Noch keine Gebühren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -17,6 +17,10 @@
     <string name="menu_settings">Ρυθμίσεις</string>
     <string name="menu_refresh">Επικαιροποίηση ισοτιμίας</string>
     <string name="menu_timeline">Διάγραμμα ισοτιμίας</string>
+    <string name="menu_quick_conversions">Γρήγορες μετατροπές</string>
+    <string name="quick_conversions_title">Γρήγορες μετατροπές</string>
+    <string name="quick_conversions_no_rates">Οι ισοτιμίες δεν έχουν φορτωθεί ακόμα.</string>
+    <string name="quick_conversions_fees_applied">Εφαρμοσμένες χρεώσεις: %s</string>
     <string name="tooltip_filter_starred">Εμφάνιση μόνο αγαπημένων νομισμάτων.</string>
     <string name="currency_dropdown_api_hint">Κάτι λείπει; Διαφορετικοί πάροχοι δεδομένων προσφέρουν διαφορετικά νομίσματα. Μεταβείτε στις ρυθμίσεις για να δοκιμάσετε έναν άλλο!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-el/strings_preference.xml
+++ b/app/src/main/res/values-el/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Προς</string>
     <string name="fee_pair_pick_currency">Επιλέξτε νόμισμα</string>
     <string name="fee_true_cost_prefix">"Πραγματικό κόστος: "</string>
+    <string name="fee_original_value_prefix">"Αρχική αξία: "</string>
     <string name="fee_side_summary_original">Το εμφανιζόμενο μετατραπέν ποσό παραμένει στη μέση τιμή αγοράς· οι προμήθειες εμφανίζονται ξεχωριστά ως \"πραγματικό κόστος\".</string>
     <string name="fee_side_summary_converted">Οι προμήθειες περιλαμβάνονται στο εμφανιζόμενο μετατραπέν ποσό.</string>
     <string name="fee_empty">Δεν υπάρχουν ακόμη προμήθειες</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -17,6 +17,10 @@
     <string name="menu_settings">Agordoj</string>
     <string name="menu_refresh">Refreŝigaj tarifoj</string>
     <string name="menu_timeline">Kurza diagramo</string>
+    <string name="menu_quick_conversions">Rapidaj konvertoj</string>
+    <string name="quick_conversions_title">Rapidaj konvertoj</string>
+    <string name="quick_conversions_no_rates">Kursoj ankoraŭ ne ŝargitaj.</string>
+    <string name="quick_conversions_fees_applied">Aplikitaj kotizoj: %s</string>
     <string name="tooltip_filter_starred">Montri nur stelumitajn valutojn.</string>
     <string name="currency_dropdown_api_hint">Io mankas? Aliaj datumprovizantoj ofertas malsamajn valutojn. Iru al la agordoj por provi alian!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-eo/strings_preference.xml
+++ b/app/src/main/res/values-eo/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Al</string>
     <string name="fee_pair_pick_currency">Elekti valuton</string>
     <string name="fee_true_cost_prefix">"Vera kosto: "</string>
+    <string name="fee_original_value_prefix">"Originala valoro: "</string>
     <string name="fee_side_summary_original">La montrata konvertita sumo restas ĉe la mez-merkata kurzo; kotizoj estas montrataj aparte kiel \"vera kosto\".</string>
     <string name="fee_side_summary_converted">Kotizoj estas inkluzivitaj en la montrata konvertita sumo.</string>
     <string name="fee_empty">Neniuj kotizoj ankoraŭ</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Configuración</string>
     <string name="menu_refresh">Tarifas de actualización</string>
     <string name="menu_timeline">Historial de tipos de cambio</string>
+    <string name="menu_quick_conversions">Conversiones rápidas</string>
+    <string name="quick_conversions_title">Conversiones rápidas</string>
+    <string name="quick_conversions_no_rates">Las tasas aún no se han cargado.</string>
+    <string name="quick_conversions_fees_applied">Comisiones aplicadas: %s</string>
     <string name="tooltip_filter_starred">Mostrar solo las monedas con estrella.</string>
     <string name="currency_dropdown_api_hint">¿Falta algo? Los distintos proveedores de datos ofrecen monedas diferentes. ¡Ve a la configuración para probar con otra!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-es/strings_preference.xml
+++ b/app/src/main/res/values-es/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">A</string>
     <string name="fee_pair_pick_currency">Selecciona moneda</string>
     <string name="fee_true_cost_prefix">"Coste real: "</string>
+    <string name="fee_original_value_prefix">"Valor original: "</string>
     <string name="fee_side_summary_original">El importe convertido mostrado se mantiene al tipo medio de mercado; las comisiones se muestran por separado como \"coste real\".</string>
     <string name="fee_side_summary_converted">Las comisiones están incluidas en el importe convertido mostrado.</string>
     <string name="fee_empty">Aún no hay comisiones</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Seadistused</string>
     <string name="menu_refresh">Uuenda vahetuskursse</string>
     <string name="menu_timeline">Vahetuskursside graafik</string>
+    <string name="menu_quick_conversions">Kiirteisendused</string>
+    <string name="quick_conversions_title">Kiirteisendused</string>
+    <string name="quick_conversions_no_rates">Kursid pole veel laaditud.</string>
+    <string name="quick_conversions_fees_applied">Rakendatud tasud: %s</string>
     <string name="tooltip_filter_starred">Näita vaid lemmikuks märgitud valuutasid.</string>
     <string name="currency_dropdown_api_hint">Midagi on puudu? Erinevad teenusepakkujad näitavad vahetuskursse erinevate valuutade jaoks. Ava seadistused ning vali mõni muu teenusepakkuja! 🤗</string>
 </resources>

--- a/app/src/main/res/values-et/strings_preference.xml
+++ b/app/src/main/res/values-et/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Kuhu</string>
     <string name="fee_pair_pick_currency">Vali valuuta</string>
     <string name="fee_true_cost_prefix">"Tegelik hind: "</string>
+    <string name="fee_original_value_prefix">"Algne väärtus: "</string>
     <string name="fee_side_summary_original">Kuvatav konverteeritud summa jääb keskturukursile; teenustasud kuvatakse eraldi kui \"tegelik hind\".</string>
     <string name="fee_side_summary_converted">Teenustasud on kuvatavasse konverteeritud summasse juba arvestatud.</string>
     <string name="fee_empty">Teenustasusid veel pole</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">پیکربندی‌ها</string>
     <string name="menu_refresh">همار نوسازی</string>
     <string name="menu_timeline">نمودار نرخ دادوستد</string>
+    <string name="menu_quick_conversions">تبدیل‌های سریع</string>
+    <string name="quick_conversions_title">تبدیل‌های سریع</string>
+    <string name="quick_conversions_no_rates">نرخ‌ها هنوز بارگذاری نشده‌اند.</string>
+    <string name="quick_conversions_fees_applied">کارمزدهای اعمال‌شده: %s</string>
     <string name="tooltip_filter_starred">تنها ارز های ستاره‌دار را نمایش دهید.</string>
     <string name="currency_dropdown_api_hint">نمی توانید ارز دلخواه خود را پیدا کنید؟ فراهم‌گران متفاوت ارز‌های متفاوت ارائه می‌کنند. به پیکربندی‌ها بروید و یکی دیگر را بیازمایید! \u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-fa/strings_preference.xml
+++ b/app/src/main/res/values-fa/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">به</string>
     <string name="fee_pair_pick_currency">انتخاب ارز</string>
     <string name="fee_true_cost_prefix">"هزینه واقعی: "</string>
+    <string name="fee_original_value_prefix">"مقدار اصلی: "</string>
     <string name="fee_side_summary_original">مبلغ تبدیل‌شده نمایش داده شده در نرخ میانگین بازار می‌ماند؛ کارمزدها به‌طور جداگانه به‌عنوان \"هزینه واقعی\" نشان داده می‌شوند.</string>
     <string name="fee_side_summary_converted">کارمزدها در مبلغ تبدیل‌شده نمایش داده شده لحاظ شده‌اند.</string>
     <string name="fee_empty">هنوز کارمزدی وجود ندارد</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Réglages</string>
     <string name="menu_refresh">Rafraîchissement des taux</string>
     <string name="menu_timeline">Historique des taux de change</string>
+    <string name="menu_quick_conversions">Conversions rapides</string>
+    <string name="quick_conversions_title">Conversions rapides</string>
+    <string name="quick_conversions_no_rates">Taux non encore chargés.</string>
+    <string name="quick_conversions_fees_applied">Frais appliqués : %s</string>
     <string name="tooltip_filter_starred">Afficher uniquement les devises étoilées.</string>
     <string name="currency_dropdown_api_hint">Quelque chose manque? Différents fournisseurs de données proposent différentes devises. Allez dans les paramètres pour en essayer un autre ! 🤗</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_preference.xml
+++ b/app/src/main/res/values-fr/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Vers</string>
     <string name="fee_pair_pick_currency">Choisir une devise</string>
     <string name="fee_true_cost_prefix">"Coût réel : "</string>
+    <string name="fee_original_value_prefix">"Valeur d’origine : "</string>
     <string name="fee_side_summary_original">Le montant converti affiché reste au taux du marché moyen ; les frais sont affichés séparément comme \"coût réel\".</string>
     <string name="fee_side_summary_converted">Les frais sont inclus dans le montant converti affiché.</string>
     <string name="fee_empty">Aucun frais pour le moment</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Postavke</string>
     <string name="menu_refresh">Osvježi tečajnu listu</string>
     <string name="menu_timeline">Grafikon tečaja</string>
+    <string name="menu_quick_conversions">Brze konverzije</string>
+    <string name="quick_conversions_title">Brze konverzije</string>
+    <string name="quick_conversions_no_rates">Tečajevi još nisu učitani.</string>
+    <string name="quick_conversions_fees_applied">Primijenjene naknade: %s</string>
     <string name="tooltip_filter_starred">Prikaži samo označene valute.</string>
     <string name="currency_dropdown_api_hint">Nešto nedostaje? Drugi pružatelji podataka nude podatke za druge valute. U postavkama možete odabrati nekog drugog pružatelja!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-hr/strings_preference.xml
+++ b/app/src/main/res/values-hr/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">U</string>
     <string name="fee_pair_pick_currency">Odaberi valutu</string>
     <string name="fee_true_cost_prefix">"Stvarna cijena: "</string>
+    <string name="fee_original_value_prefix">"Izvorni iznos: "</string>
     <string name="fee_side_summary_original">Prikazani preračunati iznos ostaje po srednjem tržišnom tečaju; provizije se prikazuju odvojeno kao \"stvarna cijena\".</string>
     <string name="fee_side_summary_converted">Provizije su uključene u prikazani preračunati iznos.</string>
     <string name="fee_empty">Još nema provizija</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -15,5 +15,9 @@
     <string name="menu_settings">Beállítások</string>
     <string name="menu_refresh">Árfolyamok frissítése</string>
     <string name="menu_timeline">Árfolyamgrafikon</string>
+    <string name="menu_quick_conversions">Gyors átváltások</string>
+    <string name="quick_conversions_title">Gyors átváltások</string>
+    <string name="quick_conversions_no_rates">Az árfolyamok még nincsenek betöltve.</string>
+    <string name="quick_conversions_fees_applied">Alkalmazott díjak: %s</string>
     <string name="tooltip_filter_starred">Csak a kedvenc valuták megjelenítése.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_preference.xml
+++ b/app/src/main/res/values-hu/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Ide</string>
     <string name="fee_pair_pick_currency">Válassz pénznemet</string>
     <string name="fee_true_cost_prefix">"Valós költség: "</string>
+    <string name="fee_original_value_prefix">"Eredeti érték: "</string>
     <string name="fee_side_summary_original">A megjelenített átváltott összeg a középárfolyamon marad; a díjak külön jelennek meg \"valós költség\" néven.</string>
     <string name="fee_side_summary_converted">A díjak bele vannak számítva a megjelenített átváltott összegbe.</string>
     <string name="fee_empty">Még nincsenek díjak</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -15,5 +15,9 @@
     <string name="menu_settings">Pengaturan</string>
     <string name="menu_refresh">Muat ulang nilai tukar</string>
     <string name="menu_timeline">Bagan nilai tukar</string>
+    <string name="menu_quick_conversions">Konversi cepat</string>
+    <string name="quick_conversions_title">Konversi cepat</string>
+    <string name="quick_conversions_no_rates">Nilai tukar belum dimuat.</string>
+    <string name="quick_conversions_fees_applied">Biaya yang diterapkan: %s</string>
     <string name="tooltip_filter_starred">Tampilkan hanya mata uang yang dibintangi.</string>
 </resources>

--- a/app/src/main/res/values-in/strings_preference.xml
+++ b/app/src/main/res/values-in/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Ke</string>
     <string name="fee_pair_pick_currency">Pilih mata uang</string>
     <string name="fee_true_cost_prefix">"Biaya sebenarnya: "</string>
+    <string name="fee_original_value_prefix">"Nilai asli: "</string>
     <string name="fee_side_summary_original">Jumlah konversi yang ditampilkan tetap pada kurs tengah pasar; biaya ditampilkan terpisah sebagai \"biaya sebenarnya\".</string>
     <string name="fee_side_summary_converted">Biaya sudah termasuk dalam jumlah konversi yang ditampilkan.</string>
     <string name="fee_empty">Belum ada biaya</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -15,5 +15,9 @@
     <string name="menu_settings">Stillingar</string>
     <string name="menu_refresh">Endurnýja gengi</string>
     <string name="menu_timeline">Línurit</string>
+    <string name="menu_quick_conversions">Skjótar umbreytingar</string>
+    <string name="quick_conversions_title">Skjótar umbreytingar</string>
+    <string name="quick_conversions_no_rates">Gengi hefur ekki verið hlaðið enn.</string>
+    <string name="quick_conversions_fees_applied">Beitt gjöld: %s</string>
     <string name="tooltip_filter_starred">Sýna aðeins eftirlæti.</string>
 </resources>

--- a/app/src/main/res/values-is/strings_preference.xml
+++ b/app/src/main/res/values-is/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Til</string>
     <string name="fee_pair_pick_currency">Veldu gjaldmiðil</string>
     <string name="fee_true_cost_prefix">"Raunverulegur kostnaður: "</string>
+    <string name="fee_original_value_prefix">"Upprunalegt verðmæti: "</string>
     <string name="fee_side_summary_original">Sýnd umreiknuð upphæð helst á miðgengi; gjöld eru sýnd sérstaklega sem \"raunverulegur kostnaður\".</string>
     <string name="fee_side_summary_converted">Gjöld eru innifalin í sýndri umreiknaðri upphæð.</string>
     <string name="fee_empty">Engin gjöld ennþá</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Impostazioni</string>
     <string name="menu_refresh">Aggiorna tassi</string>
     <string name="menu_timeline">Cronologia del tasso di cambio</string>
+    <string name="menu_quick_conversions">Conversioni rapide</string>
+    <string name="quick_conversions_title">Conversioni rapide</string>
+    <string name="quick_conversions_no_rates">Tassi non ancora caricati.</string>
+    <string name="quick_conversions_fees_applied">Commissioni applicate: %s</string>
     <string name="tooltip_filter_starred">Mostra solo le valute stellate.</string>
     <string name="currency_dropdown_api_hint">Manca qualcosa? Diversi fornitori di dati offrono valute diverse. Vai nelle impostazioni per provarne un altro! 🤗</string>
 </resources>

--- a/app/src/main/res/values-it/strings_preference.xml
+++ b/app/src/main/res/values-it/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">A</string>
     <string name="fee_pair_pick_currency">Seleziona valuta</string>
     <string name="fee_true_cost_prefix">"Costo reale: "</string>
+    <string name="fee_original_value_prefix">"Valore originale: "</string>
     <string name="fee_side_summary_original">L\'importo convertito mostrato resta al tasso medio di mercato; le commissioni sono mostrate separatamente come \"costo reale\".</string>
     <string name="fee_side_summary_converted">Le commissioni sono già incluse nell\'importo convertito mostrato.</string>
     <string name="fee_empty">Ancora nessuna commissione</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">הגדרות</string>
     <string name="menu_refresh">רענון השערים</string>
     <string name="menu_timeline">תרשים שערי חליפין</string>
+    <string name="menu_quick_conversions">המרות מהירות</string>
+    <string name="quick_conversions_title">המרות מהירות</string>
+    <string name="quick_conversions_no_rates">השערים עדיין לא נטענו.</string>
+    <string name="quick_conversions_fees_applied">עמלות שהוחלו: %s</string>
     <string name="tooltip_filter_starred">הצגת מטבעות מסומנים בלבד.</string>
     <string name="currency_dropdown_api_hint">משהו חסר? ספקי נתונים שונים מציעים מטבעות שונים. אפשר לגשת להגדרות ולנסות ספק אחר!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">אל</string>
     <string name="fee_pair_pick_currency">בחר מטבע</string>
     <string name="fee_true_cost_prefix">"עלות אמיתית: "</string>
+    <string name="fee_original_value_prefix">"ערך מקורי: "</string>
     <string name="fee_side_summary_original">הסכום המומר המוצג נשאר בשער היציג; העמלות מוצגות בנפרד בתור \"עלות אמיתית\".</string>
     <string name="fee_side_summary_converted">העמלות כלולות בסכום המומר המוצג.</string>
     <string name="fee_empty">אין עמלות עדיין</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -24,6 +24,10 @@
     <string name="menu_settings">ക്രമീകരണങ്ങൾ</string>
     <string name="menu_refresh">നിരക്കുകൾ പുതുക്കുക</string>
     <string name="menu_timeline">വിനിമയ നിരക്ക് ചാർട്ട്</string>
+    <string name="menu_quick_conversions">വേഗത്തിലുള്ള പരിവർത്തനങ്ങൾ</string>
+    <string name="quick_conversions_title">വേഗത്തിലുള്ള പരിവർത്തനങ്ങൾ</string>
+    <string name="quick_conversions_no_rates">നിരക്കുകൾ ഇതുവരെ ലോഡ് ചെയ്തിട്ടില്ല.</string>
+    <string name="quick_conversions_fees_applied">ബാധകമായ ഫീസുകൾ: %s</string>
 
     <string name="tooltip_filter_starred">നക്ഷത്രമുള്ള കറൻസികൾ മാത്രം കാണിക്കുക.</string>
     <string name="currency_dropdown_api_hint">എന്തെങ്കിലും കാണാനില്ലേ? വ്യത്യസ്ത ഡാറ്റ ദാതാക്കൾ വ്യത്യസ്ത കറൻസികൾ വാഗ്ദാനം ചെയ്യുന്നു. മറ്റൊന്ന് പരീക്ഷിക്കാൻ ക്രമീകരണങ്ങളിലേക്ക് പോകുക!\u00A0\uD83E\uDD17</string>

--- a/app/src/main/res/values-ml/strings_preference.xml
+++ b/app/src/main/res/values-ml/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">ലേക്ക്</string>
     <string name="fee_pair_pick_currency">കറൻസി തിരഞ്ഞെടുക്കുക</string>
     <string name="fee_true_cost_prefix">"യഥാർത്ഥ ചെലവ്: "</string>
+    <string name="fee_original_value_prefix">"യഥാർത്ഥ മൂല്യം: "</string>
     <string name="fee_side_summary_original">പ്രദർശിപ്പിച്ച പരിവർത്തിത തുക മധ്യ-വിപണി നിരക്കിൽ തുടരും; ഫീസുകൾ പ്രത്യേകമായി \"യഥാർത്ഥ ചെലവ്\" ആയി കാണിക്കുന്നു.</string>
     <string name="fee_side_summary_converted">ഫീസുകൾ പ്രദർശിപ്പിച്ച പരിവർത്തിത തുകയിൽ ഉൾപ്പെടുത്തിയിരിക്കുന്നു.</string>
     <string name="fee_empty">ഇതുവരെ ഫീസുകളില്ല</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -15,5 +15,9 @@
     <string name="menu_settings">Innstillinger</string>
     <string name="menu_refresh">Oppdater kurs</string>
     <string name="menu_timeline">Valutakurs historikk</string>
+    <string name="menu_quick_conversions">Raske omregninger</string>
+    <string name="quick_conversions_title">Raske omregninger</string>
+    <string name="quick_conversions_no_rates">Kursene er ikke lastet inn ennå.</string>
+    <string name="quick_conversions_fees_applied">Anvendte gebyrer: %s</string>
     <string name="tooltip_filter_starred">Vis kun favorittvalutaer.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings_preference.xml
+++ b/app/src/main/res/values-nb/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Til</string>
     <string name="fee_pair_pick_currency">Velg valuta</string>
     <string name="fee_true_cost_prefix">"Reell kostnad: "</string>
+    <string name="fee_original_value_prefix">"Opprinnelig verdi: "</string>
     <string name="fee_side_summary_original">Det viste konverterte beløpet holder seg til midtkurs; gebyrer vises separat som \"reell kostnad\".</string>
     <string name="fee_side_summary_converted">Gebyrer er inkludert i det viste konverterte beløpet.</string>
     <string name="fee_empty">Ingen gebyrer ennå</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Instellingen</string>
     <string name="menu_refresh">Update koersen</string>
     <string name="menu_timeline">Wisselkoers grafiek</string>
+    <string name="menu_quick_conversions">Snelle omrekeningen</string>
+    <string name="quick_conversions_title">Snelle omrekeningen</string>
+    <string name="quick_conversions_no_rates">Koersen zijn nog niet geladen.</string>
+    <string name="quick_conversions_fees_applied">Toegepaste kosten: %s</string>
     <string name="tooltip_filter_starred">Toon alleen favoriete valuta\'s.</string>
     <string name="currency_dropdown_api_hint">Ontbreekt er iets? Verschillende dataproviders bieden verschillende valuta\'s aan. Ga naar de instellingen om een andere te proberen! 🤗</string>
 </resources>

--- a/app/src/main/res/values-nl/strings_preference.xml
+++ b/app/src/main/res/values-nl/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Naar</string>
     <string name="fee_pair_pick_currency">Selecteer valuta</string>
     <string name="fee_true_cost_prefix">"Werkelijke kosten: "</string>
+    <string name="fee_original_value_prefix">"Oorspronkelijke waarde: "</string>
     <string name="fee_side_summary_original">Het weergegeven geconverteerde bedrag blijft op de middenkoers; kosten worden apart weergegeven als \"werkelijke kosten\".</string>
     <string name="fee_side_summary_converted">Kosten zijn verwerkt in het weergegeven geconverteerde bedrag.</string>
     <string name="fee_empty">Nog geen kosten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -17,6 +17,10 @@
     <string name="menu_settings">Ustawienia</string>
     <string name="menu_refresh">Odśwież kursy</string>
     <string name="menu_timeline">Wykres kursów wymiany</string>
+    <string name="menu_quick_conversions">Szybkie przeliczenia</string>
+    <string name="quick_conversions_title">Szybkie przeliczenia</string>
+    <string name="quick_conversions_no_rates">Kursy nie zostały jeszcze załadowane.</string>
+    <string name="quick_conversions_fees_applied">Zastosowane opłaty: %s</string>
     <string name="tooltip_filter_starred">Pokaż tylko polubione waluty.</string>
     <string name="currency_dropdown_api_hint">Czegoś brakuje? Różni dostawcy danych oferują różne waluty. Przejdź do ustawień, aby wypróbować innego dostawcę!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_preference.xml
+++ b/app/src/main/res/values-pl/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Na</string>
     <string name="fee_pair_pick_currency">Wybierz walutę</string>
     <string name="fee_true_cost_prefix">"Rzeczywisty koszt: "</string>
+    <string name="fee_original_value_prefix">"Wartość pierwotna: "</string>
     <string name="fee_side_summary_original">Wyświetlana przeliczona kwota pozostaje po średnim kursie rynkowym; opłaty są pokazywane osobno jako \"rzeczywisty koszt\".</string>
     <string name="fee_side_summary_converted">Opłaty są uwzględnione w wyświetlanej przeliczonej kwocie.</string>
     <string name="fee_empty">Brak opłat</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Configurações</string>
     <string name="menu_refresh">Atualizar taxas</string>
     <string name="menu_timeline">Gráfico da taxa de câmbio</string>
+    <string name="menu_quick_conversions">Conversões rápidas</string>
+    <string name="quick_conversions_title">Conversões rápidas</string>
+    <string name="quick_conversions_no_rates">Taxas ainda não carregadas.</string>
+    <string name="quick_conversions_fees_applied">Taxas aplicadas: %s</string>
     <string name="tooltip_filter_starred">Mostrar apenas moedas marcadas com estrela.</string>
     <string name="currency_dropdown_api_hint">Está faltando algo? Diferentes provedores de dados oferecem diferentes moedas. Vá para as configurações para tentar outro! 🤗</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings_preference.xml
+++ b/app/src/main/res/values-pt-rBR/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Para</string>
     <string name="fee_pair_pick_currency">Selecionar moeda</string>
     <string name="fee_true_cost_prefix">"Custo real: "</string>
+    <string name="fee_original_value_prefix">"Valor original: "</string>
     <string name="fee_side_summary_original">O valor convertido exibido permanece na taxa média de mercado; as taxas são mostradas separadamente como \"custo real\".</string>
     <string name="fee_side_summary_converted">As taxas estão incluídas no valor convertido exibido.</string>
     <string name="fee_empty">Ainda não há taxas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Настройки</string>
     <string name="menu_refresh">Обновить курсы валют</string>
     <string name="menu_timeline">График обменного курса</string>
+    <string name="menu_quick_conversions">Быстрая конвертация</string>
+    <string name="quick_conversions_title">Быстрая конвертация</string>
+    <string name="quick_conversions_no_rates">Курсы ещё не загружены.</string>
+    <string name="quick_conversions_fees_applied">Применённые комиссии: %s</string>
     <string name="tooltip_filter_starred">Показывать только избранные валюты.</string>
     <string name="currency_dropdown_api_hint">Чего-то не хватает? Разные поставщики данных предлагают разные валюты. Зайдите в настройки и попробуйте другого! 🤗</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_preference.xml
+++ b/app/src/main/res/values-ru/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">В</string>
     <string name="fee_pair_pick_currency">Выбрать валюту</string>
     <string name="fee_true_cost_prefix">"Реальная стоимость: "</string>
+    <string name="fee_original_value_prefix">"Исходная сумма: "</string>
     <string name="fee_side_summary_original">Отображаемая конвертированная сумма остаётся по среднерыночному курсу; комиссии показываются отдельно как \"реальная стоимость\".</string>
     <string name="fee_side_summary_converted">Комиссии уже включены в отображаемую конвертированную сумму.</string>
     <string name="fee_empty">Комиссий пока нет</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -15,6 +15,10 @@
     <string name="menu_settings">Inställningar</string>
     <string name="menu_refresh">Uppdatera kurser</string>
     <string name="menu_timeline">Diagram över valutakurs</string>
+    <string name="menu_quick_conversions">Snabba omvandlingar</string>
+    <string name="quick_conversions_title">Snabba omvandlingar</string>
+    <string name="quick_conversions_no_rates">Kurserna har inte laddats än.</string>
+    <string name="quick_conversions_fees_applied">Tillämpade avgifter: %s</string>
     <string name="tooltip_filter_starred">Visa endast favoritvalutor.</string>
     <string name="error_empty_response">Servern har ingen data för denna förfrågan.</string>
     <string name="error_try_another_api">Men det finns andra dataleverantörer som du kan välja på i inställningarna. Prova!</string>

--- a/app/src/main/res/values-sv/strings_preference.xml
+++ b/app/src/main/res/values-sv/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Till</string>
     <string name="fee_pair_pick_currency">Välj valuta</string>
     <string name="fee_true_cost_prefix">"Faktisk kostnad: "</string>
+    <string name="fee_original_value_prefix">"Ursprungligt värde: "</string>
     <string name="fee_side_summary_original">Det visade konverterade beloppet är kvar till mittkursen; avgifter visas separat som \"faktisk kostnad\".</string>
     <string name="fee_side_summary_converted">Avgifter är inräknade i det visade konverterade beloppet.</string>
     <string name="fee_empty">Inga avgifter ännu</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Ayarlar</string>
     <string name="menu_refresh">Kurları güncelle</string>
     <string name="menu_timeline">Döviz kur grafiği</string>
+    <string name="menu_quick_conversions">Hızlı dönüşümler</string>
+    <string name="quick_conversions_title">Hızlı dönüşümler</string>
+    <string name="quick_conversions_no_rates">Kurlar henüz yüklenmedi.</string>
+    <string name="quick_conversions_fees_applied">Uygulanan ücretler: %s</string>
     <string name="tooltip_filter_starred">Sadece favori para birimlerini göster.</string>
     <string name="currency_dropdown_api_hint">Eksik bir şey mi var? Farklı veri sağlayıcıları farklı para birimleri sunar. Başka bir tane denemek için ayarlara gidin!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-tr/strings_preference.xml
+++ b/app/src/main/res/values-tr/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Kime</string>
     <string name="fee_pair_pick_currency">Para birimi seç</string>
     <string name="fee_true_cost_prefix">"Gerçek maliyet: "</string>
+    <string name="fee_original_value_prefix">"Orijinal tutar: "</string>
     <string name="fee_side_summary_original">Gösterilen dönüştürülmüş tutar orta piyasa kurunda kalır; ücretler ayrı olarak \"gerçek maliyet\" şeklinde gösterilir.</string>
     <string name="fee_side_summary_converted">Ücretler gösterilen dönüştürülmüş tutara dahil edilmiştir.</string>
     <string name="fee_empty">Henüz ücret yok</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -21,6 +21,10 @@
     <string name="menu_settings">Налаштування</string>
     <string name="menu_refresh">Оновити курс</string>
     <string name="menu_timeline">Графік зміни курсу</string>
+    <string name="menu_quick_conversions">Швидкі конвертації</string>
+    <string name="quick_conversions_title">Швидкі конвертації</string>
+    <string name="quick_conversions_no_rates">Курси ще не завантажені.</string>
+    <string name="quick_conversions_fees_applied">Застосовані комісії: %s</string>
     <string name="tooltip_filter_starred">Показувати лише обрані валюти.</string>
     <string name="currency_dropdown_api_hint">Чогось не вистачає? Різні постачальники даних пропонують різні валюти. Перейдіть до налаштувань, щоб спробувати іншого!\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-uk/strings_preference.xml
+++ b/app/src/main/res/values-uk/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">На</string>
     <string name="fee_pair_pick_currency">Виберіть валюту</string>
     <string name="fee_true_cost_prefix">"Реальна вартість: "</string>
+    <string name="fee_original_value_prefix">"Початкова сума: "</string>
     <string name="fee_side_summary_original">Показана конвертована сума залишається за середнім ринковим курсом; комісії відображаються окремо як \"реальна вартість\".</string>
     <string name="fee_side_summary_converted">Комісії вже враховані в показаній конвертованій сумі.</string>
     <string name="fee_empty">Комісій ще немає</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">Cài đặt</string>
     <string name="menu_refresh">Làm mới tỷ giá</string>
     <string name="menu_timeline">Biểu đồ tỷ giá hối đoái</string>
+    <string name="menu_quick_conversions">Chuyển đổi nhanh</string>
+    <string name="quick_conversions_title">Chuyển đổi nhanh</string>
+    <string name="quick_conversions_no_rates">Tỷ giá chưa được tải.</string>
+    <string name="quick_conversions_fees_applied">Phí đã áp dụng: %s</string>
     <string name="tooltip_filter_starred">Chỉ hiện đơn vị tiền tệ nào được gắn sao.</string>
     <string name="currency_dropdown_api_hint">Có thứ gì bị thiếu à? Những nhà cung cấp dữ liệu khác nhau sẽ có các tiền tệ khác nhau. Hãy đến cài đặt để thử nhà cung cấp khác! 🤗</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_preference.xml
+++ b/app/src/main/res/values-vi/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">Đến</string>
     <string name="fee_pair_pick_currency">Chọn tiền tệ</string>
     <string name="fee_true_cost_prefix">"Chi phí thực: "</string>
+    <string name="fee_original_value_prefix">"Giá trị gốc: "</string>
     <string name="fee_side_summary_original">Số tiền chuyển đổi hiển thị giữ ở tỷ giá thị trường trung bình; phí được hiển thị riêng dưới dạng \"chi phí thực\".</string>
     <string name="fee_side_summary_converted">Phí đã được tính sẵn trong số tiền chuyển đổi hiển thị.</string>
     <string name="fee_empty">Chưa có phí nào</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,6 +20,10 @@
     <string name="error_unsupported_timeline">这个 API 不支持时间线数据.</string>
     <string name="menu_refresh">更新汇率</string>
     <string name="menu_timeline">查看汇率走势图</string>
+    <string name="menu_quick_conversions">快速换算</string>
+    <string name="quick_conversions_title">快速换算</string>
+    <string name="quick_conversions_no_rates">汇率尚未加载。</string>
+    <string name="quick_conversions_fees_applied">已应用费用：%s</string>
     <string name="tooltip_filter_starred">仅显示收藏的货币。</string>
     <string name="currency_dropdown_api_hint">没找到需要的汇率？不同的数据来源提供数量不同的货币汇率。尝试在设置里换换来源！ 🤗</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_preference.xml
+++ b/app/src/main/res/values-zh-rCN/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">到</string>
     <string name="fee_pair_pick_currency">选择货币</string>
     <string name="fee_true_cost_prefix">"实际成本："</string>
+    <string name="fee_original_value_prefix">"原始金额："</string>
     <string name="fee_side_summary_original">显示的换算金额保持中间市场汇率；手续费单独显示为\"实际成本\"。</string>
     <string name="fee_side_summary_converted">手续费已计入显示的换算金额中。</string>
     <string name="fee_empty">暂无手续费</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -20,6 +20,10 @@
     <string name="menu_settings">設定</string>
     <string name="menu_refresh">更新匯率</string>
     <string name="menu_timeline">匯率走勢圖</string>
+    <string name="menu_quick_conversions">快速換算</string>
+    <string name="quick_conversions_title">快速換算</string>
+    <string name="quick_conversions_no_rates">匯率尚未載入。</string>
+    <string name="quick_conversions_fees_applied">已套用手續費：%s</string>
     <string name="tooltip_filter_starred">只顯示最愛的匯率</string>
     <string name="currency_dropdown_api_hint">有東西不見了嗎？每個資料來源提供的數量不盡相同。請到設定去調整看看！\u00A0\uD83E\uDD17</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings_preference.xml
+++ b/app/src/main/res/values-zh-rTW/strings_preference.xml
@@ -20,6 +20,7 @@
     <string name="fee_pair_to">到</string>
     <string name="fee_pair_pick_currency">選擇貨幣</string>
     <string name="fee_true_cost_prefix">"實際成本："</string>
+    <string name="fee_original_value_prefix">"原始金額："</string>
     <string name="fee_side_summary_original">顯示的換算金額維持在中間市場匯率；手續費會單獨顯示為\"實際成本\"。</string>
     <string name="fee_side_summary_converted">手續費已計入顯示的換算金額中。</string>
     <string name="fee_empty">尚無手續費</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,12 @@
     <string name="menu_settings">Settings</string>
     <string name="menu_refresh">Refresh rates</string>
     <string name="menu_timeline">Exchange rate chart</string>
+    <string name="menu_quick_conversions">Quick conversions</string>
     <string name="menu_historical_rates" translatable="false">@string/historical_rates_dialog_title</string>
+
+    <string name="quick_conversions_title">Quick conversions</string>
+    <string name="quick_conversions_no_rates">Rates not loaded yet.</string>
+    <string name="quick_conversions_fees_applied">Fees applied: %s</string>
     <string name="title_preferences" translatable="false">@string/menu_settings</string>
 
     <string name="tooltip_filter_starred">Show only starred currencies.</string>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -24,6 +24,7 @@
     <string name="fee_pair_to">To</string>
     <string name="fee_pair_pick_currency">Select currency</string>
     <string name="fee_true_cost_prefix">"True cost: "</string>
+    <string name="fee_original_value_prefix">"Original value: "</string>
     <string name="fee_side_summary_original">Displayed converted amount stays at mid-market; fees are shown separately as \"true cost\".</string>
     <string name="fee_side_summary_converted">Fees are baked into the displayed converted amount.</string>
     <string name="fee_empty">No fees yet</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -71,7 +71,11 @@
 
         <!-- remove color tint from popup menu -->
         <item name="popupMenuBackground">?attr/colorBackground</item>
-        <item name="android:popupBackground">?attr/colorBackground</item>
+        <!-- Keep theme-wide popupBackground transparent so the text-selection
+             handle's PopupWindow doesn't render a white square behind the
+             handle drawable. Popup menus are handled by popupMenuBackground
+             and AppTheme.PopupMenu.Overflow above. -->
+        <item name="android:popupBackground">@android:color/transparent</item>
     </style>
 
     <style name="BaseAppTheme.PureBlack" parent="AppTheme">


### PR DESCRIPTION
Closes-related: sal0max/currencies#68

## Summary
- New table icon in the toolbar (between chart and history) opens a popup listing common amount conversions (1 / 5 / 10 / 20 / 50 / 100 / 500 / 1000) for the current currency pair.
- Fees are baked into the displayed amounts when any are configured; a "Fees applied: +X%" hint is shown so the numbers can't be misread as mid-market.
- The popup header carries a swap arrow that flips the pair — the flip propagates to the main screen's spinners via the existing swap logic.
- Long-pressing the popup's swap arrow — and now the main screen's swap FAB — opens the Fees settings page directly.
- Translations added for the 4 new strings (`menu_quick_conversions`, `quick_conversions_title`, `quick_conversions_no_rates`, `quick_conversions_fees_applied`) across all 31 localized `strings.xml` files.

## Test plan
- [ ] Tap the new table icon → popup opens showing 8 rows for the current pair.
- [ ] Configure a fee (e.g. +10% global exchange) → row values shrink; hint "Fees applied: +X%" appears.
- [ ] Remove all fees → hint disappears; values are mid-market.
- [ ] Tap the swap arrow in the popup → currencies flip in both the popup and the main screen underneath.
- [ ] Long-press the popup's swap arrow → Fees settings opens.
- [ ] Long-press the main-screen swap FAB → Fees settings opens.
- [ ] Switch device language (de / fr / iw / zh-rCN) → menu icon tooltip, dialog title, hint and "not loaded" text all show in that language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)