### PR TITLE
feat(ux): offline banner with last-updated timestamp

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".CurrenciesApplication"

--- a/app/src/main/kotlin/de/salomax/currencies/util/NetworkStatusLiveData.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/NetworkStatusLiveData.kt
@@ -1,0 +1,53 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.lifecycle.LiveData
+
+// Emits true when the device has a validated internet connection, false when
+// it does not. Uses [ConnectivityManager.registerNetworkCallback] so
+// transitions surface promptly (screen on, wifi flap, plane-mode toggle)
+// without polling. Initial value is derived from the currently-active network
+// so observers get a value on the first frame.
+class NetworkStatusLiveData(
+    context: Context,
+) : LiveData<Boolean>() {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val request =
+        NetworkRequest
+            .Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            .build()
+
+    private val callback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) = postValue(true)
+
+            override fun onLost(network: Network) = postValue(currentlyOnline())
+
+            override fun onUnavailable() = postValue(false)
+        }
+
+    private fun currentlyOnline(): Boolean {
+        val active = connectivityManager.activeNetwork ?: return false
+        val caps = connectivityManager.getNetworkCapabilities(active) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    override fun onActive() {
+        super.onActive()
+        postValue(currentlyOnline())
+        connectivityManager.registerNetworkCallback(request, callback)
+    }
+
+    override fun onInactive() {
+        connectivityManager.unregisterNetworkCallback(callback)
+        super.onInactive()
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.core.text.HtmlCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.window.layout.FoldingFeature
+import com.google.android.material.card.MaterialCardView
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.Snackbar
@@ -34,6 +35,7 @@ import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.FeeSide
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.repository.Database
+import de.salomax.currencies.util.NetworkStatusLiveData
 import de.salomax.currencies.util.feePercentDelta
 import de.salomax.currencies.util.getDecimalSeparator
 import de.salomax.currencies.util.hapticTap
@@ -86,6 +88,12 @@ class MainActivity : BaseActivity() {
     private lateinit var swipeRefresh: SwipeRefreshLayout
     private var menuItemRefresh: MenuItem? = null
 
+    private lateinit var offlineBanner: MaterialCardView
+    private lateinit var offlineBannerText: TextView
+    private var isOnline: Boolean = true
+    private var latestRatesDate: LocalDate? = null
+    private var latestRatesTime: LocalTime? = null
+
     private lateinit var tvCalculations: TextView
     private lateinit var tvFrom: TextView
     private lateinit var tvTo: TextView
@@ -123,6 +131,8 @@ class MainActivity : BaseActivity() {
         this.tvOriginalValue = findViewById(R.id.textOriginalValue)
         this.tvFeeBadge = findViewById(R.id.textFeeBadge)
         this.btnFeeSide = findViewById(R.id.btn_fee_side)
+        this.offlineBanner = findViewById(R.id.offlineBanner)
+        this.offlineBannerText = findViewById(R.id.offlineBannerText)
 
         // swipe-to-refresh: color scheme (not accessible in xml)
         swipeRefresh.setColorSchemeColors(MaterialColors.getColor(this, R.attr.colorOnPrimary, null))
@@ -412,6 +422,25 @@ class MainActivity : BaseActivity() {
         viewModel.getTrueCost().observe(this) { observeTrueCost(it) }
         viewModel.getOriginalValue().observe(this) { observeOriginalValue(it) }
         viewModel.getTotalStack().observe(this) { observeTotalStack(it) }
+        NetworkStatusLiveData(this).observe(this) { online ->
+            isOnline = online
+            renderOfflineBanner()
+        }
+    }
+
+    private fun renderOfflineBanner() {
+        if (isOnline) {
+            offlineBanner.visibility = View.GONE
+            return
+        }
+        val date = latestRatesDate
+        offlineBannerText.text =
+            if (date != null) {
+                getString(R.string.offline_banner_with_date, formatRatesTimestamp(date, latestRatesTime).orEmpty())
+            } else {
+                getString(R.string.offline_banner_no_data)
+            }
+        offlineBanner.visibility = View.VISIBLE
     }
 
     private fun observeFeeSide(side: FeeSide?) {
@@ -467,6 +496,9 @@ class MainActivity : BaseActivity() {
     }
 
     private fun observeExchangeRates(rates: ExchangeRates?) {
+        latestRatesDate = rates?.date
+        latestRatesTime = rates?.time
+        renderOfflineBanner()
         rates?.let {
             val date = it.date
             val dateString = formatRatesTimestamp(date, it.time)

--- a/app/src/main/res/drawable/ic_cloud_off.xml
+++ b/app/src/main/res/drawable/ic_cloud_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4c-1.48,0 -2.85,0.43 -4.01,1.17l1.46,1.46C10.21,6.23 11.08,6 12,6c3.04,0 5.5,2.46 5.5,5.5v0.5H19c1.66,0 3,1.34 3,3 0,1.13 -0.64,2.11 -1.56,2.62l1.45,1.45C23.16,18.16 24,16.68 24,15c0,-2.64 -2.05,-4.78 -4.65,-4.96zM3,5.27l2.75,2.74C2.56,8.15 0,10.77 0,14c0,3.31 2.69,6 6,6h11.73l2,2L21,20.73 4.27,4 3,5.27zM7.73,10l8,8H6c-2.21,0 -4,-1.79 -4,-4s1.79,-4 4,-4h1.73z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_root"
     android:layout_width="match_parent"
@@ -7,6 +8,32 @@
     android:baselineAligned="false"
     android:fitsSystemWindows="true"
     android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/offlineBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="?attr/colorErrorContainer"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="0dp"
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/offlineBannerText"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="12dp"
+            android:gravity="center_vertical"
+            android:padding="12dp"
+            android:textColor="?attr/colorOnErrorContainer"
+            app:drawableStartCompat="@drawable/ic_cloud_off"
+            app:drawableTint="?attr/colorOnErrorContainer"
+            tools:text="Offline • Rates from 2 hours ago" />
+
+    </com.google.android.material.card.MaterialCardView>
 
     <include
         layout="@layout/main_display"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="info_conversion">%1$s %2$s ≈ %3$s %4$s</string>
     <string name="info_date_latest">Rates as of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
     <string name="info_date_historical">Historical rates of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
+    <string name="offline_banner_with_date">Offline • Rates from %1$s</string>
+    <string name="offline_banner_no_data">Offline • No cached rates yet</string>
     <string name="copied_to_clipboard">Copied &lt;b>%s&lt;/b> to clipboard</string>
 
     <string name="historical_rates_dialog_title">Historical rates</string>


### PR DESCRIPTION
## Summary
- New MaterialCardView banner above the main display that shows when the device loses network connectivity.
- Text: \`Offline • Rates from {timestamp}\` if there are cached rates, otherwise \`Offline • No cached rates yet\`.
- \`NetworkStatusLiveData\` wraps \`ConnectivityManager.registerNetworkCallback\` — no polling, prompt online/offline transitions.
- Adds \`ACCESS_NETWORK_STATE\` permission and \`ic_cloud_off\` drawable.

## Stacking
Stacked on **#68** (OkHttp foundation). Retargets upward as earlier PRs merge.

## Test plan
- [ ] Toggle airplane mode → banner appears within ~1 s, shows last-updated timestamp.
- [ ] Toggle airplane mode off + successful refresh → banner disappears.
- [ ] First launch with no cached rates + no network → banner shows "No cached rates yet".
- [ ] CI \`build.yaml\` compiles both flavors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)