### PR TITLE
PR-E: scheduled local backup via WorkManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,10 @@ dependencies {
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
     implementation("androidx.window:window:1.5.1")
+    // scheduled backup: WorkManager for periodic exports, DocumentFile for
+    // writing into the user-picked SAF tree URI.
+    implementation("androidx.work:work-runtime-ktx:2.10.0")
+    implementation("androidx.documentfile:documentfile:1.0.1")
     implementation("com.google.android.material:material:1.14.0")
     // downloader
     val fuelVersion = "2.3.1"

--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -1,6 +1,7 @@
 package de.salomax.currencies
 
 import android.app.Application
+import de.salomax.currencies.repository.BackupScheduler
 import de.salomax.currencies.repository.Database
 import java.net.InetAddress
 import kotlin.concurrent.thread
@@ -11,6 +12,17 @@ class CurrenciesApplication : Application() {
         super.onCreate()
         warmSharedPreferences()
         prewarmProviderDns()
+        reregisterScheduledBackup()
+    }
+
+    // WorkManager persists jobs, but re-enqueuing on startup is a cheap way to
+    // recover from edge cases (app updates that changed the worker class,
+    // "Force stop" that dropped scheduled work, users who cleared app data).
+    // No-op when the user hasn't enabled scheduled backups.
+    private fun reregisterScheduledBackup() {
+        thread(name = "backup-scheduler-init", isDaemon = true) {
+            runCatching { BackupScheduler.reschedule(this) }
+        }
     }
 
     // Force each SharedPreferences file the app uses to load from disk on a

--- a/app/src/main/kotlin/de/salomax/currencies/repository/BackupScheduler.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/BackupScheduler.kt
@@ -1,0 +1,101 @@
+package de.salomax.currencies.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import androidx.preference.PreferenceManager
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import de.salomax.currencies.worker.ScheduledBackupWorker
+import java.util.concurrent.TimeUnit
+
+// Preference keys — shared between the settings UI and the WorkManager worker.
+// Persisted in the default SharedPreferences file. The tree URI is stored as
+// its string form; the worker resolves it back through DocumentFile.
+internal const val PREF_KEY_SCHEDULE_FREQUENCY = "backup_schedule_frequency"
+internal const val PREF_KEY_SCHEDULE_TREE_URI = "backup_schedule_tree_uri"
+internal const val PREF_KEY_SCHEDULE_RETENTION = "backup_schedule_retention"
+
+// Frequency tokens persisted as-is so the UI list values match the pref value
+// directly (no int/enum indirection to keep in sync).
+internal const val FREQUENCY_OFF = "off"
+internal const val FREQUENCY_DAILY = "daily"
+internal const val FREQUENCY_WEEKLY = "weekly"
+internal const val FREQUENCY_MONTHLY = "monthly"
+
+// WorkManager's minimum periodic interval is 15 min; monthly is expressed as
+// 30 days to avoid a variable-length month calculation — close enough for a
+// user-facing "monthly" cadence.
+private const val DAILY_HOURS = 24L
+private const val WEEKLY_HOURS = 24L * 7
+private const val MONTHLY_HOURS = 24L * 30
+
+internal const val DEFAULT_RETENTION = 5
+
+// Single WorkManager unique-work name so re-scheduling replaces any previous
+// job for this feature rather than accumulating parallel workers.
+internal const val WORK_NAME_SCHEDULED_BACKUP = "scheduled_backup"
+
+object BackupScheduler {
+
+    fun prefs(context: Context): SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun getFrequency(context: Context): String =
+        prefs(context).getString(PREF_KEY_SCHEDULE_FREQUENCY, FREQUENCY_OFF) ?: FREQUENCY_OFF
+
+    fun getTreeUri(context: Context): Uri? =
+        prefs(context).getString(PREF_KEY_SCHEDULE_TREE_URI, null)?.let(Uri::parse)
+
+    fun getRetention(context: Context): Int =
+        prefs(context).getInt(PREF_KEY_SCHEDULE_RETENTION, DEFAULT_RETENTION)
+
+    fun setFrequency(context: Context, frequency: String) {
+        prefs(context).edit().putString(PREF_KEY_SCHEDULE_FREQUENCY, frequency).apply()
+        reschedule(context)
+    }
+
+    fun setTreeUri(context: Context, uri: Uri) {
+        prefs(context).edit().putString(PREF_KEY_SCHEDULE_TREE_URI, uri.toString()).apply()
+        reschedule(context)
+    }
+
+    fun setRetention(context: Context, count: Int) {
+        prefs(context).edit().putInt(PREF_KEY_SCHEDULE_RETENTION, count).apply()
+        // Retention is read by the worker at run time — no need to re-enqueue.
+    }
+
+    /**
+     * Enqueue (or cancel) the periodic worker based on the current preference
+     * state. Called from settings changes and from application startup so the
+     * worker is re-registered after upgrades or reinstalls.
+     */
+    fun reschedule(context: Context) {
+        val wm = WorkManager.getInstance(context)
+        val frequency = getFrequency(context)
+        val treeUri = getTreeUri(context)
+        if (frequency == FREQUENCY_OFF || treeUri == null) {
+            wm.cancelUniqueWork(WORK_NAME_SCHEDULED_BACKUP)
+            return
+        }
+        val hours = when (frequency) {
+            FREQUENCY_DAILY -> DAILY_HOURS
+            FREQUENCY_WEEKLY -> WEEKLY_HOURS
+            FREQUENCY_MONTHLY -> MONTHLY_HOURS
+            else -> {
+                wm.cancelUniqueWork(WORK_NAME_SCHEDULED_BACKUP)
+                return
+            }
+        }
+        val request = PeriodicWorkRequestBuilder<ScheduledBackupWorker>(hours, TimeUnit.HOURS)
+            .build()
+        // UPDATE (not KEEP) so that changing the frequency actually shortens the
+        // interval; KEEP would silently ignore the new value.
+        wm.enqueueUniquePeriodicWork(
+            WORK_NAME_SCHEDULED_BACKUP,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/BackupFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/BackupFragment.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.documentfile.provider.DocumentFile
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -23,25 +24,43 @@ import com.google.android.material.textfield.TextInputLayout
 import de.salomax.currencies.R
 import de.salomax.currencies.repository.BackupManager
 import de.salomax.currencies.repository.BackupResult
+import de.salomax.currencies.repository.BackupScheduler
+import de.salomax.currencies.repository.FREQUENCY_DAILY
+import de.salomax.currencies.repository.FREQUENCY_MONTHLY
+import de.salomax.currencies.repository.FREQUENCY_OFF
+import de.salomax.currencies.repository.FREQUENCY_WEEKLY
 
 // Preference row keys — leading __ marks them as UI-only (not persisted).
 private const val PREF_KEY_EXPORT = "__backup_export"
 private const val PREF_KEY_IMPORT = "__backup_import"
+private const val PREF_KEY_SCHEDULE_FREQ = "__backup_schedule_frequency"
+private const val PREF_KEY_SCHEDULE_FOLDER = "__backup_schedule_folder"
+private const val PREF_KEY_SCHEDULE_RETENTION = "__backup_schedule_retention"
 
 // Minimum password length for encrypted export. Chosen to nudge users
 // toward something that survives a modest offline attack — PBKDF2 stretches
 // still buy time, but a 4-char password is broken in seconds.
 private const val MIN_PASSWORD_LENGTH = 8
 
+// Frequency + retention choices. Order matters — the index into these arrays
+// maps to the checked row in the single-choice dialog.
+private val FREQUENCY_VALUES = arrayOf(
+    FREQUENCY_OFF, FREQUENCY_DAILY, FREQUENCY_WEEKLY, FREQUENCY_MONTHLY
+)
+private val RETENTION_VALUES = intArrayOf(1, 3, 5, 10, 20)
+
 class BackupFragment : PreferenceFragmentCompat() {
 
     private lateinit var backupManager: BackupManager
     private lateinit var exportLauncher: ActivityResultLauncher<Intent>
     private lateinit var importLauncher: ActivityResultLauncher<Intent>
+    private lateinit var folderLauncher: ActivityResultLauncher<Intent>
 
     // The password chosen in the pre-export dialog, held only long enough to
     // hand off to BackupManager (which zeroes it after use).
     private var pendingExportPassword: CharArray? = null
+
+    private var folderPreference: Preference? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,6 +77,11 @@ class BackupFragment : PreferenceFragmentCompat() {
             ActivityResultContracts.StartActivityForResult()
         ) { result ->
             result.data?.data?.let(::beginImport)
+        }
+        folderLauncher = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            result.data?.data?.let(::onFolderPicked)
         }
     }
 
@@ -85,6 +109,39 @@ class BackupFragment : PreferenceFragmentCompat() {
                 summaryRes = R.string.backup_import_summary,
                 onClick = ::launchImport,
             )
+        )
+
+        val scheduleCategory = addCategory(screen, ctx, R.string.backup_section_schedule)
+        scheduleCategory.addPreference(
+            buildActionPreference(
+                ctx = ctx,
+                key = PREF_KEY_SCHEDULE_FREQ,
+                titleRes = R.string.backup_schedule_frequency_title,
+                summaryRes = 0,
+                onClick = ::promptFrequency,
+            ).also { it.summary = frequencySummary(BackupScheduler.getFrequency(ctx)) }
+        )
+        folderPreference = buildActionPreference(
+            ctx = ctx,
+            key = PREF_KEY_SCHEDULE_FOLDER,
+            titleRes = R.string.backup_schedule_folder_title,
+            summaryRes = 0,
+            onClick = ::launchFolderPicker,
+        ).also { it.summary = folderSummary(BackupScheduler.getTreeUri(ctx)) }
+        scheduleCategory.addPreference(folderPreference!!)
+        scheduleCategory.addPreference(
+            buildActionPreference(
+                ctx = ctx,
+                key = PREF_KEY_SCHEDULE_RETENTION,
+                titleRes = R.string.backup_schedule_retention_title,
+                summaryRes = 0,
+                onClick = ::promptRetention,
+            ).also {
+                it.summary = getString(
+                    R.string.backup_schedule_retention_summary,
+                    BackupScheduler.getRetention(ctx)
+                )
+            }
         )
 
         preferenceScreen = screen
@@ -117,7 +174,9 @@ class BackupFragment : PreferenceFragmentCompat() {
         Preference(ctx).apply {
             this.key = key
             title = getString(titleRes)
-            summary = getString(summaryRes)
+            // summaryRes == 0 means "set the summary dynamically at the call
+            // site" (e.g. schedule rows that show current state).
+            if (summaryRes != 0) summary = getString(summaryRes)
             isIconSpaceReserved = false
             setOnPreferenceClickListener {
                 onClick()
@@ -265,6 +324,76 @@ class BackupFragment : PreferenceFragmentCompat() {
             is BackupResult.PasswordRequired -> promptImportPassword(uri, isRetry = false)
             is BackupResult.WrongPassword -> promptImportPassword(uri, isRetry = true)
         }
+    }
+
+    private fun promptFrequency() {
+        val ctx = requireContext()
+        val labels = FREQUENCY_VALUES.map { getString(frequencyLabelRes(it)) }.toTypedArray()
+        val current = FREQUENCY_VALUES.indexOf(BackupScheduler.getFrequency(ctx)).coerceAtLeast(0)
+        MaterialAlertDialogBuilder(ctx)
+            .setTitle(R.string.backup_schedule_frequency_title)
+            .setSingleChoiceItems(labels, current) { dialog, which ->
+                val chosen = FREQUENCY_VALUES[which]
+                if (chosen != FREQUENCY_OFF && BackupScheduler.getTreeUri(ctx) == null) {
+                    toast(getString(R.string.backup_schedule_needs_folder))
+                    dialog.dismiss()
+                    return@setSingleChoiceItems
+                }
+                BackupScheduler.setFrequency(ctx, chosen)
+                findPreference<Preference>(PREF_KEY_SCHEDULE_FREQ)?.summary =
+                    frequencySummary(chosen)
+                dialog.dismiss()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun launchFolderPicker() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+        folderLauncher.launch(intent)
+    }
+
+    private fun onFolderPicked(uri: Uri) {
+        // Persist the read/write grant across process death and reboots; without
+        // this the URI becomes unusable as soon as the picker Activity is gone.
+        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+            Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        requireContext().contentResolver.takePersistableUriPermission(uri, flags)
+        BackupScheduler.setTreeUri(requireContext(), uri)
+        folderPreference?.summary = folderSummary(uri)
+    }
+
+    private fun promptRetention() {
+        val ctx = requireContext()
+        val labels = RETENTION_VALUES.map { it.toString() }.toTypedArray()
+        val current = RETENTION_VALUES.indexOf(BackupScheduler.getRetention(ctx)).coerceAtLeast(0)
+        MaterialAlertDialogBuilder(ctx)
+            .setTitle(R.string.backup_schedule_retention_title)
+            .setSingleChoiceItems(labels, current) { dialog, which ->
+                val chosen = RETENTION_VALUES[which]
+                BackupScheduler.setRetention(ctx, chosen)
+                findPreference<Preference>(PREF_KEY_SCHEDULE_RETENTION)?.summary =
+                    getString(R.string.backup_schedule_retention_summary, chosen)
+                dialog.dismiss()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun frequencySummary(frequency: String): String =
+        getString(frequencyLabelRes(frequency))
+
+    private fun frequencyLabelRes(frequency: String): Int = when (frequency) {
+        FREQUENCY_DAILY -> R.string.backup_schedule_frequency_daily
+        FREQUENCY_WEEKLY -> R.string.backup_schedule_frequency_weekly
+        FREQUENCY_MONTHLY -> R.string.backup_schedule_frequency_monthly
+        else -> R.string.backup_schedule_frequency_off
+    }
+
+    private fun folderSummary(uri: Uri?): String {
+        if (uri == null) return getString(R.string.backup_schedule_folder_none)
+        val name = DocumentFile.fromTreeUri(requireContext(), uri)?.name
+        return name ?: uri.toString()
     }
 
     private fun extractCharArray(input: EditText): CharArray {

--- a/app/src/main/kotlin/de/salomax/currencies/worker/ScheduledBackupWorker.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/worker/ScheduledBackupWorker.kt
@@ -1,0 +1,75 @@
+package de.salomax.currencies.worker
+
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import de.salomax.currencies.repository.BackupManager
+import de.salomax.currencies.repository.BackupResult
+import de.salomax.currencies.repository.BackupScheduler
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+// Written by the worker; also used as a filter when we prune old files so we
+// never touch anything the user might have dropped into the same folder.
+private const val BACKUP_FILE_PREFIX = "currencies-backup-"
+private const val BACKUP_FILE_SUFFIX = ".json"
+private const val BACKUP_MIME = "application/json"
+
+// Timestamp is embedded in the filename so files sort chronologically and the
+// prune step can pick the oldest without reading each file's metadata.
+private val TIMESTAMP_FORMATTER: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+
+class ScheduledBackupWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val treeUri = BackupScheduler.getTreeUri(applicationContext) ?: return Result.success()
+        val tree = DocumentFile.fromTreeUri(applicationContext, treeUri) ?: return Result.failure()
+        if (!tree.canWrite()) return Result.retry()
+
+        val filename = BACKUP_FILE_PREFIX +
+            LocalDateTime.now().format(TIMESTAMP_FORMATTER) +
+            BACKUP_FILE_SUFFIX
+
+        // createFile returns null on collision/permission failure; treat as
+        // retry rather than success so WorkManager backs off and tries later
+        // instead of silently dropping the backup.
+        val target = tree.createFile(BACKUP_MIME, filename) ?: return Result.retry()
+
+        // Scheduled backups are always plaintext: prompting the user for a
+        // password at midnight defeats the point of a scheduled job, and
+        // stashing the password in prefs would defeat the point of the
+        // password. Users who need encryption use the manual export.
+        val result = BackupManager(applicationContext).export(target.uri, password = null)
+        return when (result) {
+            is BackupResult.Success -> {
+                pruneOldBackups(tree)
+                Result.success()
+            }
+            is BackupResult.Failure -> {
+                target.delete()
+                Result.retry()
+            }
+            // Password states can't happen on export — collapse to failure so
+            // the compiler enforces exhaustiveness if the sealed class grows.
+            is BackupResult.PasswordRequired,
+            is BackupResult.WrongPassword -> {
+                target.delete()
+                Result.failure()
+            }
+        }
+    }
+
+    private fun pruneOldBackups(tree: DocumentFile) {
+        val retention = BackupScheduler.getRetention(applicationContext).coerceAtLeast(1)
+        val ours = tree.listFiles()
+            .filter { it.isFile && (it.name?.startsWith(BACKUP_FILE_PREFIX) == true) }
+            // Filename embeds the timestamp so lexicographic order = chronological.
+            .sortedByDescending { it.name }
+        ours.drop(retention).forEach { it.delete() }
+    }
+}

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -68,6 +68,17 @@
     <string name="backup_password_prompt_title">Enter password</string>
     <string name="backup_password_wrong">Password didn\'t decrypt this file. Try again.</string>
     <string name="backup_password_too_short">Password must be at least %1$d characters</string>
+    <string name="backup_section_schedule">Scheduled backup</string>
+    <string name="backup_schedule_frequency_title">Frequency</string>
+    <string name="backup_schedule_frequency_off">Off</string>
+    <string name="backup_schedule_frequency_daily">Daily</string>
+    <string name="backup_schedule_frequency_weekly">Weekly</string>
+    <string name="backup_schedule_frequency_monthly">Monthly</string>
+    <string name="backup_schedule_folder_title">Destination folder</string>
+    <string name="backup_schedule_folder_none">Not selected</string>
+    <string name="backup_schedule_retention_title">Keep last</string>
+    <string name="backup_schedule_retention_summary">Keep %1$d most recent backups</string>
+    <string name="backup_schedule_needs_folder">Pick a destination folder first</string>
     <!-- graph options -->
     <string name="category_graph_options">Graph options</string>
     <string name="graph_options_key" translatable="false">KEY_GRAPH_OPTIONS</string>

--- a/docs/markDown/security.md
+++ b/docs/markDown/security.md
@@ -47,6 +47,14 @@ At export time the user may tick **Encrypt with a password**. When set:
 
 On import the app detects the `encryption` block, prompts for the password, and re-prompts on GCM tag failure. Plaintext files still import unchanged; an earlier revision that used PBKDF2-HMAC-SHA256 (210 000 iterations) is still readable via a fallback branch keyed on the file's `kdf` field.
 
+### Scheduled backup
+
+The user may opt in to periodic backups from **Settings → Backup & Restore → Scheduled backup**. Frequency is a single-choice list (Off / Daily / Weekly / Monthly) driven by WorkManager `PeriodicWorkRequest`. The destination is a directory chosen via `ACTION_OPEN_DOCUMENT_TREE`; the read/write grant is made persistable so it survives reboots.
+
+- Scheduled exports are always **plaintext**. Prompting the user for a password at midnight defeats the point of a scheduled job, and stashing the password in preferences would defeat the point of the password. Users who require encryption at rest use the manual export flow.
+- Files are named `currencies-backup-YYYYMMDD-HHmmss.json` so lexicographic sort matches chronological order; the worker keeps the most recent N (default 5) and deletes older ones, matching only files with the `currencies-backup-` prefix so nothing else in the folder is touched.
+- WorkManager persists jobs across reboots, but the app also calls `BackupScheduler.reschedule` on `Application.onCreate` to recover from app-update or force-stop edge cases where jobs are dropped.
+
 Automatic Android backup remains disabled (`android:allowBackup="false"`) — user-initiated export is the only supported path off-device.
 
 ## Runtime Permissions


### PR DESCRIPTION
## Summary
- Opt-in scheduled backup: user picks a destination folder (SAF tree URI, persistable grant) and a cadence (Off/Daily/Weekly/Monthly).
- `WorkManager` `PeriodicWorkRequest` (`ExistingPeriodicWorkPolicy.UPDATE`) runs `ScheduledBackupWorker`, which writes `currencies-backup-YYYYMMDD-HHmmss.json` into the picked folder and prunes older files down to a configurable retention (default 5).
- `BackupScheduler.reschedule` is called from `Application.onCreate` on a daemon thread to recover from app-update / force-stop edge cases where WorkManager may drop jobs.

## Design notes
- **Scheduled exports are always plaintext**. Prompting the user for a password at midnight defeats the point of a scheduled job, and stashing the password in prefs would defeat the point of the password. Manual encrypted export from PR-D remains the path for users who need encryption at rest.
- Timestamps are embedded in the filename so lexicographic sort = chronological; the pruner filters on the `currencies-backup-` prefix so nothing else in the folder is ever touched.
- WorkManager's minimum periodic interval is 15 min; "monthly" is expressed as 30 days rather than a variable-length calendar month.

## Deps added
- `androidx.work:work-runtime-ktx:2.10.0`
- `androidx.documentfile:documentfile:1.0.1`

Both Apache-2.0, F-Droid compatible.

## Test plan
- [ ] Pick a folder, choose "Daily" — verify a backup file is written after `wm adb-shell dumpsys jobscheduler | grep scheduled_backup` triggers.
- [ ] Set retention to 3, create 5 backups manually via the worker's tag, verify only the newest 3 remain.
- [ ] Toggle frequency to "Off" — verify the worker is cancelled (`WorkManager.getWorkInfosForUniqueWork`).
- [ ] Restart the device — verify `Application.onCreate` re-registers the periodic job (`adb shell dumpsys jobscheduler | grep de.salomax.currencies`).
- [ ] Revoke the folder permission externally — worker should return `Result.retry()`, not crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)