### PR TITLE
feat(cart): CSV share via FileProvider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,16 @@
         <activity android:name=".view.timeline.TimelineActivity" />
         <activity android:name=".view.cart.CartActivity" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/kotlin/de/salomax/currencies/util/CartCsv.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/CartCsv.kt
@@ -1,0 +1,41 @@
+package de.salomax.currencies.util
+
+import de.salomax.currencies.viewmodel.cart.CartSnapshot
+import java.math.RoundingMode
+
+private const val DISPLAY_SCALE = 2
+private const val CSV_QUOTE = '"'
+private const val CSV_SEPARATOR = ','
+private const val CSV_LINE_END = "\r\n"
+
+// Builds an RFC 4180-compliant CSV rendering of a cart snapshot. Line
+// terminator is CRLF so spreadsheet apps (Excel, Numbers, LibreOffice)
+// recognise row boundaries even on macOS. Every field is quoted and inner
+// quotes are doubled — safest form when item names may contain commas or
+// quotes themselves.
+fun CartSnapshot.toCsv(): String =
+    buildString {
+        append(csvRow("Item", "Expression", "Value (${baseCurrency.iso4217Alpha()})"))
+        evaluatedItems.forEach { (item, value) ->
+            append(csvRow(item.name, item.expression, value.toDisplayString()))
+        }
+        append(csvRow("", "", ""))
+        append(csvRow("Subtotal", "", subtotal.toDisplayString()))
+        if (isConverting) {
+            append(csvRow("Converted (${destinationCurrency.iso4217Alpha()})", "", convertedSubtotal.toDisplayString()))
+        }
+        if (!feeStack.isNeutralFeeStack()) {
+            append(csvRow("Fees (${feeStack.feePercentDelta().toPlainString()}%)", "", ""))
+        }
+        append(csvRow("Total (${destinationCurrency.iso4217Alpha()})", "", total.toDisplayString()))
+    }
+
+private fun csvRow(vararg cells: String): String =
+    cells.joinToString(separator = CSV_SEPARATOR.toString(), postfix = CSV_LINE_END) { it.csvQuote() }
+
+private fun String.csvQuote(): String {
+    val escaped = replace("$CSV_QUOTE", "$CSV_QUOTE$CSV_QUOTE")
+    return "$CSV_QUOTE$escaped$CSV_QUOTE"
+}
+
+private fun java.math.BigDecimal.toDisplayString(): String = setScale(DISPLAY_SCALE, RoundingMode.HALF_EVEN).toPlainString()

--- a/app/src/main/kotlin/de/salomax/currencies/util/CartShareFile.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/CartShareFile.kt
@@ -1,0 +1,38 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+private const val EXPORT_SUBDIR = "cart-exports"
+private const val AUTHORITY_SUFFIX = ".fileprovider"
+
+// Shared helper for cart share flows that produce a file (CSV, PDF, etc.).
+// Writes [bytes] into the FileProvider-mapped [EXPORT_SUBDIR] under cacheDir
+// and returns a chooser Intent already primed with the correct MIME type and
+// per-URI read grant so any receiver can open the artifact.
+fun buildCartShareChooser(
+    context: Context,
+    filename: String,
+    mimeType: String,
+    bytes: ByteArray,
+): Intent {
+    val exportDir = File(context.cacheDir, EXPORT_SUBDIR).apply { mkdirs() }
+    val outFile = File(exportDir, filename).apply { writeBytes(bytes) }
+    val uri =
+        FileProvider.getUriForFile(
+            context,
+            context.packageName + AUTHORITY_SUFFIX,
+            outFile,
+        )
+    val sendIntent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    return Intent.createChooser(sendIntent, null).apply {
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
@@ -34,12 +34,14 @@ import de.salomax.currencies.model.SavedCart
 import de.salomax.currencies.repository.CartExporter
 import de.salomax.currencies.repository.CartFileResult
 import de.salomax.currencies.util.OPERATOR_REGEX
+import de.salomax.currencies.util.buildCartShareChooser
 import de.salomax.currencies.util.choiceExplainerRow
 import de.salomax.currencies.util.feePercentDelta
 import de.salomax.currencies.util.hapticTap
 import de.salomax.currencies.util.isNeutralFeeStack
 import de.salomax.currencies.util.paddedDialogContainer
 import de.salomax.currencies.util.rateSpinnerListener
+import de.salomax.currencies.util.toCsv
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.view.BaseActivity
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
@@ -62,6 +64,12 @@ private const val CART_DISPLAY_SCALE = 2
 private const val EXPORT_FILE_MIME = "application/json"
 private const val EXPORT_FILE_EXT = ".json"
 private const val EXPORT_FILE_DATE_FORMAT = "yyyyMMdd-HHmmss"
+
+// Shared filename base + format for the CSV / PDF share flows.
+private const val SHARE_FILE_DATE_FORMAT = EXPORT_FILE_DATE_FORMAT
+private const val CSV_MIME = "text/csv"
+private const val CSV_EXT = ".csv"
+private const val SHARE_FILE_PREFIX = "cart-"
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
 private const val KEYPAD_ANIM_MS = 180L
@@ -210,6 +218,10 @@ class CartActivity : BaseActivity() {
             }
             R.id.cart_share -> {
                 shareCart()
+                true
+            }
+            R.id.cart_share_csv -> {
+                shareCartCsv()
                 true
             }
             R.id.cart_save -> {
@@ -664,6 +676,27 @@ class CartActivity : BaseActivity() {
                 putExtra(Intent.EXTRA_TEXT, text)
             }
         startActivity(Intent.createChooser(intent, null))
+    }
+
+    private fun shareCartCsv() {
+        val snapshot = viewModel.snapshotForShare()
+        if (snapshot == null) {
+            showSnackbar(getString(R.string.cart_share_empty))
+            return
+        }
+        val chooser =
+            buildCartShareChooser(
+                context = this,
+                filename = shareFilename(CSV_EXT),
+                mimeType = CSV_MIME,
+                bytes = snapshot.toCsv().toByteArray(Charsets.UTF_8),
+            )
+        startActivity(chooser)
+    }
+
+    private fun shareFilename(extension: String): String {
+        val timestamp = SimpleDateFormat(SHARE_FILE_DATE_FORMAT, Locale.US).format(Date())
+        return SHARE_FILE_PREFIX + timestamp + extension
     }
 
     private fun buildShareText(snapshot: CartSnapshot): String =

--- a/app/src/main/res/menu/cart.xml
+++ b/app/src/main/res/menu/cart.xml
@@ -9,6 +9,12 @@
         app:showAsAction="never" />
 
     <item
+        android:orderInCategory="1"
+        android:id="@+id/cart_share_csv"
+        android:title="@string/cart_menu_share_csv"
+        app:showAsAction="never" />
+
+    <item
         android:orderInCategory="9"
         android:id="@+id/cart_save"
         android:title="@string/cart_menu_save"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="cart_menu_export">Export to file</string>
     <string name="cart_menu_import">Import from file</string>
     <string name="cart_menu_clear">Clear</string>
+    <string name="cart_menu_share_csv">Share as CSV</string>
     <string name="cart_save_name_hint">Cart name</string>
     <string name="cart_default_saved_name">My cart</string>
     <string name="cart_saved_toast">Saved as “%s”</string>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Named subpath under cacheDir where transient share artifacts (CSV, PDF) live.
+         The exported name in the FileProvider URI stays stable across app updates
+         even if the on-disk directory layout changes. -->
+    <cache-path
+        name="cart-exports"
+        path="cart-exports/" />
+</paths>


### PR DESCRIPTION
## Summary
- New **Share as CSV** menu entry under Cart → overflow.
- \`CartCsv.toCsv()\` renders a snapshot as **RFC 4180** CSV (CRLF terminators, every field quoted with doubled internal quotes so item names with commas/quotes round-trip).
- Shared through the new **FileProvider** (\`\${applicationId}.fileprovider\`) mapped to \`cacheDir/cart-exports/\`.
- \`buildCartShareChooser()\` is generic — the PDF phase reuses it.

## Stacking
Stacked on **#69** (offline banner). Retargets upward as earlier PRs merge.

## Test plan
- [ ] Cart with 3 items → Share as CSV → open in a spreadsheet app, headers + items + subtotal + total render correctly.
- [ ] Item name containing \`,\` and \`"\` → shows literally in destination app.
- [ ] Cart with fees + conversion → CSV contains \`Fees (%)\` and \`Converted\` rows.
- [ ] Empty cart → snackbar "nothing to share".

🤖 Generated with [Claude Code](https://claude.com/claude-code)