### PR TITLE
feat(logging): Timber with rotating local file tree

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,9 @@ dependencies {
     // crypto: BouncyCastle provides pure-Java Argon2id, used by BackupManager
     // for password-based backup encryption (quantum-resistant KDF).
     implementation("org.bouncycastle:bcprov-jdk18on:1.85")
+    // logging: Timber routes to a rotating file tree written under filesDir/logs.
+    // Local-only — no remote crash / analytics sink.
+    implementation("com.jakewharton.timber:timber:5.0.1")
     // test
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")

--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -3,15 +3,27 @@ package de.salomax.currencies
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import de.salomax.currencies.repository.Database
+import de.salomax.currencies.util.FileLoggingTree
+import timber.log.Timber
 import java.net.InetAddress
 import kotlin.concurrent.thread
 
 class CurrenciesApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        installLogging()
         applyNightMode()
         warmSharedPreferences()
         prewarmProviderDns()
+    }
+
+    // Debug builds also get a console tree so `adb logcat` mirrors what the
+    // file tree captures. Release builds are file-only — no remote sink.
+    private fun installLogging() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+        Timber.plant(FileLoggingTree(filesDir))
     }
 
     // Apply the persisted day/night mode before any Activity is created, so

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -3,7 +3,6 @@ package de.salomax.currencies.repository
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import de.salomax.currencies.model.ApiProvider
@@ -31,6 +30,7 @@ import de.salomax.currencies.util.toMillis
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import timber.log.Timber
 import java.time.LocalDate
 import java.util.UUID
 
@@ -125,7 +125,7 @@ class Database(
                 provider = provider,
             )
         } catch (e: JSONException) {
-            Log.w("Database", "Malformed cached timeline, dropping", e)
+            Timber.tag("Database").w(e, "Malformed cached timeline, dropping")
             null
         }
     }
@@ -470,7 +470,7 @@ class Database(
             val arr = JSONArray(json)
             (0 until arr.length()).mapNotNull { i -> parseFeeEntry(arr.optJSONObject(i)) }
         } catch (e: JSONException) {
-            Log.w("Database", "Malformed fee JSON, resetting", e)
+            Timber.tag("Database").w(e, "Malformed fee JSON, resetting")
             emptyList()
         }
 

--- a/app/src/main/kotlin/de/salomax/currencies/util/FileLoggingTree.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/FileLoggingTree.kt
@@ -1,0 +1,93 @@
+package de.salomax.currencies.util
+
+import android.util.Log
+import timber.log.Timber
+import java.io.File
+import java.io.PrintWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.Executors
+
+private const val LOG_DIR = "logs"
+private const val CURRENT_LOG = "app.log"
+private const val PREVIOUS_LOG = "app.log.1"
+private const val MAX_BYTES = 256L * 1024L
+private const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS"
+
+// Timber tree that appends log lines to an app-private rotating file. All I/O
+// runs on a single background thread so callers never block; rotation swaps
+// [CURRENT_LOG] → [PREVIOUS_LOG] when the active file exceeds [MAX_BYTES],
+// bounding on-disk footprint at ~512 KiB regardless of runtime volume.
+class FileLoggingTree(
+    filesDir: File,
+) : Timber.Tree() {
+    private val logDir = File(filesDir, LOG_DIR).apply { mkdirs() }
+    private val currentFile = File(logDir, CURRENT_LOG)
+    private val previousFile = File(logDir, PREVIOUS_LOG)
+    private val executor =
+        Executors.newSingleThreadExecutor { r ->
+            Thread(r, "file-log").apply { isDaemon = true }
+        }
+    private val timestampFormat = SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US)
+
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
+        val line = formatLine(priority, tag, message, t)
+        executor.execute {
+            runCatching {
+                rotateIfNeeded()
+                currentFile.appendText(line)
+            }
+        }
+    }
+
+    private fun formatLine(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ): String {
+        val builder =
+            StringBuilder()
+                .append(timestampFormat.format(Date()))
+                .append(' ')
+                .append(priorityLabel(priority))
+                .append('/')
+                .append(tag ?: "-")
+                .append(": ")
+                .append(message)
+                .append('\n')
+        if (t != null) {
+            builder.append(stackTraceOf(t))
+        }
+        return builder.toString()
+    }
+
+    private fun stackTraceOf(t: Throwable): String {
+        val writer = java.io.StringWriter()
+        PrintWriter(writer).use { t.printStackTrace(it) }
+        return writer.toString()
+    }
+
+    private fun rotateIfNeeded() {
+        if (currentFile.length() < MAX_BYTES) return
+        if (previousFile.exists()) previousFile.delete()
+        currentFile.renameTo(previousFile)
+    }
+
+    private fun priorityLabel(priority: Int): String =
+        when (priority) {
+            Log.VERBOSE -> "V"
+            Log.DEBUG -> "D"
+            Log.INFO -> "I"
+            Log.WARN -> "W"
+            Log.ERROR -> "E"
+            Log.ASSERT -> "A"
+            else -> "?"
+        }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.core.app.TaskStackBuilder
 import androidx.fragment.app.Fragment
@@ -26,9 +25,8 @@ import de.salomax.currencies.util.DECIMAL_PLACES_MIN
 import de.salomax.currencies.view.main.MainActivity
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
 import de.salomax.currencies.widget.LongSummaryPreference
+import timber.log.Timber
 import java.util.Calendar
-
-private const val TAG = "PreferenceFragment"
 
 // Sentinel returned by ApiProvider.fromId when the stored value is unknown /
 // unset; the pref layer treats this as "use the default provider".
@@ -212,7 +210,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
                 try {
                     startActivity(createIntent(URL_PLAY_MARKET))
                 } catch (e: ActivityNotFoundException) {
-                    Log.d(TAG, "Play Store not available, opening browser", e)
+                    Timber.tag("PreferenceFragment").d(e, "Play Store not available, opening browser")
                     startActivity(createIntent(URL_PLAY_WEB))
                 }
                 true


### PR DESCRIPTION
## Summary
- Introduces **Timber 5.0.1** with a purpose-built \`FileLoggingTree\` writing to app-private \`filesDir/logs/app.log\` with 256 KiB rotation (~512 KiB total on disk).
- All file I/O runs on a single background daemon thread, so \`Timber.d/w/e\` never blocks a caller.
- \`DebugTree\` is planted only in debug builds; the file tree runs in every build (**local-only, no remote sink** per user's constraint).
- Migrates the 3 existing \`android.util.Log\` call sites (\`Database.kt\` x2, \`PreferenceFragment.kt\`) — no more raw Log usage in the app module.

## Stacking
Stacked on **#66** (fee-stack tests). Base will retarget upward as earlier PRs merge.

## Test plan
- [ ] CI \`build.yaml\` compiles both flavors and tests pass.
- [ ] Manual: install debug build, exercise Play-store fallback in Settings, then confirm \`filesDir/logs/app.log\` contains a \`D/PreferenceFragment\` entry.
- [ ] Manual: force malformed cache to verify \`W/Database\` entries land in the log file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)