### PR TITLE
fix(fees): back returns to caller (Main / Quick conversions), not Settings

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceActivity.kt
@@ -39,10 +39,14 @@ class PreferenceActivity: BaseActivity() {
         setTitle(R.string.title_preferences)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
+        // When opened directly via feesIntent (from Main / Quick conversions),
+        // make FeeManager the root fragment with no back-stack entry, so pressing
+        // back finishes this activity and returns to the caller — not to Settings.
+        // The path from Settings itself uses its own fragment transaction in
+        // PreferenceFragment (with addToBackStack), so back there still pops to Settings.
         if (savedInstanceState == null && intent.getBooleanExtra(EXTRA_OPEN_FEES, false)) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.preferences_fragment, FeeManagerFragment())
-                .addToBackStack(null)
                 .commit()
         }
     }


### PR DESCRIPTION
## Summary
When Fees was opened directly via `PreferenceActivity.feesIntent()` from `MainActivity` or `QuickConversionsDialog`, `PreferenceActivity` inflated its layout — which auto-instantiates `PreferenceFragment` (Settings) via the `FragmentContainerView`'s `android:name` — and then replaced it with `FeeManagerFragment` on the back stack. Pressing back popped to Settings instead of returning to the caller.

Drop `addToBackStack` for the direct-open path so `FeeManagerFragment` becomes the root fragment: back finishes the activity and returns to whichever screen invoked it.

The Settings-launched path uses its own fragment transaction in `PreferenceFragment` (with `addToBackStack`) — unchanged, so back there still pops to Settings.

Fees changes propagate back to the caller automatically: `MainActivity` and `QuickConversionsDialog` both observe fee `LiveData` and re-render on resume, so returning from FeeManager shows up-to-date fees without any manual refresh.

## Test plan
- [ ] From Main → overflow menu → Fees → edit a fee → press back → land on **Main**, with the new fee reflected in totals.
- [ ] Open Quick conversions dialog → long-press swap or fee-side button → Fees → edit a fee → press back → land back on **Quick conversions**, rows re-rendered with new fee.
- [ ] Open Settings → tap the Fees preference → edit a fee → press back → land on **Settings** (unchanged behavior).
- [ ] Repeat all three above using the Up (home) arrow instead of the system back button.
- [ ] Repeat on Android 13+ with predictive back — animated preview should show the correct destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)