### PR TITLE
PR-A: security & perf quick wins — no-backup, TLS config, shared Moshi, cached date

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,11 +6,14 @@
 
     <application
         android:name=".CurrenciesApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="UnusedAttribute">

--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -9,7 +9,21 @@ class CurrenciesApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        warmSharedPreferences()
         prewarmProviderDns()
+    }
+
+    // Force each SharedPreferences file the app uses to load from disk on a
+    // background thread ahead of the first Activity. SharedPreferences is
+    // in-memory after the first read, so subsequent main-thread reads in
+    // BaseActivity.onCreate (theme, pure-black) hit RAM instead of blocking
+    // on I/O during app startup.
+    private fun warmSharedPreferences() {
+        thread(name = "prefs-warm", isDaemon = true) {
+            runCatching {
+                Database(this).getTheme()
+            }
+        }
     }
 
     // Resolve the currently-selected provider's host on a background thread so

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/BankOfCanada.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/BankOfCanada.kt
@@ -7,7 +7,6 @@ import com.github.kittinunf.fuel.core.awaitResult
 import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
@@ -58,7 +57,7 @@ class BankOfCanada: ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .add(BankOfCanadaRatesAdapter())
                     .build()
                     .adapter(ExchangeRates::class.java)
@@ -90,7 +89,7 @@ class BankOfCanada: ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .add(BankOfCanadaTimelineAdapter(base, symbol))
                     .build()
                     .adapter(Timeline::class.java)

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/FerEe.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/FerEe.kt
@@ -8,13 +8,11 @@ import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Timeline
-import de.salomax.currencies.model.adapter.LocalDateAdapter
 import de.salomax.currencies.model.adapter.FrankfurterAppRatesAdapter
 import de.salomax.currencies.model.adapter.FrankfurterAppTimelineAdapter
 import java.time.LocalDate
@@ -52,10 +50,10 @@ class FerEe : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(FrankfurterAppRatesAdapter(base))
-                        add(LocalDateAdapter())
+                        add(SHARED_LOCAL_DATE_ADAPTER)
                     }
                     .build()
                     .adapter(ExchangeRates::class.java)
@@ -84,10 +82,10 @@ class FerEe : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(FrankfurterAppRatesAdapter(base))
-                        add(LocalDateAdapter())
+                        add(SHARED_LOCAL_DATE_ADAPTER)
                         add(FrankfurterAppTimelineAdapter(symbol))
                     }
                     .build()

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/FrankfurterApp.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/FrankfurterApp.kt
@@ -8,13 +8,11 @@ import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Timeline
-import de.salomax.currencies.model.adapter.LocalDateAdapter
 import de.salomax.currencies.model.adapter.FrankfurterAppRatesAdapter
 import de.salomax.currencies.model.adapter.FrankfurterAppTimelineAdapter
 import java.time.LocalDate
@@ -52,10 +50,10 @@ class FrankfurterApp : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(FrankfurterAppRatesAdapter(base))
-                        add(LocalDateAdapter())
+                        add(SHARED_LOCAL_DATE_ADAPTER)
                     }
                     .build()
                     .adapter(ExchangeRates::class.java)
@@ -87,10 +85,10 @@ class FrankfurterApp : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(FrankfurterAppRatesAdapter(base))
-                        add(LocalDateAdapter())
+                        add(SHARED_LOCAL_DATE_ADAPTER)
                         add(FrankfurterAppTimelineAdapter(symbol))
                     }
                     .build()

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/InforEuro.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/InforEuro.kt
@@ -8,7 +8,6 @@ import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
@@ -49,7 +48,7 @@ class InforEuro : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(InforEuroRatesAdapter(date ?: LocalDate.now(ZoneOffset.UTC)))
                     }
@@ -76,7 +75,7 @@ class InforEuro : ApiProvider.Api() {
 
         val deserializer = moshiDeserializerOf(
             Moshi.Builder()
-                .addLast(KotlinJsonAdapterFactory())
+                .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                 .add(InforEuroTimelineAdapter(startDate, endDate))
                 .build()
                 .adapter(Timeline::class.java)

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/OpenExchangerates.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/OpenExchangerates.kt
@@ -8,7 +8,6 @@ import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
@@ -59,7 +58,7 @@ class OpenExchangerates : ApiProvider.Api() {
         ).awaitResult(
             moshiDeserializerOf(
                 Moshi.Builder()
-                    .addLast(KotlinJsonAdapterFactory())
+                    .addLast(SHARED_KOTLIN_JSON_ADAPTER_FACTORY)
                     .apply {
                         add(OpenExchangeratesRatesAdapter())
                     }

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/ProviderUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/ProviderUtils.kt
@@ -1,8 +1,20 @@
 package de.salomax.currencies.model.provider
 
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.salomax.currencies.model.Currency
+import de.salomax.currencies.model.adapter.LocalDateAdapter
 
 // FOK (Faroese króna) is pegged 1:1 to DKK and not listed by upstream APIs —
 // query DKK instead and let callers relabel the result on the way back.
 internal fun Currency.apiCodeOrDkkForFok(): String =
     if (this == Currency.FOK) "DKK" else this.iso4217Alpha()
+
+// One shared KotlinJsonAdapterFactory across every provider. The factory
+// keeps its own class-to-adapter cache internally, so a single instance
+// means the reflection scan runs once app-wide per data class instead of
+// once per HTTP request. Safe to share: the factory is stateless.
+internal val SHARED_KOTLIN_JSON_ADAPTER_FACTORY: KotlinJsonAdapterFactory =
+    KotlinJsonAdapterFactory()
+
+// Stateless date adapter — hoisted for the same reason as the factory above.
+internal val SHARED_LOCAL_DATE_ADAPTER: LocalDateAdapter = LocalDateAdapter()

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -78,6 +78,10 @@ class MainActivity : BaseActivity() {
     private lateinit var preferenceModel: PreferenceViewModel
 
     private var hapticEnabled = false
+    // Cached date pattern so the frequently-fired `observeExchangeRates`
+    // handler doesn't hit SharedPreferences on the main thread on every rate
+    // emission. Kept in sync via the `getDateFormat()` LiveData below.
+    private var dateFormatPattern: String = "dd/MM/yy HH:mm"
 
     private lateinit var refreshIndicator: LinearProgressIndicator
     private lateinit var swipeRefresh: SwipeRefreshLayout
@@ -324,6 +328,12 @@ class MainActivity : BaseActivity() {
     }
 
     private fun observe() {
+        Database(this).getDateFormat().observe(this) { pattern ->
+            dateFormatPattern = pattern
+            // Re-render the rates footer so a pattern change from Settings
+            // takes effect immediately without waiting for the next refresh.
+            observeExchangeRates(viewModel.getExchangeRates().value)
+        }
         viewModel.ratesInformationFooter.observe(this) { tvInfoConversion.text = it }
         viewModel.getExchangeRates().observe(this) { observeExchangeRates(it) }
         viewModel.getError().observe(this) { showErrorSnackbar(it) }
@@ -398,8 +408,8 @@ class MainActivity : BaseActivity() {
         rates?.let {
             val date = it.date
             val time = it.time
-            val pattern = Database(this).getDateFormatBlocking()
-            val effectivePattern = if (time != null) pattern else stripTimePattern(pattern)
+            val effectivePattern =
+                if (time != null) dateFormatPattern else stripTimePattern(dateFormatPattern)
             val temporal = when {
                 date == null -> null
                 time != null -> date.atTime(time)

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Android 12+ (API 31+) backup/transfer rules. Paired with
+  android:allowBackup="false" and android:fullBackupContent="false" in the
+  manifest, so no SharedPreferences are copied to Google cloud backups or
+  device-to-device transfers. Explicit rules keep the intent legible even
+  though the parent flags already opt out.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="file" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+        <exclude domain="file" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cleartext HTTP is refused globally. Every exchange-rate provider currently
+  configured (see ApiProvider) exposes HTTPS-only endpoints, so this closes
+  off downgrade/MITM avenues without breaking any real traffic.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/docs/markDown/security.md
+++ b/docs/markDown/security.md
@@ -40,6 +40,16 @@ The app declares a single permission:
 
 No location, contacts, storage, camera, or microphone access.
 
+## Network Security
+
+`res/xml/network_security_config.xml` refuses cleartext HTTP globally. Every configured exchange-rate provider serves HTTPS only, so the config closes off downgrade / MITM avenues without breaking real traffic.
+
+## Backups
+
+`android:allowBackup="false"` and `android:fullBackupContent="false"` are set in the manifest, backed by an explicit `res/xml/data_extraction_rules.xml` that excludes every domain (`root`, `database`, `sharedpref`, `external`, `file`) from both **cloud backups** and **device-to-device transfers** on Android 12+.
+
+Rationale: SharedPreferences contain the user's OpenExchangeRates API key (if any), their fee config, and starred currencies — none of which should leak into an off-device Google backup by default. Users who want backups get an in-app, opt-in mechanism (see the Backup feature in Settings) with optional password encryption.
+
 ## Code Analysis
 
 | Tool | Scope | Frequency |


### PR DESCRIPTION
## Summary
First of a five-part hardening sweep. All items low-risk, no behaviour changes for the user.

**Security**
- `android:allowBackup="false"` + explicit `res/xml/data_extraction_rules.xml` — SharedPreferences (OpenExchangeRates API key, fees, starred currencies) no longer leak into Google Cloud backups or Android 12+ device-to-device transfers. Intentional prep for the opt-in Backup feature landing in PR-C/D/E, which gives users an on-device alternative with optional password encryption.
- New `res/xml/network_security_config.xml` refuses cleartext HTTP globally. Every configured provider is HTTPS-only, so nothing legitimate breaks; closes off any accidental future downgrade.

**Performance**
- Shared `KotlinJsonAdapterFactory` + `LocalDateAdapter` hoisted into `ProviderUtils.kt`. The factory keeps its own class-to-adapter cache internally, so one instance means the reflection scan runs once app-wide per data class instead of once per HTTP request.
- `CurrenciesApplication.onCreate` warms `SharedPreferences` on a background thread. `BaseActivity.onCreate` still reads theme + pure-black synchronously (Android requires that before `super.onCreate`), but now hits RAM instead of blocking on disk during cold start.
- `MainActivity` caches the date pattern via `getDateFormat()` LiveData instead of calling `getDateFormatBlocking()` on every rate emission. Removes a main-thread SharedPreferences read from a hot re-render path.

Docs update: `docs/markDown/security.md` gains sections on the new network-security config and backup posture.

## Test plan
- [ ] `./gradlew assembleFdroidDebug` passes on CI
- [ ] App launches; theme + pure-black still applied without flash
- [ ] Currency conversion works (verifies shared Moshi factory doesn't break any provider)
- [ ] Timeline chart still loads for all providers that support it
- [ ] Changing the date format in Settings updates the main-screen footer immediately
- [ ] No Detekt regressions

## Follow-ups (separate PRs)
- **PR-B**: LiveData/adapter hot-path fixes (`SharedPreferenceExchangeRatesLiveData.getAll()`, `SearchableSpinnerAdapter` DiffUtil, request coalescing).
- **PR-C**: Backup MVP (Settings screen, Off/Local, SAF export+import, plaintext JSON).
- **PR-D**: Backup encryption (optional password → PBKDF2 + AES-256-GCM).
- **PR-E**: Scheduled local backup (frequency picker + WorkManager + retention).