### PR TITLE
Predictive back gesture + DNS prewarm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,13 @@ Other reference docs are in [`docs/markDown/`](docs/markDown/):
 - [`security.md`](docs/markDown/security.md) — security posture
 
 Follow the guidance in those files. If a docs update is needed, edit the relevant `.md` there.
+
+## Code-shape defaults
+
+When touching code, always look for and apply these where possible:
+
+- **Extract functions** for any block that's non-trivial or reused — even once, if it clarifies intent.
+- **Deduplicate**: identical or near-identical logic in two places should become one helper (top-level `internal` fun, extension, or shared util in `model/adapter/AdapterUtils.kt` / similar).
+- **Hoist to variables/constants**: repeated expressions become locals; repeated literals (URLs, date patterns, magic numbers, keys) become named `const val` or `val` at file/package scope.
+
+Do this in-line with whatever task you're doing — don't gate it behind a separate "refactor" ask.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".CurrenciesApplication"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -1,0 +1,26 @@
+package de.salomax.currencies
+
+import android.app.Application
+import de.salomax.currencies.repository.Database
+import java.net.InetAddress
+import kotlin.concurrent.thread
+
+class CurrenciesApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        prewarmProviderDns()
+    }
+
+    // Resolve the currently-selected provider's host on a background thread so
+    // the first network request doesn't pay for DNS. The preference read and
+    // resolution both run off the main thread. Failures (offline, DNS outage)
+    // are silent — this is a best-effort warm-up, not a health check.
+    private fun prewarmProviderDns() {
+        thread(name = "dns-prewarm", isDaemon = true) {
+            val host = Database(this).getApiProvider().getHost() ?: return@thread
+            runCatching { InetAddress.getAllByName(host) }
+        }
+    }
+
+}

--- a/app/src/main/kotlin/de/salomax/currencies/model/ApiProvider.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/ApiProvider.kt
@@ -11,6 +11,7 @@ import de.salomax.currencies.model.provider.FrankfurterApp
 import de.salomax.currencies.model.provider.InforEuro
 import de.salomax.currencies.model.provider.NorgesBank
 import de.salomax.currencies.model.provider.OpenExchangerates
+import java.net.URI
 import java.time.LocalDate
 
 private const val ID_FRANKFURTER_APP = 1
@@ -55,6 +56,10 @@ enum class ApiProvider(
 
     fun getHint(context: Context): CharSequence? =
         this.implementation.descriptionHint(context)
+
+    // Host portion of [baseUrl], used to prewarm DNS at app start.
+    fun getHost(): String? =
+        runCatching { URI(this.implementation.baseUrl).host }.getOrNull()
 
     suspend fun getRates(context: Context?, date: LocalDate?): Result<ExchangeRates, FuelError> =
         this.implementation.getRates(context, date)

--- a/docs/features.html
+++ b/docs/features.html
@@ -132,6 +132,20 @@
       <h3>20+ Languages</h3>
       <p>Translated by the community via <a href="https://translate.codeberg.org/engage/currencies/">Weblate</a>. RTL languages are fully supported.</p>
     </div>
+    <div class="card">
+      <span class="card-icon">👆</span>
+      <h3>Predictive Back Gesture</h3>
+      <p>On Android 13+ the system's animated back-preview is enabled, so swiping back reveals where you're heading before you commit to the gesture.</p>
+    </div>
+  </div>
+
+  <h2 class="section-title">Performance</h2>
+  <div class="cards" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));">
+    <div class="card">
+      <span class="card-icon">⚡</span>
+      <h3>DNS Prewarm</h3>
+      <p>At app startup the currently-selected provider's hostname is resolved on a background thread, so the first rate refresh doesn't have to wait on DNS.</p>
+    </div>
   </div>
 
   <h2 class="section-title">Privacy &amp; Permissions</h2>

--- a/docs/markDown/architecture.md
+++ b/docs/markDown/architecture.md
@@ -33,6 +33,7 @@ Currencies follows **MVVM** (Model-View-ViewModel) with a Repository layer, impl
 
 ```
 app/src/main/kotlin/de/salomax/currencies/
+├── CurrenciesApplication.kt   # Application subclass — prewarms provider DNS at startup
 ├── model/
 │   ├── ApiProvider.kt          # Enum of 6 providers + abstract Api interface
 │   ├── Currency.kt             # 190+ ISO-4217 currencies with symbols & flags
@@ -101,6 +102,18 @@ Behavior preserved: dashed reference line at the last value, scrub-to-past-date 
 ### Graph options: user-tunable chart chrome
 
 Four `SharedPreferenceLiveData<Boolean>` streams — grid, X-axis labels, Y-axis labels, and highlight-extremes — flow from `Database` through the `TimelineActivity` into `TimelineChart`. All default to `true` so first-run appearance is unchanged. Inside the composable each toggle swaps a Vico component for `null` (e.g. `guideline = if (showGrid) rememberAxisGuidelineComponent() else null`); Vico treats `null` as "don't draw," so no branching in the layer definitions is needed.
+
+### Application subclass prewarms DNS for the selected provider
+
+`CurrenciesApplication` is registered via `android:name=".CurrenciesApplication"` on the manifest's `<application>` tag. Its only responsibility today is to resolve the currently-selected `ApiProvider`'s host on a background daemon thread during `onCreate()`, so the first exchange-rate request doesn't pay for DNS.
+
+The preference read (`Database(this).getApiProvider()`) and the `InetAddress.getAllByName(host)` call both run **inside** the background thread — SharedPreferences load and DNS resolution are both blocking I/O and neither belongs on the main thread during app startup. Failures (offline, DNS outage) are swallowed with `runCatching`; this is a best-effort warm-up, not a health check.
+
+`ApiProvider.getHost()` (a narrow accessor over the enum's `private implementation.baseUrl`) exposes only the hostname to callers, so the `Application` never touches the full base URL.
+
+### Predictive back gesture
+
+Opted in via `android:enableOnBackInvokedCallback="true"` on the manifest's `<application>` tag. This is a global opt-in for the predictive back animation on Android 13+ (API 33). No per-screen `OnBackInvokedCallback` wiring is added — the app's existing back behavior is compatible with the default animated preview.
 
 ### Build Flavors: `play` vs `fdroid`
 

--- a/docs/markDown/overview.md
+++ b/docs/markDown/overview.md
@@ -24,6 +24,8 @@ Convert between 30–160+ world currencies using live exchange rates fetched fro
 | Starred currencies | Favourite/filter currencies for quick access |
 | Themes | Light, dark, and pure-black modes; follows system setting |
 | Foldable support | Adaptive multi-pane layout via WindowInfoTracker |
+| Predictive back gesture | Opted in via `android:enableOnBackInvokedCallback` (API 33+) |
+| DNS prewarm | Selected provider's host is resolved at app startup on a background thread |
 | Internationalization | 20+ languages via Weblate |
 
 ## Distribution


### PR DESCRIPTION
## Summary
- Opt in to Android 13+ predictive back animation via `android:enableOnBackInvokedCallback` on `<application>`.
- Add `CurrenciesApplication` subclass that resolves the currently-selected provider's host on a background daemon thread during `onCreate()`, so the first rate refresh doesn't pay for DNS. SharedPreferences read + `InetAddress.getAllByName` both run off the main thread; failures swallowed with `runCatching` (best-effort warm-up, not a health check).
- Narrow `ApiProvider.getHost()` accessor keeps the enum's `baseUrl` private.
- Codify "extract / dedupe / hoist repeated literals" as an in-line default in `CLAUDE.md`.
- Docs updated: `features.html`, `overview.md`, `architecture.md`.

## Test plan
- [ ] Install on an Android 13+ device — confirm animated back preview appears on gesture-nav swipe-back.
- [ ] Cold-start the app offline, then online — confirm no crash from the prewarm thread in either case.
- [ ] Switch provider in Settings, cold-start again — confirm the new provider's host is what gets prewarmed (check via `adb logcat` if instrumented, or infer from first-request latency).
- [ ] Verify `ApiProvider.getHost()` returns only the host, not the full base URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)