### PR TITLE
chore(deps): consolidated dependabot updates

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: actions
           build-mode: none
@@ -36,6 +36,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: /language:actions

--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -40,7 +40,7 @@ jobs:
             --jvm-target 21
       - name: Upload SARIF to code scanning
         if: always() && hashFiles('detekt-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: detekt-results.sarif
           category: detekt

--- a/.github/workflows/owasp-dependency-check.yaml
+++ b/.github/workflows/owasp-dependency-check.yaml
@@ -37,7 +37,7 @@ jobs:
             --enableRetired
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: reports/dependency-check-report.sarif
           category: owasp-dependency-check

--- a/.github/workflows/qodana.yaml
+++ b/.github/workflows/qodana.yaml
@@ -35,7 +35,7 @@ jobs:
           pr-mode: false
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
           category: qodana

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -32,6 +32,6 @@ jobs:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,7 +34,7 @@ jobs:
             || true
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,9 +6,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    // Pinned to the latest stable 2.3.x — 2.4.0 flakes in CI's plugin repos.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21"
-    id("com.google.devtools.ksp") version "2.3.9"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 kotlin {
@@ -123,7 +122,7 @@ dependencies {
     // math (v5 releases use incompatible license to fdroid: noinspection GradleDependency)
     implementation("org.mariuszgromada.math:MathParser.org-mXparser:4.4.3")
     // compose (needed to host the Vico chart via ComposeView)
-    val composeBomVersion = "2024.12.01"
+    val composeBomVersion = "2026.06.01"
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.foundation:foundation")
@@ -134,7 +133,7 @@ dependencies {
     implementation("com.patrykandpatrick.vico:compose:$vicoVersion")
     // crypto: BouncyCastle provides pure-Java Argon2id, used by BackupManager
     // for password-based backup encryption (quantum-resistant KDF).
-    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.85")
     // test
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
@@ -142,7 +141,7 @@ dependencies {
     // run on the JVM test thread without hitting the main-thread assertion.
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     // fuzzing
-    val junitVersion = "6.1.1"
+    val junitVersion = "6.1.2"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$junitVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 plugins {
-    id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.jvm") version "2.4.0" apply false
+    id("com.android.application") version "9.3.0" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.4.10" apply false
     // dependency-update-checker
     id("com.github.ben-manes.versions") version "0.54.0"
 }


### PR DESCRIPTION
## Summary

Bundles the 6 open Dependabot PRs (#55, #57, #58, #59, #60, #61) into a single update so we get one CI pass and one merge instead of six.

### Gradle plugins
- `com.android.application` 9.2.1 → 9.3.0 (#59)
- `org.jetbrains.kotlin.jvm` 2.4.0 → 2.4.10 (#61)
- `org.jetbrains.kotlin.plugin.compose` 2.3.21 → 2.4.10 (#61)
- `com.google.devtools.ksp` 2.3.9 → 2.3.10 (#61)

The Kotlin plugins now align on the 2.4.x line, so the pin comment about 2.4.0 flaking in CI is no longer accurate and has been dropped.

### Library deps
- `androidx.compose:compose-bom` 2024.12.01 → 2026.06.01 (#55)
- `org.bouncycastle:bcprov-jdk18on` 1.78.1 → 1.85 (#58)
- `junit-jupiter-api` / `junit-jupiter-engine` / `junit-vintage-engine` 6.1.1 → 6.1.2 (#57)

### GitHub Actions
- `github/codeql-action` pinned SHA `54f647b7…` → `99df26d4…` (v4) across `codeql`, `detekt`, `owasp-dependency-check`, `qodana`, `scorecard`, and `semgrep` workflows (#60)

## Test plan

- [ ] `./gradlew clean assembleDebug` on both `play` and `fdroid` flavors
- [ ] `./gradlew test` (junit-jupiter + jazzer fuzz targets)
- [ ] Detekt / CodeQL / Qodana / OWASP / scorecard / semgrep workflows pass on this PR
- [ ] Smoke: launch app, confirm Vico chart renders (compose-bom bump) and password-backup flow still works (BouncyCastle bump)

Closes #55, #57, #58, #59, #60, #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)