### PR TITLE
feat(net): OkHttp client + cache + Timber-bridged logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,12 @@ dependencies {
     implementation("com.github.kittinunf.fuel:fuel-android:$fuelVersion")
     implementation("com.github.kittinunf.fuel:fuel-coroutines:$fuelVersion")
     implementation("com.github.kittinunf.fuel:fuel-moshi:$fuelVersion")
+    // OkHttp foundation for HTTP caching + Timber-bridged logging. Fuel is
+    // still the calling surface for now; a follow-up phase will migrate
+    // providers to Retrofit built on this shared client.
+    val okHttpVersion = "4.12.0"
+    implementation("com.squareup.okhttp3:okhttp:$okHttpVersion")
+    implementation("com.squareup.okhttp3:logging-interceptor:$okHttpVersion")
     val moshiVersion = "1.15.2"
     implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
     ksp("com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion")

--- a/app/src/main/kotlin/de/salomax/currencies/util/HttpClientProvider.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/HttpClientProvider.kt
@@ -1,0 +1,45 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import timber.log.Timber
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+private const val CACHE_DIR = "http-cache"
+private const val CACHE_SIZE_BYTES = 5L * 1024L * 1024L
+private const val CONNECT_TIMEOUT_SECONDS = 15L
+private const val READ_TIMEOUT_SECONDS = 15L
+
+// Shared OkHttp client with an on-disk response cache and Timber-bridged
+// wire logging. Rate providers still call Fuel today; the cache warms up
+// only if the provider's response carries Cache-Control headers or is
+// wrapped by a forthcoming Retrofit-based service that sets its own policy.
+object HttpClientProvider {
+    @Volatile
+    private var instance: OkHttpClient? = null
+
+    fun client(context: Context): OkHttpClient =
+        instance ?: synchronized(this) {
+            instance ?: build(context).also { instance = it }
+        }
+
+    private fun build(context: Context): OkHttpClient {
+        val cacheDir = File(context.cacheDir, CACHE_DIR).apply { mkdirs() }
+        val loggingInterceptor =
+            HttpLoggingInterceptor { line ->
+                Timber.tag("HTTP").d(line)
+            }.apply {
+                level = HttpLoggingInterceptor.Level.BASIC
+            }
+        return OkHttpClient
+            .Builder()
+            .cache(Cache(cacheDir, CACHE_SIZE_BYTES))
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **OkHttp 4.12.0** and **logging-interceptor** as the shared HTTP foundation.
- \`HttpClientProvider\` exposes a lazy singleton \`OkHttpClient\` with:
  - 5 MiB on-disk response cache under \`cacheDir/http-cache\`
  - Timber-bridged \`HttpLoggingInterceptor\` (BASIC level → \`Tag=HTTP\`)
  - 15 s connect + read timeouts (matches previous Fuel defaults)

## Scope note
This PR intentionally **does not swap Fuel for Retrofit** yet. Providers keep calling Fuel; the new client is unused by production code paths. The swap requires per-provider Retrofit interfaces + Moshi converter wiring + error-shape translation across ~10 providers — a follow-up phase that needs a live Android build environment to validate.

## Stacking
Stacked on **#67** (Timber). Retargets upward as earlier PRs merge.

## Test plan
- [ ] CI compiles both flavors.
- [ ] Follow-up: implement \`OkHttpFuelClient\` (Fuel \`Client\` bridge) so the cache actually engages, or migrate providers to Retrofit built on this client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)