### PR TITLE
refactor(adapters): use buildList/buildMap in JSON parsers

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/AdapterUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/AdapterUtils.kt
@@ -9,6 +9,21 @@ import java.io.InputStream
 import java.time.format.DateTimeFormatter
 import kotlin.math.pow
 
+// Both InforEuro endpoints return a JSON array on success and an
+// { "message": "..." } object on failure. Peek at the token: on an array,
+// walk it via [onArray] (begin/endArray are handled here); otherwise pass
+// the error message to [onError].
+internal inline fun <T> JsonReader.readArrayOrError(
+    onError: (String?) -> T,
+    onArray: (JsonReader) -> T
+): T {
+    if (peek() != JsonReader.Token.BEGIN_ARRAY) return onError(readErrorMessage())
+    beginArray()
+    val result = onArray(this)
+    endArray()
+    return result
+}
+
 // Providers surface error payloads as { "message": "..." }. This helper reads
 // that message field out of the current object, skipping anything else.
 internal fun JsonReader.readErrorMessage(): String? {
@@ -25,6 +40,10 @@ internal fun JsonReader.readErrorMessage(): String? {
 // Bank Rossii serializes dates as dd.MM.yyyy in every response.
 internal val BANK_ROSSII_DATE_FORMATTER: DateTimeFormatter =
     DateTimeFormatter.ofPattern("dd.MM.yyyy")
+
+// InforEuro's timeline endpoint uses dd/MM/yyyy for dateStart/dateEnd.
+internal val INFOR_EURO_DATE_FORMATTER: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
 // Faroese króna isn't listed by upstream APIs; mirror the Danish krone
 // value into the response so FOK still shows up in the UI as a 1:1 peg.

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppRatesAdapter.kt
@@ -19,21 +19,19 @@ internal class FrankfurterAppRatesAdapter(private val base: Currency) {
     @Synchronized
     @FromJson
     @Throws(IOException::class)
-    fun fromJson(reader: JsonReader): List<Rate> {
-        val list = mutableListOf<Rate>()
+    fun fromJson(reader: JsonReader): List<Rate> = buildList {
         reader.beginObject()
         // convert
         while (reader.hasNext()) {
             val name: String = reader.nextName()
             val value: BigDecimal = BigDecimal(reader.nextString())
-            Currency.fromString(name)?.let { list.add(Rate(it, value)) }
+            Currency.fromString(name)?.let { add(Rate(it, value)) }
         }
         reader.endObject()
         // add base - but only if it's missing in the api response!
-        if (list.find { rate -> rate.currency == base } == null)
-            list.add(Rate(base, BigDecimal.ONE))
-        list.addFokFromDkkIfMissing()
-        return list
+        if (none { rate -> rate.currency == base })
+            add(Rate(base, BigDecimal.ONE))
+        addFokFromDkkIfMissing()
     }
 
     @Synchronized

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/FrankfurterAppTimelineAdapter.kt
@@ -20,8 +20,7 @@ internal class FrankfurterAppTimelineAdapter(private val symbol: Currency) {
 
     @Synchronized
     @FromJson
-    fun fromJson(reader: JsonReader): Map<LocalDate, Rate> {
-        val map = mutableMapOf<LocalDate, Rate>()
+    fun fromJson(reader: JsonReader): Map<LocalDate, Rate> = buildMap {
         reader.beginObject()
         // convert
         while (reader.hasNext()) {
@@ -43,11 +42,10 @@ internal class FrankfurterAppTimelineAdapter(private val symbol: Currency) {
                         null
             }
             if (rate != null)
-                map[date] = rate
+                put(date, rate)
             reader.endObject()
         }
         reader.endObject()
-        return map
     }
 
     @Synchronized

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
@@ -19,15 +19,15 @@ internal class InforEuroRatesAdapter(private val date: LocalDate) {
     @FromJson
     @Throws(IOException::class)
     fun fromJson(reader: JsonReader): ExchangeRates {
-        val rates = mutableListOf<Rate>()
-
         if (reader.peek() != JsonReader.Token.BEGIN_ARRAY) return readErrorResponse(reader)
 
-        reader.beginArray()
-        while (reader.hasNext()) {
-            parseEntry(reader)?.let { rates.add(it) }
+        val rates = buildList {
+            reader.beginArray()
+            while (reader.hasNext()) {
+                parseEntry(reader)?.let { add(it) }
+            }
+            reader.endArray()
         }
-        reader.endArray()
 
         return ExchangeRates(
             success = rates.isNotEmpty(),

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroRatesAdapter.kt
@@ -18,18 +18,15 @@ internal class InforEuroRatesAdapter(private val date: LocalDate) {
     @Synchronized
     @FromJson
     @Throws(IOException::class)
-    fun fromJson(reader: JsonReader): ExchangeRates {
-        if (reader.peek() != JsonReader.Token.BEGIN_ARRAY) return readErrorResponse(reader)
-
+    fun fromJson(reader: JsonReader): ExchangeRates = reader.readArrayOrError(
+        onError = ::errorResponse
+    ) { r ->
         val rates = buildList {
-            reader.beginArray()
-            while (reader.hasNext()) {
-                parseEntry(reader)?.let { add(it) }
+            while (r.hasNext()) {
+                parseEntry(r)?.let { add(it) }
             }
-            reader.endArray()
         }
-
-        return ExchangeRates(
+        ExchangeRates(
             success = rates.isNotEmpty(),
             error = null,
             base = Currency.EUR,
@@ -54,16 +51,14 @@ internal class InforEuroRatesAdapter(private val date: LocalDate) {
         return if (name != null && value != null) Rate(name, value) else null
     }
 
-    private fun readErrorResponse(reader: JsonReader): ExchangeRates {
-        return ExchangeRates(
-            success = false,
-            error = reader.readErrorMessage(),
-            base = Currency.EUR,
-            date = date,
-            rates = null,
-            provider = ApiProvider.INFOR_EURO
-        )
-    }
+    private fun errorResponse(message: String?): ExchangeRates = ExchangeRates(
+        success = false,
+        error = message,
+        base = Currency.EUR,
+        date = date,
+        rates = null,
+        provider = ApiProvider.INFOR_EURO
+    )
 
     @Synchronized
     @ToJson

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
@@ -23,16 +23,17 @@ internal class InforEuroTimelineAdapter(
     @FromJson
     @Throws(IOException::class)
     fun fromJson(reader: JsonReader): Timeline {
-        val rates = mutableMapOf<LocalDate, Rate>()
         val datePattern = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
         if (reader.peek() != JsonReader.Token.BEGIN_ARRAY) return readErrorResponse(reader)
 
-        reader.beginArray()
-        while (reader.hasNext()) {
-            processEntry(reader, datePattern, rates)
+        val rates = buildMap {
+            reader.beginArray()
+            while (reader.hasNext()) {
+                processEntry(reader, datePattern, this)
+            }
+            reader.endArray()
         }
-        reader.endArray()
 
         return Timeline(
             success = rates.isNotEmpty(),

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/InforEuroTimelineAdapter.kt
@@ -11,7 +11,6 @@ import de.salomax.currencies.model.Timeline
 import java.io.IOException
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @Suppress("unused", "UNUSED_PARAMETER")
 internal class InforEuroTimelineAdapter(
@@ -19,26 +18,23 @@ internal class InforEuroTimelineAdapter(
     private val endDate: LocalDate
 ) {
 
+    private val base: String = Currency.EUR.iso4217Alpha()
+
     @Synchronized
     @FromJson
     @Throws(IOException::class)
-    fun fromJson(reader: JsonReader): Timeline {
-        val datePattern = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-
-        if (reader.peek() != JsonReader.Token.BEGIN_ARRAY) return readErrorResponse(reader)
-
+    fun fromJson(reader: JsonReader): Timeline = reader.readArrayOrError(
+        onError = ::errorResponse
+    ) { r ->
         val rates = buildMap {
-            reader.beginArray()
-            while (reader.hasNext()) {
-                processEntry(reader, datePattern, this)
+            while (r.hasNext()) {
+                processEntry(r, this)
             }
-            reader.endArray()
         }
-
-        return Timeline(
+        Timeline(
             success = rates.isNotEmpty(),
             error = null,
-            base = Currency.EUR.iso4217Alpha(),
+            base = base,
             startDate = startDate,
             endDate = endDate,
             rates = rates.toSortedMap(compareBy { it }),
@@ -48,7 +44,6 @@ internal class InforEuroTimelineAdapter(
 
     private fun processEntry(
         reader: JsonReader,
-        datePattern: DateTimeFormatter,
         rates: MutableMap<LocalDate, Rate>
     ) {
         reader.beginObject()
@@ -60,8 +55,8 @@ internal class InforEuroTimelineAdapter(
             when (reader.nextName()) {
                 "currencyIso" -> currencyIso = Currency.fromString(reader.nextString())
                 "amount" -> value = BigDecimal(reader.nextString())
-                "dateStart" -> dateStart = LocalDate.parse(reader.nextString(), datePattern)
-                "dateEnd" -> dateEnd = LocalDate.parse(reader.nextString(), datePattern)
+                "dateStart" -> dateStart = LocalDate.parse(reader.nextString(), INFOR_EURO_DATE_FORMATTER)
+                "dateEnd" -> dateEnd = LocalDate.parse(reader.nextString(), INFOR_EURO_DATE_FORMATTER)
                 else -> reader.skipValue()
             }
         }
@@ -71,24 +66,23 @@ internal class InforEuroTimelineAdapter(
         // inclusive: before-or-equal start
         if (startDate.withDayOfMonth(1).isAfter(dateStart)) return
 
+        val rate = Rate(currencyIso, value)
         var date: LocalDate = dateEnd
         while (!date.isBefore(dateStart)) {
-            rates[date] = Rate(currencyIso, value)
+            rates[date] = rate
             date = date.minusDays(1)
         }
     }
 
-    private fun readErrorResponse(reader: JsonReader): Timeline {
-        return Timeline(
-            success = false,
-            error = reader.readErrorMessage(),
-            base = Currency.EUR.iso4217Alpha(),
-            startDate = null,
-            endDate = null,
-            rates = null,
-            provider = ApiProvider.INFOR_EURO
-        )
-    }
+    private fun errorResponse(message: String?): Timeline = Timeline(
+        success = false,
+        error = message,
+        base = base,
+        startDate = null,
+        endDate = null,
+        rates = null,
+        provider = ApiProvider.INFOR_EURO
+    )
 
     @Synchronized
     @ToJson

--- a/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/adapter/OpenExchangeratesRatesAdapter.kt
@@ -23,33 +23,33 @@ internal class OpenExchangeratesRatesAdapter {
     @FromJson
     @Throws(IOException::class)
     fun fromJson(reader: JsonReader): ExchangeRates? {
-        val rates = mutableListOf<Rate>()
         var base: Currency? = null
         var date: LocalDate? = null
         var time: LocalTime? = null
         var errorMessage: String? = null
 
         if (reader.peek() != JsonReader.Token.BEGIN_OBJECT) return null
-        reader.beginObject()
 
-        while (reader.hasNext()) {
-            if (reader.peek() != JsonReader.Token.NAME) continue
-            when (reader.nextName()) {
-                "rates" -> rates.addAll(parseRates(reader))
-                "timestamp" -> {
-                    val zoned = Instant.ofEpochSecond(reader.nextLong())
-                        .atZone(ZoneId.systemDefault())
-                    date = zoned.toLocalDate()
-                    time = zoned.toLocalTime().withSecond(0).withNano(0)
+        val rates = buildList {
+            reader.beginObject()
+            while (reader.hasNext()) {
+                if (reader.peek() != JsonReader.Token.NAME) continue
+                when (reader.nextName()) {
+                    "rates" -> addAll(parseRates(reader))
+                    "timestamp" -> {
+                        val zoned = Instant.ofEpochSecond(reader.nextLong())
+                            .atZone(ZoneId.systemDefault())
+                        date = zoned.toLocalDate()
+                        time = zoned.toLocalTime().withSecond(0).withNano(0)
+                    }
+                    "base" -> base = Currency.fromString(reader.nextString())
+                    "message" -> errorMessage = reader.nextString()
+                    else -> reader.skipValue()
                 }
-                "base" -> base = Currency.fromString(reader.nextString())
-                "message" -> errorMessage = reader.nextString()
-                else -> reader.skipValue()
             }
+            reader.endObject()
+            addFokFromDkkIfMissing()
         }
-
-        reader.endObject()
-        rates.addFokFromDkkIfMissing()
 
         return if (rates.isNotEmpty())
             ExchangeRates(success = true, error = null, base = base, date = date, time = time,
@@ -59,17 +59,15 @@ internal class OpenExchangeratesRatesAdapter {
                 rates = null, provider = ApiProvider.OPEN_EXCHANGERATES)
     }
 
-    private fun parseRates(reader: JsonReader): List<Rate> {
-        val rates = mutableListOf<Rate>()
+    private fun parseRates(reader: JsonReader): List<Rate> = buildList {
         reader.beginObject()
         while (reader.hasNext()) {
             val name = Currency.fromString(reader.nextName())
             val value: BigDecimal = BigDecimal(reader.nextString())
             if (name != null)
-                rates.add(Rate(name, value))
+                add(Rate(name, value))
         }
         reader.endObject()
-        return rates
     }
 
     @Synchronized


### PR DESCRIPTION
## Summary

Two low-risk refactors to the Moshi adapters:

**Commit 1 — `buildList`/`buildMap` in JSON parsers**
Return sealed `List<Rate>` / `Map<LocalDate, Rate>` instead of leaking `MutableList` / `MutableMap` out of the parse builders. Zero runtime cost (Kotlin `buildList {}` uses the same `MutableList` under the hood, just exposes an immutable interface at the boundary).

Touched:
- `FrankfurterAppRatesAdapter` (also swaps `find {} == null` → `none {}`)
- `FrankfurterAppTimelineAdapter`
- `InforEuroRatesAdapter`
- `InforEuroTimelineAdapter`
- `OpenExchangeratesRatesAdapter` (both `fromJson` and `parseRates`)

**Commit 2 — hoist InforEuro constants, dedupe array-or-error**
- Add `INFOR_EURO_DATE_FORMATTER` (`dd/MM/yyyy`) constant in `AdapterUtils.kt`, matching the existing `BANK_ROSSII_DATE_FORMATTER` pattern. Drops the per-call formatter allocation and the `datePattern` parameter previously threaded through `processEntry`.
- Add generic `JsonReader.readArrayOrError<T>` helper. Both InforEuro adapters share the same peek/`BEGIN_ARRAY` opening: on success walk the array, on failure read the `{ "message": ... }` object. The helper centralizes `beginArray`/`endArray` bookkeeping so each adapter only expresses the payload-shaped bits.
- `InforEuroTimelineAdapter`: hoist `Rate(currencyIso, value)` out of the per-date inner loop (one `Rate` instance reused across the date range instead of being reassigned every iteration), and extract `Currency.EUR.iso4217Alpha()` into a private `val` used by both the success and error `Timeline` paths.

Intentionally skipped:
- `BankOfCanadaRatesAdapter` — inner helper `readObservationRates` returns an unrelated `LocalDate?` while mutating a passed-in list; converting would worsen the helper's API.
- `TimelineChart.kt` — the `mutableList*` locals are temporary accumulators inside an already-`buildList { }` outer scope.
- `FeeManagerFragment.kt` — the `radios` list is captured by later click handlers and mutated for selection state.
- The 5 `toJson { writer.nullValue() }` stubs — Moshi requires the concrete typed signature per adapter.
- `readErrorResponse` per-adapter helpers — return types differ (`ExchangeRates` vs `Timeline`); handled instead by the generic helper + a per-adapter `errorResponse(String?)` factory.

## Test plan

- [ ] `./gradlew check assembleDebug` passes locally (blocked here on missing Android SDK — CI will validate)
- [ ] Manual: fetch rates from Frankfurter, InforEuro, and OpenExchangeRates
- [ ] Manual: render the timeline chart for Frankfurter and InforEuro (verify date ranges and value continuity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)