### PR TITLE
feat(cart): Compose pilot — empty-state hint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.runtime:runtime-livedata")
     // charts

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
@@ -22,6 +22,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -45,6 +47,7 @@ import de.salomax.currencies.util.toCsv
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.util.toPdfBytes
 import de.salomax.currencies.view.BaseActivity
+import de.salomax.currencies.view.cart.compose.CartEmptyHint
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
 import de.salomax.currencies.view.preference.PreferenceActivity
 import de.salomax.currencies.viewmodel.cart.CartSnapshot
@@ -95,7 +98,7 @@ class CartActivity : BaseActivity() {
     private lateinit var spinnerTo: SearchableSpinner
     private lateinit var swapButton: ImageButton
     private lateinit var feeSideButton: AppCompatImageButton
-    private lateinit var emptyHint: TextView
+    private lateinit var emptyHint: ComposeView
     private lateinit var addButton: MaterialButton
 
     private lateinit var adapter: CartItemAdapter
@@ -145,7 +148,11 @@ class CartActivity : BaseActivity() {
         this.spinnerTo = findViewById(R.id.cart_spinner_to)
         this.swapButton = findViewById(R.id.cart_swap)
         this.feeSideButton = findViewById(R.id.cart_btn_fee_side)
-        this.emptyHint = findViewById(R.id.cart_empty_hint)
+        this.emptyHint =
+            findViewById<ComposeView>(R.id.cart_empty_hint).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent { CartEmptyHint() }
+            }
         this.addButton = findViewById(R.id.cart_add_item)
         this.keypadContainer = findViewById(R.id.cart_keypad_container)
         this.keypadRegular = findViewById(R.id.cart_keypad_regular)

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/compose/CartEmptyHint.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/compose/CartEmptyHint.kt
@@ -1,0 +1,45 @@
+package de.salomax.currencies.view.cart.compose
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import de.salomax.currencies.R
+
+// First Compose surface migrated off XML. Rendered inside a ComposeView that
+// replaces the old TextView with id `cart_empty_hint`. Kept intentionally
+// small — the goal of the pilot is to prove the wiring (dependency, theme,
+// live recomposition on visibility toggle) works end-to-end so the larger
+// totals / row list can migrate in follow-up phases.
+//
+// MaterialTheme is wired here (rather than at the activity level) because
+// this is currently the only Compose surface in CartActivity; once more
+// composables move over, hoist the theme wrapper up to a single call site.
+@Composable
+fun CartEmptyHint() {
+    val colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+    MaterialTheme(colorScheme = colorScheme) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(id = R.dimen.margin3x)),
+        ) {
+            Text(
+                text = stringResource(id = R.string.cart_empty_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -28,14 +28,10 @@
             android:paddingHorizontal="@dimen/margin1x"
             android:paddingVertical="@dimen/margin1x" />
 
-        <TextView
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/cart_empty_hint"
-            style="@style/TextAppearance.Material3.BodyMedium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/margin3x"
-            android:gravity="center"
-            android:text="@string/cart_empty_hint"
             android:visibility="gone" />
 
         <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
## Summary
- First surface on CartActivity migrated off XML views: the empty-state hint TextView is replaced by a \`ComposeView\` hosting a small Material3 Compose function (\`CartEmptyHint\`).
- Adds \`androidx.compose.material3\` via the existing Compose BOM (ui/foundation/runtime were already present for the Vico chart, so no new BOM entry).
- Uses \`ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed\` — the ComposeView's visibility toggling is still driven from the existing activity code, so no ViewModel/state hoist is needed for this step.

Deliberately narrow: the aim is to prove wiring (compiler plugin, theme, live compose in an existing XML activity, visibility toggling) end-to-end so subsequent phases can migrate the totals card / row list without also debugging build plumbing.

## Test plan
- [ ] Open the Cart screen with items — hint stays hidden.
- [ ] Clear the cart — hint appears centered, same copy as before.
- [ ] Toggle system dark/light theme while the hint is visible — text color adapts.
- [ ] Rotate the device with an empty cart — hint re-renders without crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)