### PR TITLE
refactor: consolidate theme + calculator operators into enums

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -6,11 +6,6 @@ import de.salomax.currencies.repository.Database
 import java.net.InetAddress
 import kotlin.concurrent.thread
 
-// Kept in sync with Database.getTheme() unified values.
-private const val THEME_LIGHT = 0
-private const val THEME_DARK = 1
-private const val THEME_OLED = 2
-
 class CurrenciesApplication : Application() {
 
     override fun onCreate() {
@@ -26,13 +21,7 @@ class CurrenciesApplication : Application() {
     // background renders as the day-mode color until setDefaultNightMode
     // triggers a recreate.
     private fun applyNightMode() {
-        AppCompatDelegate.setDefaultNightMode(
-            when (Database(this).getTheme()) {
-                THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-                THEME_DARK, THEME_OLED -> AppCompatDelegate.MODE_NIGHT_YES
-                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-            }
-        )
+        AppCompatDelegate.setDefaultNightMode(Database(this).getTheme().nightMode)
     }
 
     // Force each SharedPreferences file the app uses to load from disk on a

--- a/app/src/main/kotlin/de/salomax/currencies/model/AppTheme.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/AppTheme.kt
@@ -1,0 +1,37 @@
+package de.salomax.currencies.model
+
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
+
+/**
+ * The five theme choices exposed to the user, unified into a single enum so the
+ * (id, night mode, pure-black) triple stays in one place instead of being
+ * mirrored across the DB, application, view-model and view layers.
+ *
+ * `id` is the value persisted in SharedPreferences and referenced from
+ * `arrays_preference.xml`, so **it must not change once shipped**.
+ */
+enum class AppTheme(
+    val id: Int,
+    val nightMode: Int,
+    val isPureBlack: Boolean,
+) {
+    LIGHT      (0, AppCompatDelegate.MODE_NIGHT_NO,            false),
+    DARK       (1, AppCompatDelegate.MODE_NIGHT_YES,           false),
+    OLED       (2, AppCompatDelegate.MODE_NIGHT_YES,           true),
+    SYSTEM     (3, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, false),
+    SYSTEM_OLED(4, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, true);
+
+    /** True when this theme currently renders dark under [config]. */
+    fun isDarkActive(config: Configuration): Boolean = when (nightMode) {
+        AppCompatDelegate.MODE_NIGHT_YES -> true
+        AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM ->
+            (config.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        else -> false
+    }
+
+    companion object {
+        val DEFAULT = SYSTEM
+        fun fromId(id: Int): AppTheme = entries.firstOrNull { it.id == id } ?: DEFAULT
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/model/Fee.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/Fee.kt
@@ -11,20 +11,25 @@ sealed class Fee {
     abstract val id: String
     abstract val percent: BigDecimal
     abstract val isMarkup: Boolean
+    abstract val type: FeeType
 
     /** Applies to every conversion, no matter which currencies are involved. */
     data class GlobalExchange(
         override val id: String,
         override val percent: BigDecimal,
         override val isMarkup: Boolean,
-    ) : Fee()
+    ) : Fee() {
+        override val type: FeeType get() = FeeType.GLOBAL_EXCHANGE
+    }
 
     /** Bank / card fee that also applies to every conversion. */
     data class GlobalBank(
         override val id: String,
         override val percent: BigDecimal,
         override val isMarkup: Boolean,
-    ) : Fee()
+    ) : Fee() {
+        override val type: FeeType get() = FeeType.GLOBAL_BANK
+    }
 
     /**
      * A fee tied to a specific currency pair. When [bothWays] is true the
@@ -37,7 +42,24 @@ sealed class Fee {
         val from: String,
         val to: String,
         val bothWays: Boolean,
-    ) : Fee()
+    ) : Fee() {
+        override val type: FeeType get() = FeeType.SPECIFIC_PAIR
+    }
+}
+
+/**
+ * Discriminator tag for the [Fee] sealed hierarchy, kept next to the model so
+ * on-disk backups and the [Database] JSON encoding read from a single source
+ * of truth. `wire` values are persisted verbatim and **must not change**.
+ */
+enum class FeeType(val wire: String) {
+    GLOBAL_EXCHANGE("global_exchange"),
+    GLOBAL_BANK("global_bank"),
+    SPECIFIC_PAIR("specific_pair");
+
+    companion object {
+        fun fromWire(wire: String?): FeeType? = entries.firstOrNull { it.wire == wire }
+    }
 }
 
 /**

--- a/app/src/main/kotlin/de/salomax/currencies/model/provider/BankRossii.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/model/provider/BankRossii.kt
@@ -21,6 +21,12 @@ import java.math.MathContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+// The Bank Rossii URL endpoints accept dates as dd/MM/yyyy in the query
+// string. The XML *response* uses dd.MM.yyyy — that formatter lives in
+// AdapterUtils as BANK_ROSSII_DATE_FORMATTER and shouldn't be reused here.
+private val BANK_ROSSII_URL_DATE_FORMATTER: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
 class BankRossii : ApiProvider.Api() {
 
     override val name = "Bank Rossii"
@@ -44,7 +50,7 @@ class BankRossii : ApiProvider.Api() {
             // latest
             if (date == null) ""
             // historical
-            else "?date_req=${date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))}"
+            else "?date_req=${date.format(BANK_ROSSII_URL_DATE_FORMATTER)}"
 
         return Fuel.get(
             baseUrl +
@@ -66,7 +72,6 @@ class BankRossii : ApiProvider.Api() {
         startDate: LocalDate,
         endDate: LocalDate
     ): Result<Timeline, FuelError> {
-        val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
         val parameterBase = base.apiCodeOrDkkForFok()
         val parameterSymbol = symbol.apiCodeOrDkkForFok()
 
@@ -88,12 +93,12 @@ class BankRossii : ApiProvider.Api() {
         val baseTimeline = if (parameterBase == Currency.RUB.iso4217Alpha())
             Result.success(timelineRub)
         else
-            fetchCurrencyTimeline(startDate, endDate, idBase!!, ids, dateFormatter)
+            fetchCurrencyTimeline(startDate, endDate, idBase!!, ids)
 
         val symbolTimeline = if (parameterSymbol == Currency.RUB.iso4217Alpha())
             Result.success(timelineRub)
         else
-            fetchCurrencyTimeline(startDate, endDate, idSymbol!!, ids, dateFormatter)
+            fetchCurrencyTimeline(startDate, endDate, idSymbol!!, ids)
 
         val baseRates: Map<LocalDate, Rate>? = baseTimeline.component1()?.rates
         val symbolRates: Map<LocalDate, Rate>? = symbolTimeline.component1()?.rates
@@ -142,13 +147,12 @@ class BankRossii : ApiProvider.Api() {
         startDate: LocalDate,
         endDate: LocalDate,
         currencyId: String,
-        ids: Map<String, String>,
-        dateFormatter: DateTimeFormatter
+        ids: Map<String, String>
     ): Result<Timeline, FuelError> {
         return Fuel.get(
             baseUrl + "/XML_dynamic.asp" +
-                "?date_req1=${startDate.format(dateFormatter)}" +
-                "&date_req2=${endDate.format(dateFormatter)}" +
+                "?date_req1=${startDate.format(BANK_ROSSII_URL_DATE_FORMATTER)}" +
+                "&date_req2=${endDate.format(BANK_ROSSII_URL_DATE_FORMATTER)}" +
                 "&VAL_NM_RQ=$currencyId"
         ).awaitResult(object : ResponseDeserializable<Timeline> {
             override fun deserialize(inputStream: InputStream): Timeline =

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -12,6 +12,7 @@ import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Fee
 import de.salomax.currencies.model.FeeSide
+import de.salomax.currencies.model.FeeType
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.model.Timeline
 import de.salomax.currencies.util.KEY_RATES_BASE
@@ -35,10 +36,6 @@ import java.util.UUID
 private const val LEGACY_FEE_KEY = "_fee"
 private const val LEGACY_FEE_STR_KEY = "_fee_str"
 private const val LEGACY_FEE_ENABLED_KEY = "_feeEnabled"
-
-private const val FEE_TYPE_GLOBAL_EXCHANGE = "global_exchange"
-private const val FEE_TYPE_GLOBAL_BANK = "global_bank"
-private const val FEE_TYPE_SPECIFIC_PAIR = "specific_pair"
 
 // Sentinel for "no historical date stored" in the millis-since-epoch pref.
 // -1L is used because it can't collide with any real epoch millis (1970-01-01
@@ -436,15 +433,11 @@ class Database(context: Context) {
             obj.put("id", fee.id)
             obj.put("percent", fee.percent.toPlainString())
             obj.put("isMarkup", fee.isMarkup)
-            when (fee) {
-                is Fee.GlobalExchange -> obj.put("type", FEE_TYPE_GLOBAL_EXCHANGE)
-                is Fee.GlobalBank -> obj.put("type", FEE_TYPE_GLOBAL_BANK)
-                is Fee.SpecificPair -> {
-                    obj.put("type", FEE_TYPE_SPECIFIC_PAIR)
-                    obj.put("from", fee.from)
-                    obj.put("to", fee.to)
-                    obj.put("bothWays", fee.bothWays)
-                }
+            obj.put("type", fee.type.wire)
+            if (fee is Fee.SpecificPair) {
+                obj.put("from", fee.from)
+                obj.put("to", fee.to)
+                obj.put("bothWays", fee.bothWays)
             }
             arr.put(obj)
         }
@@ -466,10 +459,10 @@ class Database(context: Context) {
         val id = obj.optString("id", "").ifEmpty { UUID.randomUUID().toString() }
         val percent = obj.optString("percent", "0").toBigDecimalOrNull() ?: return null
         val isMarkup = obj.optBoolean("isMarkup", true)
-        return when (obj.optString("type")) {
-            FEE_TYPE_GLOBAL_EXCHANGE -> Fee.GlobalExchange(id, percent, isMarkup)
-            FEE_TYPE_GLOBAL_BANK -> Fee.GlobalBank(id, percent, isMarkup)
-            FEE_TYPE_SPECIFIC_PAIR -> Fee.SpecificPair(
+        return when (FeeType.fromWire(obj.optString("type"))) {
+            FeeType.GLOBAL_EXCHANGE -> Fee.GlobalExchange(id, percent, isMarkup)
+            FeeType.GLOBAL_BANK -> Fee.GlobalBank(id, percent, isMarkup)
+            FeeType.SPECIFIC_PAIR -> Fee.SpecificPair(
                 id = id,
                 percent = percent,
                 isMarkup = isMarkup,
@@ -477,7 +470,7 @@ class Database(context: Context) {
                 to = obj.optString("to", ""),
                 bothWays = obj.optBoolean("bothWays", false),
             )
-            else -> null
+            null -> null
         }
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import de.salomax.currencies.model.ApiProvider
+import de.salomax.currencies.model.AppTheme
 import de.salomax.currencies.model.Currency
 import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.Fee
@@ -38,15 +39,6 @@ private const val LEGACY_FEE_ENABLED_KEY = "_feeEnabled"
 private const val FEE_TYPE_GLOBAL_EXCHANGE = "global_exchange"
 private const val FEE_TYPE_GLOBAL_BANK = "global_bank"
 private const val FEE_TYPE_SPECIFIC_PAIR = "specific_pair"
-
-// Unified theme values (see Database.getTheme). Kept as plain ints so the DB
-// layer doesn't need to depend on androidx.appcompat.
-private const val THEME_LIGHT = 0
-private const val THEME_DARK = 1
-private const val THEME_OLED = 2
-private const val THEME_SYSTEM = 3
-private const val THEME_SYSTEM_OLED = 4
-private const val DEFAULT_THEME_MODE = THEME_SYSTEM
 
 // Sentinel for "no historical date stored" in the millis-since-epoch pref.
 // -1L is used because it can't collide with any real epoch millis (1970-01-01
@@ -306,44 +298,33 @@ class Database(context: Context) {
 
     /* theme */
 
-    fun setTheme(theme: Int) {
-        prefs.apply {
-            edit().putInt(keyTheme, theme).apply()
-        }
+    fun setTheme(theme: AppTheme) {
+        prefs.edit().putInt(keyTheme, theme.id).apply()
     }
 
     /**
-     * 0 = Light           (MODE_NIGHT_NO)
-     * 1 = Dark            (MODE_NIGHT_YES)
-     * 2 = OLED            (MODE_NIGHT_YES, pure-black)
-     * 3 = System default  (MODE_NIGHT_FOLLOW_SYSTEM)
-     * 4 = System (OLED)   (MODE_NIGHT_FOLLOW_SYSTEM, pure-black)
-     *
      * Migrates the legacy separate pure-black boolean into the new unified
      * value on first read after upgrade, then deletes the legacy key.
      */
-    fun getTheme(): Int {
+    fun getTheme(): AppTheme {
         migrateLegacyPureBlackIfNeeded()
-        return prefs.getInt(keyTheme, DEFAULT_THEME_MODE)
+        return AppTheme.fromId(prefs.getInt(keyTheme, AppTheme.DEFAULT.id))
     }
 
-    fun isPureBlackEnabled(): Boolean {
-        val theme = getTheme()
-        return theme == THEME_OLED || theme == THEME_SYSTEM_OLED
-    }
+    fun isPureBlackEnabled(): Boolean = getTheme().isPureBlack
 
     private fun migrateLegacyPureBlackIfNeeded() {
         if (!prefs.contains(keyPureBlackEnabled)) return
         val wasPureBlack = prefs.getBoolean(keyPureBlackEnabled, false)
         val editor = prefs.edit().remove(keyPureBlackEnabled)
         if (wasPureBlack) {
-            val current = prefs.getInt(keyTheme, DEFAULT_THEME_MODE)
+            val current = AppTheme.fromId(prefs.getInt(keyTheme, AppTheme.DEFAULT.id))
             val migrated = when (current) {
-                THEME_DARK -> THEME_OLED
-                THEME_SYSTEM -> THEME_SYSTEM_OLED
+                AppTheme.DARK -> AppTheme.OLED
+                AppTheme.SYSTEM -> AppTheme.SYSTEM_OLED
                 else -> current // Light + OLED is meaningless — keep as Light.
             }
-            editor.putInt(keyTheme, migrated)
+            editor.putInt(keyTheme, migrated.id)
         }
         editor.apply()
     }

--- a/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/TextUtils.kt
@@ -28,6 +28,20 @@ internal const val DECIMAL_PLACES_DEFAULT = 2
 internal const val DECIMAL_PLACES_MIN = 0
 internal const val DECIMAL_PLACES_MAX = 6
 
+// Trailing zeros after a decimal point ("12.3400" -> "12.34"), and the point
+// itself when nothing survives ("12.0000" -> "12"). Anchored so a leading
+// zero on an integer ("0" or "0.5") is preserved.
+private val TRAILING_ZEROS_REGEX = Regex("(?!^)\\.?0+$")
+
+// Characters accepted by [CharSequence.toNumber]: digits, comma, dot, and any
+// whitespace (thousands separator can be NBSP or normal space depending on
+// locale). Anything else means "not a number, don't try to parse".
+private val NUMERIC_INPUT_REGEX = Regex("[0-9,.\\s]+")
+
+// Any run of whitespace — used to strip locale thousands separators before
+// handing the string to NumberFormat.parse.
+private val WHITESPACE_REGEX = Regex("\\s+")
+
 /**
  * Wrap [s] in Unicode LTR isolate (U+2066 … U+2069) so an "<amount> <currency>"
  * chunk stays glued together as one LTR unit inside an RTL paragraph — otherwise
@@ -146,7 +160,7 @@ private fun roundIfNeeded(value: String, decimalPlaces: Int?): String {
 }
 
 private fun trimTrailingZeros(value: String): String =
-    value.replace("(?!^)\\.?0+$".toRegex(), "")
+    value.replace(TRAILING_ZEROS_REGEX, "")
 
 private fun applyGrouping(value: String, context: Context): String {
     if (!value.contains('.')) return value.groupNumbers(context)
@@ -180,6 +194,6 @@ private fun String.groupNumbers(context: Context): String {
  */
 fun CharSequence.toNumber(): Number? {
     // allow 0-9 , . whitespace only
-    if (isBlank() || !matches("[0-9,.\\s]+".toRegex())) return null
-    return NumberFormat.getNumberInstance().parse(toString().replace("\\s+".toRegex(), ""))
+    if (isBlank() || !matches(NUMERIC_INPUT_REGEX)) return null
+    return NumberFormat.getNumberInstance().parse(toString().replace(WHITESPACE_REGEX, ""))
 }

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -52,6 +52,7 @@ import de.salomax.currencies.viewmodel.main.Operator
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 private const val HISTORICAL_MIN_YEAR = 2010
@@ -177,12 +178,20 @@ class MainActivity : BaseActivity() {
     private fun buildShareFooter(rates: ExchangeRates?): String? {
         if (rates == null) return null
         val providerName = rates.provider?.getName() ?: return null
-        val date = rates.date ?: return null
-        val time = rates.time
+        val dateString = formatRatesTimestamp(rates.date, rates.time) ?: return null
+        return getString(R.string.share_footer, providerName, dateString)
+    }
+
+    // Combine [date] and optional [time] into a single formatted string using
+    // the user's configured pattern. When [time] is null the time portion is
+    // stripped from the pattern first so users on "date-only" don't see a
+    // trailing "00:00". RTL marks injected by some locale formatters are
+    // stripped so a right-side timestamp stays flush with the label.
+    private fun formatRatesTimestamp(date: LocalDate?, time: LocalTime?): String? {
+        if (date == null) return null
         val pattern = if (time != null) dateFormatPattern else stripTimePattern(dateFormatPattern)
         val temporal = if (time != null) date.atTime(time) else date
-        val dateString = DateTimeFormatter.ofPattern(pattern).format(temporal).stripRtlMark()
-        return getString(R.string.share_footer, providerName, dateString)
+        return DateTimeFormatter.ofPattern(pattern).format(temporal).stripRtlMark()
     }
 
     private fun openQuickConversionsDialog() {
@@ -288,34 +297,8 @@ class MainActivity : BaseActivity() {
         registerForContextMenu(findViewById<LinearLayout>(R.id.textTo))
 
         // spinners: listen for changes
-        spinnerFrom.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
-            override fun onItemSelected(
-                parent: AdapterView<*>?,
-                view: View?,
-                position: Int,
-                id: Long
-            ) {
-                if (position != -1 && parent?.adapter?.isEmpty != true) {
-                    val rate = parent?.adapter?.getItem(position) as Rate?
-                    rate?.let { viewModel.setBaseCurrency(it.currency) }
-                }
-            }
-        }
-        spinnerTo.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
-            override fun onItemSelected(
-                parent: AdapterView<*>?,
-                view: View?,
-                position: Int,
-                id: Long
-            ) {
-                if (position != -1 && parent?.adapter?.isEmpty != true) {
-                    val rate = parent?.adapter?.getItem(position) as Rate?
-                    rate?.let { viewModel.setDestinationCurrency(it.currency) }
-                }
-            }
-        }
+        spinnerFrom.onItemSelectedListener = rateSpinnerListener(viewModel::setBaseCurrency)
+        spinnerTo.onItemSelectedListener = rateSpinnerListener(viewModel::setDestinationCurrency)
 
         // swipe to refresh
         swipeRefresh.setOnRefreshListener {
@@ -342,6 +325,22 @@ class MainActivity : BaseActivity() {
         startActivity(PreferenceActivity.feesIntent(this))
         return true
     }
+
+    // Forward the picked rate's currency to [onCurrencySelected]; both spinners
+    // share this exact shape (guard against empty adapter / position -1 first).
+    private fun rateSpinnerListener(onCurrencySelected: (Currency) -> Unit) =
+        object : AdapterView.OnItemSelectedListener {
+            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+            override fun onItemSelected(
+                parent: AdapterView<*>?,
+                view: View?,
+                position: Int,
+                id: Long,
+            ) {
+                if (position == -1 || parent?.adapter?.isEmpty == true) return
+                (parent?.adapter?.getItem(position) as Rate?)?.let { onCurrencySelected(it.currency) }
+            }
+        }
 
     private fun copyToClipboard(copyText: String) {
         clipboardManager().setPrimaryClip(ClipData.newPlainText(null, copyText))
@@ -435,17 +434,7 @@ class MainActivity : BaseActivity() {
     private fun observeExchangeRates(rates: ExchangeRates?) {
         rates?.let {
             val date = it.date
-            val time = it.time
-            val effectivePattern =
-                if (time != null) dateFormatPattern else stripTimePattern(dateFormatPattern)
-            val temporal = when {
-                date == null -> null
-                time != null -> date.atTime(time)
-                else -> date
-            }
-            val dateString = temporal
-                ?.let { DateTimeFormatter.ofPattern(effectivePattern).format(it) }
-                ?.stripRtlMark()
+            val dateString = formatRatesTimestamp(date, it.time)
             val providerString = it.provider?.getName()
             tvInfoDate.text =
                 if (dateString != null && providerString != null)

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -48,6 +48,7 @@ import de.salomax.currencies.view.preference.PreferenceActivity
 import de.salomax.currencies.view.preference.showProviderPickerDialog
 import de.salomax.currencies.view.timeline.TimelineActivity
 import de.salomax.currencies.viewmodel.main.MainViewModel
+import de.salomax.currencies.viewmodel.main.Operator
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -66,12 +67,6 @@ private const val CTX_MENU_COPY_TO = 2
 private const val PERCENT_MULTIPLIER = 100
 private const val FEE_BADGE_DECIMAL_PLACES = 2
 private const val AMOUNT_DECIMAL_PLACES = 2
-
-// calculator button labels
-private const val KEY_PLUS = "+"
-private const val KEY_MINUS = "−"
-private const val KEY_TIMES = "×"
-private const val KEY_DIVIDE = "÷"
 
 class MainActivity : BaseActivity() {
 
@@ -562,12 +557,8 @@ class MainActivity : BaseActivity() {
      */
     fun calculationEvent(view: View) {
         haptic(view)
-        when ((view as AppCompatButton).text.toString()) {
-            KEY_PLUS -> viewModel.addition()
-            KEY_MINUS -> viewModel.subtraction()
-            KEY_TIMES -> viewModel.multiplication()
-            KEY_DIVIDE -> viewModel.division()
-        }
+        Operator.fromDisplay((view as AppCompatButton).text.toString())
+            ?.apply?.invoke(viewModel)
     }
 
     // capture hardware keyboard input
@@ -580,13 +571,10 @@ class MainActivity : BaseActivity() {
 
     private fun handleCharKey(key: Char?): Boolean {
         key ?: return false
+        Operator.fromHardware(key)?.let { it.apply(viewModel); return true }
         when {
             key.isDigit() -> viewModel.addNumber(key.toString())
             key == '.' || key == ',' -> viewModel.addDecimal()
-            key == '+' -> viewModel.addition()
-            key == '-' -> viewModel.subtraction()
-            key == '*' -> viewModel.multiplication()
-            key == '/' -> viewModel.division()
             else -> return false
         }
         return true

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -17,6 +17,7 @@ import androidx.preference.SwitchPreferenceCompat
 import de.salomax.currencies.BuildConfig
 import de.salomax.currencies.R
 import de.salomax.currencies.model.ApiProvider
+import de.salomax.currencies.model.AppTheme
 import de.salomax.currencies.view.main.MainActivity
 import de.salomax.currencies.util.DECIMAL_PLACES_DEFAULT
 import de.salomax.currencies.util.DECIMAL_PLACES_MAX
@@ -118,7 +119,8 @@ class PreferenceFragment: PreferenceFragmentCompat() {
         }
         findPreference<ListPreference>(getString(R.string.theme_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
-                if (viewModel.setTheme(newValue.toString().toInt())) {
+                val theme = AppTheme.fromId(newValue.toString().toInt())
+                if (viewModel.setTheme(theme)) {
                     rebuildActivityStack()
                 }
                 true

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/Operator.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/Operator.kt
@@ -1,0 +1,24 @@
+package de.salomax.currencies.viewmodel.main
+
+/**
+ * The four arithmetic operators the calculator keypad exposes. Each entry
+ * carries both its on-screen label ([display], as rendered on the keypad
+ * button) and the ASCII glyph the hardware keyboard produces ([hardware]),
+ * so the same enum can route either input path into the corresponding
+ * [MainViewModel] call.
+ */
+enum class Operator(
+    val display: String,
+    val hardware: Char,
+    val apply: MainViewModel.() -> Unit,
+) {
+    PLUS  ("+", '+', MainViewModel::addition),
+    MINUS ("−", '-', MainViewModel::subtraction),
+    TIMES ("×", '*', MainViewModel::multiplication),
+    DIVIDE("÷", '/', MainViewModel::division);
+
+    companion object {
+        fun fromDisplay(label: String): Operator? = entries.firstOrNull { it.display == label }
+        fun fromHardware(char: Char): Operator? = entries.firstOrNull { it.hardware == char }
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
@@ -1,21 +1,14 @@
 package de.salomax.currencies.viewmodel.preference
 
 import android.app.Application
-import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import de.salomax.currencies.model.ApiProvider
+import de.salomax.currencies.model.AppTheme
 import de.salomax.currencies.repository.Database
 import de.salomax.currencies.repository.ExchangeRatesRepository
-
-// Same numeric contract as Database.getTheme() / BaseActivity.
-private const val THEME_LIGHT = 0
-private const val THEME_DARK = 1
-private const val THEME_OLED = 2
-private const val THEME_SYSTEM = 3
-private const val THEME_SYSTEM_OLED = 4
 
 // Language.SYSTEM.iso — matches the enum value that means "follow system
 // locale" without pulling the enum into this file.
@@ -58,31 +51,13 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app) 
      * System ↔ System-OLED while system is dark) keeps the same night mode,
      * so `BaseActivity.setTheme` doesn't rerun on its own.
      */
-    fun setTheme(theme: Int): Boolean {
+    fun setTheme(theme: AppTheme): Boolean {
         val old = db.getTheme()
         db.setTheme(theme)
-        AppCompatDelegate.setDefaultNightMode(nightModeFor(theme))
-        return nightModeFor(old) == nightModeFor(theme) &&
-            isPureBlack(old) != isPureBlack(theme) &&
-            isDarkThemeActive(theme)
-    }
-
-    private fun nightModeFor(theme: Int): Int = when (theme) {
-        THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-        THEME_DARK, THEME_OLED -> AppCompatDelegate.MODE_NIGHT_YES
-        else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-    }
-
-    private fun isPureBlack(theme: Int): Boolean =
-        theme == THEME_OLED || theme == THEME_SYSTEM_OLED
-
-    private fun isDarkThemeActive(theme: Int): Boolean {
-        val explicitlyDark = theme == THEME_DARK || theme == THEME_OLED
-        val followingSystem = theme == THEME_SYSTEM || theme == THEME_SYSTEM_OLED
-        val systemDark = followingSystem &&
-            (app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-                Configuration.UI_MODE_NIGHT_YES
-        return explicitlyDark || systemDark
+        AppCompatDelegate.setDefaultNightMode(theme.nightMode)
+        return old.nightMode == theme.nightMode &&
+            old.isPureBlack != theme.isPureBlack &&
+            theme.isDarkActive(app.resources.configuration)
     }
 
     fun setLanguage(language: String) {


### PR DESCRIPTION
## Summary
Post-merge cleanup of the theme picker PR (#54) and a follow-up survey of the rest of the codebase for other enum-worthy constant groups plus readability wins.

- **`AppTheme` enum** (`model/AppTheme.kt`): the (id, night-mode, pure-black) triple for each theme choice was previously mirrored as five `THEME_*` int constants in `Database`, three in `CurrenciesApplication`, and another five in `PreferenceViewModel`, each with its own mapping helpers. Collapsed into a single enum that also owns `isDarkActive(config)`. `Database.getTheme()` now returns `AppTheme`; call sites are typed end-to-end.
- **`Operator` enum** (`viewmodel/main/Operator.kt`): `MainActivity` dispatched the four arithmetic keys twice — once for on-screen button labels (`+`, `−`, `×`, `÷`) and once for hardware keyboard glyphs (`+`, `-`, `*`, `/`) — with a private `KEY_*` string per symbol. Folded both dispatches through one enum that carries `(display, hardware, viewModelAction)`.
- **`FeeType` enum** (`model/Fee.kt`): the three fee-type discriminator strings lived as private constants in `Database`, right next to the JSON serializer. Moved them onto the `Fee` model itself so each subtype exposes its own `type`, and `parseFeeEntry`'s when-block is now exhaustive over `FeeType` instead of a `String` when with an `else -> null` branch.
- **Readability pass**:
  - `TextUtils`: hoisted three inline `.toRegex()` literals (`TRAILING_ZEROS_REGEX`, `NUMERIC_INPUT_REGEX`, `WHITESPACE_REGEX`) to file-scope named vals so they compile once and carry intent comments.
  - `MainActivity`: collapsed the two identical `AdapterView.OnItemSelectedListener` bodies (from/to spinners) into a `rateSpinnerListener(onCurrencySelected)` factory; extracted the shared "format date+time with RTL-mark strip" logic (previously duplicated between `buildShareFooter` and `observeExchangeRates`) into `formatRatesTimestamp`.
  - `BankRossii`: hoisted the URL date formatter (`dd/MM/yyyy`) to a file-scope `BANK_ROSSII_URL_DATE_FORMATTER` and dropped the redundant `dateFormatter` parameter threaded through `fetchCurrencyTimeline`.

Other constant groups (`BackupManager` wire tags, `CTX_MENU_*`, `VIEW_TYPE_*`, `KEYBOARD_TYPE_BASIC`, `ARROW_*`, KDF/cipher IDs) were evaluated and left as-is. Each is either a single-dispatch site with named constants already just as readable as enum entries would be, or an Android-API-shaped int/string that an enum wouldn't simplify.

## Test plan
- [ ] Theme picker: switch between Light / Dark / OLED / System / System-OLED; verify persistence across cold start.
- [ ] Dark ↔ OLED and System ↔ System-OLED (while system is dark) still trigger the activity-stack rebuild.
- [ ] Legacy pure-black migration: install over a build with `_pureBlackEnabled=true` + Dark/System stored, verify it maps to OLED/System-OLED once.
- [ ] Calculator: on-screen `+ − × ÷` buttons work; hardware `+ - * /` keys work.
- [ ] Fees: add one of each type (global exchange, global bank, specific pair with `bothWays` on/off), close & reopen the app, verify all fields round-trip through the JSON store.
- [ ] Currency spinners (from/to) still update the base/destination correctly.
- [ ] Bank Rossii provider: fetch latest rates and a historical date; open a timeline chart for a non-RUB pair.
- [ ] Share footer + info bar show a properly formatted timestamp (date-only when the provider omits time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)