### PR TITLE
feat(widget): home-screen widget with last-used pair rate

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,17 @@
                 android:resource="@xml/file_provider_paths" />
         </provider>
 
+        <receiver
+            android:name=".view.widget.CurrencyWidget"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/currency_widget_info" />
+        </receiver>
+
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -27,6 +27,7 @@ import de.salomax.currencies.util.SharedPreferenceLongLiveData
 import de.salomax.currencies.util.SharedPreferenceStringLiveData
 import de.salomax.currencies.util.toLocalDate
 import de.salomax.currencies.util.toMillis
+import de.salomax.currencies.view.widget.CurrencyWidget
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -48,7 +49,7 @@ private const val NO_HISTORICAL_DATE = -1L
 const val KEYBOARD_TYPE_BASIC = 0
 
 class Database(
-    context: Context,
+    private val context: Context,
 ) {
     /*
      * current exchange rates from api =============================================================
@@ -73,6 +74,7 @@ class Database(
                 // persist
                 editor.apply()
             }
+            CurrencyWidget.refreshWidgets(context)
         }
     }
 
@@ -165,6 +167,7 @@ class Database(
             from?.let { edit().putString(keyLastStateFrom, it.iso4217Alpha()).apply() }
             to?.let { edit().putString(keyLastStateTo, it.iso4217Alpha()).apply() }
         }
+        CurrencyWidget.refreshWidgets(context)
     }
 
     fun getLastBaseCurrency(): LiveData<Currency?> =

--- a/app/src/main/kotlin/de/salomax/currencies/view/widget/CurrencyWidget.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/widget/CurrencyWidget.kt
@@ -1,0 +1,132 @@
+package de.salomax.currencies.view.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import de.salomax.currencies.R
+import de.salomax.currencies.model.Currency
+import de.salomax.currencies.util.KEY_RATES_BASE
+import de.salomax.currencies.util.KEY_RATES_DATE
+import de.salomax.currencies.view.main.MainActivity
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+private const val RATES_PREFS = "rates"
+private const val LAST_STATE_PREFS = "last_state"
+private const val KEY_LAST_FROM = "_last_from"
+private const val KEY_LAST_TO = "_last_to"
+private const val DEFAULT_FROM = "USD"
+private const val DEFAULT_TO = "EUR"
+private const val WIDGET_DISPLAY_SCALE = 4
+
+// Home-screen widget rendering the last-used base → destination pair and the
+// cached conversion rate. Backed by the same SharedPreferences the app writes
+// to (rates + last_state), so there's no separate widget data source. Refresh
+// happens on the AppWidget update tick (see currency_widget_info.xml) and via
+// [refreshWidgets], called after every successful rate insert.
+class CurrencyWidget : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        appWidgetIds.forEach { id ->
+            appWidgetManager.updateAppWidget(id, buildRemoteViews(context))
+        }
+    }
+
+    companion object {
+        // Called from the repository after new rates land, so an open widget
+        // reflects the fresh values without waiting for the next system tick.
+        fun refreshWidgets(context: Context) {
+            val manager = AppWidgetManager.getInstance(context) ?: return
+            val ids = manager.getAppWidgetIds(ComponentName(context, CurrencyWidget::class.java))
+            if (ids.isEmpty()) return
+            val views = buildRemoteViews(context)
+            ids.forEach { manager.updateAppWidget(it, views) }
+        }
+
+        private fun buildRemoteViews(context: Context): RemoteViews {
+            val views = RemoteViews(context.packageName, R.layout.widget_currency)
+            val snapshot = readSnapshot(context)
+            views.setTextViewText(R.id.widget_rate_line, snapshot.rateLine(context))
+            views.setTextViewText(R.id.widget_footer, snapshot.footerLine(context))
+            views.setOnClickPendingIntent(R.id.widget_root, launchAppIntent(context))
+            return views
+        }
+
+        private fun launchAppIntent(context: Context): PendingIntent {
+            val intent =
+                Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+
+        private fun readSnapshot(context: Context): WidgetSnapshot {
+            val ratesPrefs = context.getSharedPreferences(RATES_PREFS, Context.MODE_PRIVATE)
+            val lastState = context.getSharedPreferences(LAST_STATE_PREFS, Context.MODE_PRIVATE)
+            val fromCode = lastState.getString(KEY_LAST_FROM, DEFAULT_FROM) ?: DEFAULT_FROM
+            val toCode = lastState.getString(KEY_LAST_TO, DEFAULT_TO) ?: DEFAULT_TO
+            val from = Currency.fromString(fromCode)
+            val to = Currency.fromString(toCode)
+            val date = ratesPrefs.getString(KEY_RATES_DATE, null)
+            val baseCode = ratesPrefs.getString(KEY_RATES_BASE, null)
+            val fromRate = fromCode.let { ratesPrefs.getString(it, null)?.toBigDecimalOrNull() }
+            val toRate = toCode.let { ratesPrefs.getString(it, null)?.toBigDecimalOrNull() }
+            val converted =
+                if (fromRate != null && toRate != null && fromRate.signum() != 0) {
+                    BigDecimal.ONE
+                        .divide(fromRate, MathContext.DECIMAL64)
+                        .multiply(toRate)
+                        .setScale(WIDGET_DISPLAY_SCALE, RoundingMode.HALF_EVEN)
+                } else {
+                    null
+                }
+            return WidgetSnapshot(
+                fromCode = from?.iso4217Alpha() ?: fromCode,
+                toCode = to?.iso4217Alpha() ?: toCode,
+                converted = converted,
+                date = date,
+                hasAnyCachedRate = baseCode != null,
+            )
+        }
+    }
+}
+
+private data class WidgetSnapshot(
+    val fromCode: String,
+    val toCode: String,
+    val converted: BigDecimal?,
+    val date: String?,
+    val hasAnyCachedRate: Boolean,
+) {
+    fun rateLine(context: Context): String =
+        if (converted != null) {
+            context.getString(
+                R.string.widget_rate_line,
+                fromCode,
+                converted.toPlainString(),
+                toCode,
+            )
+        } else {
+            context.getString(R.string.widget_no_rate)
+        }
+
+    fun footerLine(context: Context): String =
+        when {
+            date != null -> context.getString(R.string.widget_footer_date, date)
+            hasAnyCachedRate -> context.getString(R.string.widget_no_rate)
+            else -> context.getString(R.string.widget_footer_empty)
+        }
+}

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="?android:attr/colorBackground" />
+</shape>

--- a/app/src/main/res/layout/widget_currency.xml
+++ b/app/src/main/res/layout/widget_currency.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/widget_rate_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        tools:ignore="UnusedAttribute" />
+
+    <TextView
+        android:id="@+id/widget_footer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="11sp"
+        tools:ignore="UnusedAttribute" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,13 @@
     <string name="tooltip_filter_starred">Show only starred currencies.</string>
     <string name="currency_dropdown_api_hint">Something missing? Different data providers offer different currencies. Go to the settings to try another one!\u00A0\uD83E\uDD17</string>
 
+    <!-- Home-screen widget -->
+    <string name="widget_description">Latest conversion rate for your last-used currency pair.</string>
+    <string name="widget_rate_line">1 %1$s = %2$s %3$s</string>
+    <string name="widget_footer_date">As of %s</string>
+    <string name="widget_footer_empty">Open the app to load rates.</string>
+    <string name="widget_no_rate">Rate unavailable</string>
+
     <!-- Shopping cart -->
     <string name="cart_title">Shopping cart</string>
     <string name="cart_empty_hint">Your cart is empty. Tap “Add item” to start.</string>

--- a/app/src/main/res/xml/currency_widget_info.xml
+++ b/app/src/main/res/xml/currency_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/widget_currency"
+    android:minWidth="180dp"
+    android:minHeight="60dp"
+    android:previewLayout="@layout/widget_currency"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="1"
+    android:targetCellWidth="2"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- Adds a resizable home-screen widget (\`res/xml/currency_widget_info.xml\`) that renders \`1 USD = 0.9200 EUR\` and the rate date for the user's last-used pair.
- Reads directly from the existing \`rates\` + \`last_state\` SharedPreferences — no new data source, no schema migration.
- Refreshes on the system 30-min tick and opportunistically from \`Database.insertExchangeRates\` and \`saveLastUsedRates\`, so the widget updates as soon as the app fetches new rates or the user changes the pair.
- Tap on the widget launches MainActivity.

## Test plan
- [ ] Long-press home screen → Widgets → Currencies → drag onto home. Verify pair + rate + date render.
- [ ] Change base/destination in the app; verify the widget updates within a second.
- [ ] Airplane mode + no cached rates: widget shows \`Open the app to load rates.\` and \`Rate unavailable\`.
- [ ] Resize the widget both directions; text truncates cleanly.
- [ ] Tap widget → MainActivity opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)