### PR TITLE
PR-B: dedupe in-flight API calls + collapse LiveData hot paths

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/repository/ExchangeRatesRepository.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/ExchangeRatesRepository.kt
@@ -11,6 +11,7 @@ import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Timeline
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -36,21 +37,31 @@ class ExchangeRatesRepository(private val context: Context) {
     private var liveError = MutableLiveData<String?>()
     private var isUpdating = db.isUpdating()
 
+    // Track in-flight fetches so rapid re-triggers (swipe-to-refresh spam,
+    // toolbar tap during pull, currency swap chains) share the current job
+    // instead of spawning parallel HTTP requests against the same endpoint.
+    // A single key per fetch shape is enough: rates has no args, timeline
+    // is keyed by "base|symbol".
+    private var ratesJob: Job? = null
+    private val timelineJobs = mutableMapOf<String, Job>()
+
     /**
      * Gets and returns all latest exchange rates from the API.
      */
     fun getExchangeRates(): LiveData<ExchangeRates?> {
-        launchApiCall { start ->
-            ExchangeRatesService.getRates(
-                apiProvider = db.getApiProvider(),
-                date = db.getHistoricalDate(),
-                context
-            ).processResponse(
-                start = start,
-                successFlag = { success },
-                errorMessage = { error },
-                onSuccess = { db.insertExchangeRates(it) }
-            )
+        if (ratesJob?.isActive != true) {
+            ratesJob = launchApiCall { start ->
+                ExchangeRatesService.getRates(
+                    apiProvider = db.getApiProvider(),
+                    date = db.getHistoricalDate(),
+                    context
+                ).processResponse(
+                    start = start,
+                    successFlag = { success },
+                    errorMessage = { error },
+                    onSuccess = { db.insertExchangeRates(it) }
+                )
+            }
         }
         return liveExchangeRates
     }
@@ -59,30 +70,35 @@ class ExchangeRatesRepository(private val context: Context) {
      * Gets and returns the timeline of the last year of the given base and target currency
      */
     fun getTimeline(base: Currency, symbol: Currency): LiveData<Timeline?> {
-        launchApiCall { start ->
-            ExchangeRatesService.getTimeline(
-                apiProvider = db.getApiProvider(),
-                base = base,
-                symbol = symbol,
-                context = context
-            ).processResponse(
-                start = start,
-                successFlag = { success },
-                errorMessage = { error },
-                onSuccess = { timeline ->
-                    CoroutineScope(Dispatchers.Main).launch {
-                        liveTimeline.setValue(timeline)
+        val key = "${base.iso4217Alpha()}|${symbol.iso4217Alpha()}"
+        val existing = timelineJobs[key]
+        if (existing?.isActive != true) {
+            val job = launchApiCall { start ->
+                ExchangeRatesService.getTimeline(
+                    apiProvider = db.getApiProvider(),
+                    base = base,
+                    symbol = symbol,
+                    context = context
+                ).processResponse(
+                    start = start,
+                    successFlag = { success },
+                    errorMessage = { error },
+                    onSuccess = { timeline ->
+                        CoroutineScope(Dispatchers.Main).launch {
+                            liveTimeline.setValue(timeline)
+                        }
                     }
-                }
-            )
+                )
+            }
+            timelineJobs[key] = job
         }
         return liveTimeline
     }
 
-    private fun launchApiCall(block: suspend (start: Long) -> Unit) {
+    private fun launchApiCall(block: suspend (start: Long) -> Unit): Job {
         val start = System.currentTimeMillis()
         db.setUpdating(true)
-        CoroutineScope(Dispatchers.IO).launch { block(start) }
+        return CoroutineScope(Dispatchers.IO).launch { block(start) }
     }
 
     private suspend fun <T : Any> Result<T, FuelError>.processResponse(

--- a/app/src/main/kotlin/de/salomax/currencies/util/SharedPreferenceExchangeRatesLiveData.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/SharedPreferenceExchangeRatesLiveData.kt
@@ -2,6 +2,8 @@ package de.salomax.currencies.util
 
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.LiveData
 import de.salomax.currencies.model.ApiProvider
 import de.salomax.currencies.model.Currency
@@ -25,7 +27,17 @@ internal const val NO_PROVIDER_ID = -1
 
 private const val METADATA_KEY_PREFIX = "_"
 
+// insertExchangeRates() writes ~180 currency keys in a single edit(); the
+// OnSharedPreferenceChangeListener still fires once per key. Debouncing the
+// recompute collapses that burst into a single O(n) pass instead of O(n²).
+// 50 ms is well below any human-perceptible refresh latency and long enough
+// to cover the whole apply() cycle even on slow devices.
+private const val DEBOUNCE_MS = 50L
+
 class SharedPreferenceExchangeRatesLiveData(private val sharedPrefs: SharedPreferences) : LiveData<ExchangeRates?>() {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val recomputeRunnable = Runnable { postValue(getValueFromPreferences()) }
 
     private fun getValueFromPreferences(): ExchangeRates? {
         if (sharedPrefs.getString(KEY_RATES_BASE, null) == null || sharedPrefs.getString(KEY_RATES_DATE, null) == null)
@@ -51,7 +63,8 @@ class SharedPreferenceExchangeRatesLiveData(private val sharedPrefs: SharedPrefe
     }
 
     private val preferenceChangeListener = OnSharedPreferenceChangeListener { _: SharedPreferences?, _: String? ->
-            postValue(getValueFromPreferences())
+        mainHandler.removeCallbacks(recomputeRunnable)
+        mainHandler.postDelayed(recomputeRunnable, DEBOUNCE_MS)
     }
 
     override fun onActive() {
@@ -62,6 +75,7 @@ class SharedPreferenceExchangeRatesLiveData(private val sharedPrefs: SharedPrefe
 
     override fun onInactive() {
         sharedPrefs.unregisterOnSharedPreferenceChangeListener(preferenceChangeListener)
+        mainHandler.removeCallbacks(recomputeRunnable)
         super.onInactive()
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerAdapter.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/spinner/SearchableSpinnerAdapter.kt
@@ -70,11 +70,14 @@ class SearchableSpinnerAdapter(context: Context, resource: Int) :
     }
 
     fun setRates(rates: List<Rate>?) {
-        if (rates == null)
-            this.rates = ArrayList()
-        else
-            this.rates = rates
-        notifyDataSetChanged()
+        val next = rates ?: emptyList()
+        // The spinner row only renders currency + flag; the rate value never
+        // shows. Compare by currency list so no-op updates (same currencies,
+        // fresh values) don't force a full rebind cycle.
+        val sameCurrencies = next.size == this.rates.size &&
+            next.asSequence().zip(this.rates.asSequence()).all { (a, b) -> a.currency == b.currency }
+        this.rates = next
+        if (!sameCurrencies) notifyDataSetChanged()
     }
 
     internal class ViewHolder {


### PR DESCRIPTION
## Summary
Follow-up to PR-A. Three narrow perf fixes, no behaviour changes for the user.

**SharedPreferenceExchangeRatesLiveData**
- `insertExchangeRates()` writes ~180 currency keys under one `apply()`, but `OnSharedPreferenceChangeListener` fires per key — so the O(n) `getValueFromPreferences()` ran ~180× per refresh (O(n²) overall).
- Debounce the recompute via a 50 ms `Handler` post so the whole burst collapses into one pass. Cancelled on `onInactive()`.

**SearchableSpinnerAdapter**
- Row only renders currency + flag; the rate value never shows.
- Guard `setRates()` so no-op refreshes (same currencies, fresh values) skip `notifyDataSetChanged` and avoid a full spinner rebind cycle. Cheap ordered-list compare; no DiffUtil rewrite needed (spinners can't use it anyway).

**ExchangeRatesRepository**
- Track in-flight fetches via `Job` references. Rapid re-triggers (swipe-to-refresh spam, LiveData re-observation on config change, currency-swap chains) share the current job instead of spawning parallel identical HTTP requests.
- Timeline is keyed by `base|symbol` since parallel fetches for different pairs are legitimate.

## Test plan
- [ ] `./gradlew assembleFdroidDebug` passes on CI
- [ ] Cold start → rates load and display correctly
- [ ] Swipe-to-refresh: single network hit even when swiped multiple times rapidly
- [ ] Change provider in Settings → rates re-fetch and update
- [ ] Timeline: open, close, reopen with different pair — each pair fetches fresh
- [ ] Spinner still shows all 30+ currencies after force refresh

## Depends on
Independent of PR-A. Cleanly rebases either way.

## Follow-ups
- **PR-C**: Backup MVP (Settings → Off/Local + SAF export/import + plaintext JSON)
- **PR-D**: Backup encryption
- **PR-E**: Scheduled local backup