### PR TITLE
feat: land improvements-roadmap stack (recovery PR)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,9 @@ dependencies {
     // crypto: BouncyCastle provides pure-Java Argon2id, used by BackupManager
     // for password-based backup encryption (quantum-resistant KDF).
     implementation("org.bouncycastle:bcprov-jdk18on:1.85")
+    // logging: Timber routes to a rotating file tree written under filesDir/logs.
+    // Local-only — no remote crash / analytics sink.
+    implementation("com.jakewharton.timber:timber:5.0.1")
     // test
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.runtime:runtime-livedata")
     // charts

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,12 @@ dependencies {
     implementation("com.github.kittinunf.fuel:fuel-android:$fuelVersion")
     implementation("com.github.kittinunf.fuel:fuel-coroutines:$fuelVersion")
     implementation("com.github.kittinunf.fuel:fuel-moshi:$fuelVersion")
+    // OkHttp foundation for HTTP caching + Timber-bridged logging. Fuel is
+    // still the calling surface for now; a follow-up phase will migrate
+    // providers to Retrofit built on this shared client.
+    val okHttpVersion = "4.12.0"
+    implementation("com.squareup.okhttp3:okhttp:$okHttpVersion")
+    implementation("com.squareup.okhttp3:logging-interceptor:$okHttpVersion")
     val moshiVersion = "1.15.2"
     implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
     ksp("com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,16 @@
         <activity android:name=".view.timeline.TimelineActivity" />
         <activity android:name=".view.cart.CartActivity" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,17 @@
                 android:resource="@xml/file_provider_paths" />
         </provider>
 
+        <receiver
+            android:name=".view.widget.CurrencyWidget"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/currency_widget_info" />
+        </receiver>
+
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".CurrenciesApplication"

--- a/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/CurrenciesApplication.kt
@@ -3,15 +3,27 @@ package de.salomax.currencies
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import de.salomax.currencies.repository.Database
+import de.salomax.currencies.util.FileLoggingTree
+import timber.log.Timber
 import java.net.InetAddress
 import kotlin.concurrent.thread
 
 class CurrenciesApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        installLogging()
         applyNightMode()
         warmSharedPreferences()
         prewarmProviderDns()
+    }
+
+    // Debug builds also get a console tree so `adb logcat` mirrors what the
+    // file tree captures. Release builds are file-only — no remote sink.
+    private fun installLogging() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+        Timber.plant(FileLoggingTree(filesDir))
     }
 
     // Apply the persisted day/night mode before any Activity is created, so

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -3,7 +3,6 @@ package de.salomax.currencies.repository
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import de.salomax.currencies.model.ApiProvider
@@ -31,6 +30,7 @@ import de.salomax.currencies.util.toMillis
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import timber.log.Timber
 import java.time.LocalDate
 import java.util.UUID
 
@@ -125,7 +125,7 @@ class Database(
                 provider = provider,
             )
         } catch (e: JSONException) {
-            Log.w("Database", "Malformed cached timeline, dropping", e)
+            Timber.tag("Database").w(e, "Malformed cached timeline, dropping")
             null
         }
     }
@@ -470,7 +470,7 @@ class Database(
             val arr = JSONArray(json)
             (0 until arr.length()).mapNotNull { i -> parseFeeEntry(arr.optJSONObject(i)) }
         } catch (e: JSONException) {
-            Log.w("Database", "Malformed fee JSON, resetting", e)
+            Timber.tag("Database").w(e, "Malformed fee JSON, resetting")
             emptyList()
         }
 

--- a/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/repository/Database.kt
@@ -27,6 +27,7 @@ import de.salomax.currencies.util.SharedPreferenceLongLiveData
 import de.salomax.currencies.util.SharedPreferenceStringLiveData
 import de.salomax.currencies.util.toLocalDate
 import de.salomax.currencies.util.toMillis
+import de.salomax.currencies.view.widget.CurrencyWidget
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -48,7 +49,7 @@ private const val NO_HISTORICAL_DATE = -1L
 const val KEYBOARD_TYPE_BASIC = 0
 
 class Database(
-    context: Context,
+    private val context: Context,
 ) {
     /*
      * current exchange rates from api =============================================================
@@ -73,6 +74,7 @@ class Database(
                 // persist
                 editor.apply()
             }
+            CurrencyWidget.refreshWidgets(context)
         }
     }
 
@@ -165,6 +167,7 @@ class Database(
             from?.let { edit().putString(keyLastStateFrom, it.iso4217Alpha()).apply() }
             to?.let { edit().putString(keyLastStateTo, it.iso4217Alpha()).apply() }
         }
+        CurrencyWidget.refreshWidgets(context)
     }
 
     fun getLastBaseCurrency(): LiveData<Currency?> =

--- a/app/src/main/kotlin/de/salomax/currencies/util/CartCsv.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/CartCsv.kt
@@ -1,0 +1,41 @@
+package de.salomax.currencies.util
+
+import de.salomax.currencies.viewmodel.cart.CartSnapshot
+import java.math.RoundingMode
+
+private const val DISPLAY_SCALE = 2
+private const val CSV_QUOTE = '"'
+private const val CSV_SEPARATOR = ','
+private const val CSV_LINE_END = "\r\n"
+
+// Builds an RFC 4180-compliant CSV rendering of a cart snapshot. Line
+// terminator is CRLF so spreadsheet apps (Excel, Numbers, LibreOffice)
+// recognise row boundaries even on macOS. Every field is quoted and inner
+// quotes are doubled — safest form when item names may contain commas or
+// quotes themselves.
+fun CartSnapshot.toCsv(): String =
+    buildString {
+        append(csvRow("Item", "Expression", "Value (${baseCurrency.iso4217Alpha()})"))
+        evaluatedItems.forEach { (item, value) ->
+            append(csvRow(item.name, item.expression, value.toDisplayString()))
+        }
+        append(csvRow("", "", ""))
+        append(csvRow("Subtotal", "", subtotal.toDisplayString()))
+        if (isConverting) {
+            append(csvRow("Converted (${destinationCurrency.iso4217Alpha()})", "", convertedSubtotal.toDisplayString()))
+        }
+        if (!feeStack.isNeutralFeeStack()) {
+            append(csvRow("Fees (${feeStack.feePercentDelta().toPlainString()}%)", "", ""))
+        }
+        append(csvRow("Total (${destinationCurrency.iso4217Alpha()})", "", total.toDisplayString()))
+    }
+
+private fun csvRow(vararg cells: String): String =
+    cells.joinToString(separator = CSV_SEPARATOR.toString(), postfix = CSV_LINE_END) { it.csvQuote() }
+
+private fun String.csvQuote(): String {
+    val escaped = replace("$CSV_QUOTE", "$CSV_QUOTE$CSV_QUOTE")
+    return "$CSV_QUOTE$escaped$CSV_QUOTE"
+}
+
+private fun java.math.BigDecimal.toDisplayString(): String = setScale(DISPLAY_SCALE, RoundingMode.HALF_EVEN).toPlainString()

--- a/app/src/main/kotlin/de/salomax/currencies/util/CartPdf.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/CartPdf.kt
@@ -1,0 +1,103 @@
+package de.salomax.currencies.util
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.pdf.PdfDocument
+import de.salomax.currencies.viewmodel.cart.CartSnapshot
+import java.io.ByteArrayOutputStream
+import java.math.RoundingMode
+
+// A4 at 72 dpi. Android's PdfDocument treats page units as points; A4 is
+// 8.27 × 11.69 in = 595 × 842 pt. Matches what every desktop PDF renderer
+// expects, so the output prints without scaling.
+private const val PAGE_WIDTH_PT = 595
+private const val PAGE_HEIGHT_PT = 842
+private const val PAGE_MARGIN_PT = 40f
+private const val LINE_HEIGHT_PT = 18f
+private const val SECTION_GAP_PT = 12f
+
+private const val TITLE_TEXT_SIZE = 20f
+private const val HEADER_TEXT_SIZE = 12f
+private const val BODY_TEXT_SIZE = 11f
+private const val DISPLAY_SCALE = 2
+
+// Renders a cart snapshot into a single-page A4 PDF. Deliberately built on
+// [PdfDocument] rather than a third-party generator so the app doesn't pick
+// up an extra dependency for this narrow feature. Wide carts still fit
+// because item names truncate at the value column; a follow-up can add
+// multi-page pagination if user carts start exceeding ~40 rows.
+fun CartSnapshot.toPdfBytes(title: String): ByteArray {
+    val document = PdfDocument()
+    val pageInfo = PdfDocument.PageInfo.Builder(PAGE_WIDTH_PT, PAGE_HEIGHT_PT, 1).create()
+    val page = document.startPage(pageInfo)
+    drawSnapshot(page.canvas, title)
+    document.finishPage(page)
+
+    val out = ByteArrayOutputStream()
+    document.writeTo(out)
+    document.close()
+    return out.toByteArray()
+}
+
+private fun CartSnapshot.drawSnapshot(
+    canvas: Canvas,
+    title: String,
+) {
+    val titlePaint = paint(TITLE_TEXT_SIZE, bold = true)
+    val headerPaint = paint(HEADER_TEXT_SIZE, bold = true)
+    val bodyPaint = paint(BODY_TEXT_SIZE)
+    val bodyRight = paint(BODY_TEXT_SIZE).apply { textAlign = Paint.Align.RIGHT }
+
+    val rightX = PAGE_WIDTH_PT - PAGE_MARGIN_PT
+    var y = PAGE_MARGIN_PT + TITLE_TEXT_SIZE
+
+    canvas.drawText(title, PAGE_MARGIN_PT, y, titlePaint)
+    y += SECTION_GAP_PT + LINE_HEIGHT_PT
+
+    canvas.drawText("Item", PAGE_MARGIN_PT, y, headerPaint)
+    canvas.drawText("Value (${baseCurrency.iso4217Alpha()})", rightX, y, headerPaint.apply { textAlign = Paint.Align.RIGHT })
+    y += LINE_HEIGHT_PT
+
+    evaluatedItems.forEach { (item, value) ->
+        val label = item.name.ifBlank { item.expression }
+        canvas.drawText(label, PAGE_MARGIN_PT, y, bodyPaint)
+        canvas.drawText(value.toDisplayString(), rightX, y, bodyRight)
+        y += LINE_HEIGHT_PT
+    }
+
+    y += SECTION_GAP_PT
+    canvas.drawText("Subtotal", PAGE_MARGIN_PT, y, headerPaint.apply { textAlign = Paint.Align.LEFT })
+    canvas.drawText("${subtotal.toDisplayString()} ${baseCurrency.iso4217Alpha()}", rightX, y, bodyRight)
+    y += LINE_HEIGHT_PT
+
+    if (isConverting) {
+        canvas.drawText("Converted", PAGE_MARGIN_PT, y, bodyPaint)
+        canvas.drawText("${convertedSubtotal.toDisplayString()} ${destinationCurrency.iso4217Alpha()}", rightX, y, bodyRight)
+        y += LINE_HEIGHT_PT
+    }
+    if (!feeStack.isNeutralFeeStack()) {
+        canvas.drawText("Fees", PAGE_MARGIN_PT, y, bodyPaint)
+        canvas.drawText("${feeStack.feePercentDelta().toPlainString()}%", rightX, y, bodyRight)
+        y += LINE_HEIGHT_PT
+    }
+
+    y += SECTION_GAP_PT
+    canvas.drawText("Total", PAGE_MARGIN_PT, y, headerPaint.apply { textAlign = Paint.Align.LEFT })
+    canvas.drawText(
+        "${total.toDisplayString()} ${destinationCurrency.iso4217Alpha()}",
+        rightX,
+        y,
+        paint(BODY_TEXT_SIZE, bold = true).apply { textAlign = Paint.Align.RIGHT },
+    )
+}
+
+private fun paint(
+    size: Float,
+    bold: Boolean = false,
+): Paint =
+    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = size
+        if (bold) isFakeBoldText = true
+    }
+
+private fun java.math.BigDecimal.toDisplayString(): String = setScale(DISPLAY_SCALE, RoundingMode.HALF_EVEN).toPlainString()

--- a/app/src/main/kotlin/de/salomax/currencies/util/CartShareFile.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/CartShareFile.kt
@@ -1,0 +1,38 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+private const val EXPORT_SUBDIR = "cart-exports"
+private const val AUTHORITY_SUFFIX = ".fileprovider"
+
+// Shared helper for cart share flows that produce a file (CSV, PDF, etc.).
+// Writes [bytes] into the FileProvider-mapped [EXPORT_SUBDIR] under cacheDir
+// and returns a chooser Intent already primed with the correct MIME type and
+// per-URI read grant so any receiver can open the artifact.
+fun buildCartShareChooser(
+    context: Context,
+    filename: String,
+    mimeType: String,
+    bytes: ByteArray,
+): Intent {
+    val exportDir = File(context.cacheDir, EXPORT_SUBDIR).apply { mkdirs() }
+    val outFile = File(exportDir, filename).apply { writeBytes(bytes) }
+    val uri =
+        FileProvider.getUriForFile(
+            context,
+            context.packageName + AUTHORITY_SUFFIX,
+            outFile,
+        )
+    val sendIntent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    return Intent.createChooser(sendIntent, null).apply {
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/util/FileLoggingTree.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/FileLoggingTree.kt
@@ -1,0 +1,93 @@
+package de.salomax.currencies.util
+
+import android.util.Log
+import timber.log.Timber
+import java.io.File
+import java.io.PrintWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.Executors
+
+private const val LOG_DIR = "logs"
+private const val CURRENT_LOG = "app.log"
+private const val PREVIOUS_LOG = "app.log.1"
+private const val MAX_BYTES = 256L * 1024L
+private const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS"
+
+// Timber tree that appends log lines to an app-private rotating file. All I/O
+// runs on a single background thread so callers never block; rotation swaps
+// [CURRENT_LOG] → [PREVIOUS_LOG] when the active file exceeds [MAX_BYTES],
+// bounding on-disk footprint at ~512 KiB regardless of runtime volume.
+class FileLoggingTree(
+    filesDir: File,
+) : Timber.Tree() {
+    private val logDir = File(filesDir, LOG_DIR).apply { mkdirs() }
+    private val currentFile = File(logDir, CURRENT_LOG)
+    private val previousFile = File(logDir, PREVIOUS_LOG)
+    private val executor =
+        Executors.newSingleThreadExecutor { r ->
+            Thread(r, "file-log").apply { isDaemon = true }
+        }
+    private val timestampFormat = SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US)
+
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
+        val line = formatLine(priority, tag, message, t)
+        executor.execute {
+            runCatching {
+                rotateIfNeeded()
+                currentFile.appendText(line)
+            }
+        }
+    }
+
+    private fun formatLine(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ): String {
+        val builder =
+            StringBuilder()
+                .append(timestampFormat.format(Date()))
+                .append(' ')
+                .append(priorityLabel(priority))
+                .append('/')
+                .append(tag ?: "-")
+                .append(": ")
+                .append(message)
+                .append('\n')
+        if (t != null) {
+            builder.append(stackTraceOf(t))
+        }
+        return builder.toString()
+    }
+
+    private fun stackTraceOf(t: Throwable): String {
+        val writer = java.io.StringWriter()
+        PrintWriter(writer).use { t.printStackTrace(it) }
+        return writer.toString()
+    }
+
+    private fun rotateIfNeeded() {
+        if (currentFile.length() < MAX_BYTES) return
+        if (previousFile.exists()) previousFile.delete()
+        currentFile.renameTo(previousFile)
+    }
+
+    private fun priorityLabel(priority: Int): String =
+        when (priority) {
+            Log.VERBOSE -> "V"
+            Log.DEBUG -> "D"
+            Log.INFO -> "I"
+            Log.WARN -> "W"
+            Log.ERROR -> "E"
+            Log.ASSERT -> "A"
+            else -> "?"
+        }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/util/HttpClientProvider.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/HttpClientProvider.kt
@@ -1,0 +1,45 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import timber.log.Timber
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+private const val CACHE_DIR = "http-cache"
+private const val CACHE_SIZE_BYTES = 5L * 1024L * 1024L
+private const val CONNECT_TIMEOUT_SECONDS = 15L
+private const val READ_TIMEOUT_SECONDS = 15L
+
+// Shared OkHttp client with an on-disk response cache and Timber-bridged
+// wire logging. Rate providers still call Fuel today; the cache warms up
+// only if the provider's response carries Cache-Control headers or is
+// wrapped by a forthcoming Retrofit-based service that sets its own policy.
+object HttpClientProvider {
+    @Volatile
+    private var instance: OkHttpClient? = null
+
+    fun client(context: Context): OkHttpClient =
+        instance ?: synchronized(this) {
+            instance ?: build(context).also { instance = it }
+        }
+
+    private fun build(context: Context): OkHttpClient {
+        val cacheDir = File(context.cacheDir, CACHE_DIR).apply { mkdirs() }
+        val loggingInterceptor =
+            HttpLoggingInterceptor { line ->
+                Timber.tag("HTTP").d(line)
+            }.apply {
+                level = HttpLoggingInterceptor.Level.BASIC
+            }
+        return OkHttpClient
+            .Builder()
+            .cache(Cache(cacheDir, CACHE_SIZE_BYTES))
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/util/NetworkStatusLiveData.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/util/NetworkStatusLiveData.kt
@@ -1,0 +1,53 @@
+package de.salomax.currencies.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.lifecycle.LiveData
+
+// Emits true when the device has a validated internet connection, false when
+// it does not. Uses [ConnectivityManager.registerNetworkCallback] so
+// transitions surface promptly (screen on, wifi flap, plane-mode toggle)
+// without polling. Initial value is derived from the currently-active network
+// so observers get a value on the first frame.
+class NetworkStatusLiveData(
+    context: Context,
+) : LiveData<Boolean>() {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val request =
+        NetworkRequest
+            .Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            .build()
+
+    private val callback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) = postValue(true)
+
+            override fun onLost(network: Network) = postValue(currentlyOnline())
+
+            override fun onUnavailable() = postValue(false)
+        }
+
+    private fun currentlyOnline(): Boolean {
+        val active = connectivityManager.activeNetwork ?: return false
+        val caps = connectivityManager.getNetworkCapabilities(active) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    override fun onActive() {
+        super.onActive()
+        postValue(currentlyOnline())
+        connectivityManager.registerNetworkCallback(request, callback)
+    }
+
+    override fun onInactive() {
+        connectivityManager.unregisterNetworkCallback(callback)
+        super.onInactive()
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
@@ -22,6 +22,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -45,6 +47,7 @@ import de.salomax.currencies.util.toCsv
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.util.toPdfBytes
 import de.salomax.currencies.view.BaseActivity
+import de.salomax.currencies.view.cart.compose.CartEmptyHint
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
 import de.salomax.currencies.view.preference.PreferenceActivity
 import de.salomax.currencies.viewmodel.cart.CartSnapshot
@@ -95,7 +98,7 @@ class CartActivity : BaseActivity() {
     private lateinit var spinnerTo: SearchableSpinner
     private lateinit var swapButton: ImageButton
     private lateinit var feeSideButton: AppCompatImageButton
-    private lateinit var emptyHint: TextView
+    private lateinit var emptyHint: ComposeView
     private lateinit var addButton: MaterialButton
 
     private lateinit var adapter: CartItemAdapter
@@ -145,7 +148,11 @@ class CartActivity : BaseActivity() {
         this.spinnerTo = findViewById(R.id.cart_spinner_to)
         this.swapButton = findViewById(R.id.cart_swap)
         this.feeSideButton = findViewById(R.id.cart_btn_fee_side)
-        this.emptyHint = findViewById(R.id.cart_empty_hint)
+        this.emptyHint =
+            findViewById<ComposeView>(R.id.cart_empty_hint).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent { CartEmptyHint() }
+            }
         this.addButton = findViewById(R.id.cart_add_item)
         this.keypadContainer = findViewById(R.id.cart_keypad_container)
         this.keypadRegular = findViewById(R.id.cart_keypad_regular)

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
@@ -34,12 +34,14 @@ import de.salomax.currencies.model.SavedCart
 import de.salomax.currencies.repository.CartExporter
 import de.salomax.currencies.repository.CartFileResult
 import de.salomax.currencies.util.OPERATOR_REGEX
+import de.salomax.currencies.util.buildCartShareChooser
 import de.salomax.currencies.util.choiceExplainerRow
 import de.salomax.currencies.util.feePercentDelta
 import de.salomax.currencies.util.hapticTap
 import de.salomax.currencies.util.isNeutralFeeStack
 import de.salomax.currencies.util.paddedDialogContainer
 import de.salomax.currencies.util.rateSpinnerListener
+import de.salomax.currencies.util.toCsv
 import de.salomax.currencies.util.toHumanReadableNumber
 import de.salomax.currencies.view.BaseActivity
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
@@ -62,6 +64,12 @@ private const val CART_DISPLAY_SCALE = 2
 private const val EXPORT_FILE_MIME = "application/json"
 private const val EXPORT_FILE_EXT = ".json"
 private const val EXPORT_FILE_DATE_FORMAT = "yyyyMMdd-HHmmss"
+
+// Shared filename base + format for the CSV / PDF share flows.
+private const val SHARE_FILE_DATE_FORMAT = EXPORT_FILE_DATE_FORMAT
+private const val CSV_MIME = "text/csv"
+private const val CSV_EXT = ".csv"
+private const val SHARE_FILE_PREFIX = "cart-"
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
 private const val KEYPAD_ANIM_MS = 180L
@@ -210,6 +218,10 @@ class CartActivity : BaseActivity() {
             }
             R.id.cart_share -> {
                 shareCart()
+                true
+            }
+            R.id.cart_share_csv -> {
+                shareCartCsv()
                 true
             }
             R.id.cart_save -> {
@@ -664,6 +676,27 @@ class CartActivity : BaseActivity() {
                 putExtra(Intent.EXTRA_TEXT, text)
             }
         startActivity(Intent.createChooser(intent, null))
+    }
+
+    private fun shareCartCsv() {
+        val snapshot = viewModel.snapshotForShare()
+        if (snapshot == null) {
+            showSnackbar(getString(R.string.cart_share_empty))
+            return
+        }
+        val chooser =
+            buildCartShareChooser(
+                context = this,
+                filename = shareFilename(CSV_EXT),
+                mimeType = CSV_MIME,
+                bytes = snapshot.toCsv().toByteArray(Charsets.UTF_8),
+            )
+        startActivity(chooser)
+    }
+
+    private fun shareFilename(extension: String): String {
+        val timestamp = SimpleDateFormat(SHARE_FILE_DATE_FORMAT, Locale.US).format(Date())
+        return SHARE_FILE_PREFIX + timestamp + extension
     }
 
     private fun buildShareText(snapshot: CartSnapshot): String =

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/CartActivity.kt
@@ -43,6 +43,7 @@ import de.salomax.currencies.util.paddedDialogContainer
 import de.salomax.currencies.util.rateSpinnerListener
 import de.salomax.currencies.util.toCsv
 import de.salomax.currencies.util.toHumanReadableNumber
+import de.salomax.currencies.util.toPdfBytes
 import de.salomax.currencies.view.BaseActivity
 import de.salomax.currencies.view.main.spinner.SearchableSpinner
 import de.salomax.currencies.view.preference.PreferenceActivity
@@ -69,6 +70,8 @@ private const val EXPORT_FILE_DATE_FORMAT = "yyyyMMdd-HHmmss"
 private const val SHARE_FILE_DATE_FORMAT = EXPORT_FILE_DATE_FORMAT
 private const val CSV_MIME = "text/csv"
 private const val CSV_EXT = ".csv"
+private const val PDF_MIME = "application/pdf"
+private const val PDF_EXT = ".pdf"
 private const val SHARE_FILE_PREFIX = "cart-"
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
@@ -222,6 +225,10 @@ class CartActivity : BaseActivity() {
             }
             R.id.cart_share_csv -> {
                 shareCartCsv()
+                true
+            }
+            R.id.cart_share_pdf -> {
+                shareCartPdf()
                 true
             }
             R.id.cart_save -> {
@@ -690,6 +697,23 @@ class CartActivity : BaseActivity() {
                 filename = shareFilename(CSV_EXT),
                 mimeType = CSV_MIME,
                 bytes = snapshot.toCsv().toByteArray(Charsets.UTF_8),
+            )
+        startActivity(chooser)
+    }
+
+    private fun shareCartPdf() {
+        val snapshot = viewModel.snapshotForShare()
+        if (snapshot == null) {
+            showSnackbar(getString(R.string.cart_share_empty))
+            return
+        }
+        val title = snapshot.cart.name.ifBlank { getString(R.string.cart_share_default_title) }
+        val chooser =
+            buildCartShareChooser(
+                context = this,
+                filename = shareFilename(PDF_EXT),
+                mimeType = PDF_MIME,
+                bytes = snapshot.toPdfBytes(title),
             )
         startActivity(chooser)
     }

--- a/app/src/main/kotlin/de/salomax/currencies/view/cart/compose/CartEmptyHint.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/cart/compose/CartEmptyHint.kt
@@ -1,0 +1,45 @@
+package de.salomax.currencies.view.cart.compose
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import de.salomax.currencies.R
+
+// First Compose surface migrated off XML. Rendered inside a ComposeView that
+// replaces the old TextView with id `cart_empty_hint`. Kept intentionally
+// small — the goal of the pilot is to prove the wiring (dependency, theme,
+// live recomposition on visibility toggle) works end-to-end so the larger
+// totals / row list can migrate in follow-up phases.
+//
+// MaterialTheme is wired here (rather than at the activity level) because
+// this is currently the only Compose surface in CartActivity; once more
+// composables move over, hoist the theme wrapper up to a single call site.
+@Composable
+fun CartEmptyHint() {
+    val colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+    MaterialTheme(colorScheme = colorScheme) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(id = R.dimen.margin3x)),
+        ) {
+            Text(
+                text = stringResource(id = R.string.cart_empty_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.core.text.HtmlCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.window.layout.FoldingFeature
+import com.google.android.material.card.MaterialCardView
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.Snackbar
@@ -34,6 +35,7 @@ import de.salomax.currencies.model.ExchangeRates
 import de.salomax.currencies.model.FeeSide
 import de.salomax.currencies.model.Rate
 import de.salomax.currencies.repository.Database
+import de.salomax.currencies.util.NetworkStatusLiveData
 import de.salomax.currencies.util.feePercentDelta
 import de.salomax.currencies.util.getDecimalSeparator
 import de.salomax.currencies.util.hapticTap
@@ -86,6 +88,12 @@ class MainActivity : BaseActivity() {
     private lateinit var swipeRefresh: SwipeRefreshLayout
     private var menuItemRefresh: MenuItem? = null
 
+    private lateinit var offlineBanner: MaterialCardView
+    private lateinit var offlineBannerText: TextView
+    private var isOnline: Boolean = true
+    private var latestRatesDate: LocalDate? = null
+    private var latestRatesTime: LocalTime? = null
+
     private lateinit var tvCalculations: TextView
     private lateinit var tvFrom: TextView
     private lateinit var tvTo: TextView
@@ -123,6 +131,8 @@ class MainActivity : BaseActivity() {
         this.tvOriginalValue = findViewById(R.id.textOriginalValue)
         this.tvFeeBadge = findViewById(R.id.textFeeBadge)
         this.btnFeeSide = findViewById(R.id.btn_fee_side)
+        this.offlineBanner = findViewById(R.id.offlineBanner)
+        this.offlineBannerText = findViewById(R.id.offlineBannerText)
 
         // swipe-to-refresh: color scheme (not accessible in xml)
         swipeRefresh.setColorSchemeColors(MaterialColors.getColor(this, R.attr.colorOnPrimary, null))
@@ -412,6 +422,25 @@ class MainActivity : BaseActivity() {
         viewModel.getTrueCost().observe(this) { observeTrueCost(it) }
         viewModel.getOriginalValue().observe(this) { observeOriginalValue(it) }
         viewModel.getTotalStack().observe(this) { observeTotalStack(it) }
+        NetworkStatusLiveData(this).observe(this) { online ->
+            isOnline = online
+            renderOfflineBanner()
+        }
+    }
+
+    private fun renderOfflineBanner() {
+        if (isOnline) {
+            offlineBanner.visibility = View.GONE
+            return
+        }
+        val date = latestRatesDate
+        offlineBannerText.text =
+            if (date != null) {
+                getString(R.string.offline_banner_with_date, formatRatesTimestamp(date, latestRatesTime).orEmpty())
+            } else {
+                getString(R.string.offline_banner_no_data)
+            }
+        offlineBanner.visibility = View.VISIBLE
     }
 
     private fun observeFeeSide(side: FeeSide?) {
@@ -467,6 +496,9 @@ class MainActivity : BaseActivity() {
     }
 
     private fun observeExchangeRates(rates: ExchangeRates?) {
+        latestRatesDate = rates?.date
+        latestRatesTime = rates?.time
+        renderOfflineBanner()
         rates?.let {
             val date = it.date
             val dateString = formatRatesTimestamp(date, it.time)

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.core.app.TaskStackBuilder
 import androidx.fragment.app.Fragment
@@ -26,9 +25,8 @@ import de.salomax.currencies.util.DECIMAL_PLACES_MIN
 import de.salomax.currencies.view.main.MainActivity
 import de.salomax.currencies.viewmodel.preference.PreferenceViewModel
 import de.salomax.currencies.widget.LongSummaryPreference
+import timber.log.Timber
 import java.util.Calendar
-
-private const val TAG = "PreferenceFragment"
 
 // Sentinel returned by ApiProvider.fromId when the stored value is unknown /
 // unset; the pref layer treats this as "use the default provider".
@@ -212,7 +210,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
                 try {
                     startActivity(createIntent(URL_PLAY_MARKET))
                 } catch (e: ActivityNotFoundException) {
-                    Log.d(TAG, "Play Store not available, opening browser", e)
+                    Timber.tag("PreferenceFragment").d(e, "Play Store not available, opening browser")
                     startActivity(createIntent(URL_PLAY_WEB))
                 }
                 true

--- a/app/src/main/kotlin/de/salomax/currencies/view/widget/CurrencyWidget.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/widget/CurrencyWidget.kt
@@ -1,0 +1,132 @@
+package de.salomax.currencies.view.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import de.salomax.currencies.R
+import de.salomax.currencies.model.Currency
+import de.salomax.currencies.util.KEY_RATES_BASE
+import de.salomax.currencies.util.KEY_RATES_DATE
+import de.salomax.currencies.view.main.MainActivity
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+private const val RATES_PREFS = "rates"
+private const val LAST_STATE_PREFS = "last_state"
+private const val KEY_LAST_FROM = "_last_from"
+private const val KEY_LAST_TO = "_last_to"
+private const val DEFAULT_FROM = "USD"
+private const val DEFAULT_TO = "EUR"
+private const val WIDGET_DISPLAY_SCALE = 4
+
+// Home-screen widget rendering the last-used base → destination pair and the
+// cached conversion rate. Backed by the same SharedPreferences the app writes
+// to (rates + last_state), so there's no separate widget data source. Refresh
+// happens on the AppWidget update tick (see currency_widget_info.xml) and via
+// [refreshWidgets], called after every successful rate insert.
+class CurrencyWidget : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        appWidgetIds.forEach { id ->
+            appWidgetManager.updateAppWidget(id, buildRemoteViews(context))
+        }
+    }
+
+    companion object {
+        // Called from the repository after new rates land, so an open widget
+        // reflects the fresh values without waiting for the next system tick.
+        fun refreshWidgets(context: Context) {
+            val manager = AppWidgetManager.getInstance(context) ?: return
+            val ids = manager.getAppWidgetIds(ComponentName(context, CurrencyWidget::class.java))
+            if (ids.isEmpty()) return
+            val views = buildRemoteViews(context)
+            ids.forEach { manager.updateAppWidget(it, views) }
+        }
+
+        private fun buildRemoteViews(context: Context): RemoteViews {
+            val views = RemoteViews(context.packageName, R.layout.widget_currency)
+            val snapshot = readSnapshot(context)
+            views.setTextViewText(R.id.widget_rate_line, snapshot.rateLine(context))
+            views.setTextViewText(R.id.widget_footer, snapshot.footerLine(context))
+            views.setOnClickPendingIntent(R.id.widget_root, launchAppIntent(context))
+            return views
+        }
+
+        private fun launchAppIntent(context: Context): PendingIntent {
+            val intent =
+                Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+
+        private fun readSnapshot(context: Context): WidgetSnapshot {
+            val ratesPrefs = context.getSharedPreferences(RATES_PREFS, Context.MODE_PRIVATE)
+            val lastState = context.getSharedPreferences(LAST_STATE_PREFS, Context.MODE_PRIVATE)
+            val fromCode = lastState.getString(KEY_LAST_FROM, DEFAULT_FROM) ?: DEFAULT_FROM
+            val toCode = lastState.getString(KEY_LAST_TO, DEFAULT_TO) ?: DEFAULT_TO
+            val from = Currency.fromString(fromCode)
+            val to = Currency.fromString(toCode)
+            val date = ratesPrefs.getString(KEY_RATES_DATE, null)
+            val baseCode = ratesPrefs.getString(KEY_RATES_BASE, null)
+            val fromRate = fromCode.let { ratesPrefs.getString(it, null)?.toBigDecimalOrNull() }
+            val toRate = toCode.let { ratesPrefs.getString(it, null)?.toBigDecimalOrNull() }
+            val converted =
+                if (fromRate != null && toRate != null && fromRate.signum() != 0) {
+                    BigDecimal.ONE
+                        .divide(fromRate, MathContext.DECIMAL64)
+                        .multiply(toRate)
+                        .setScale(WIDGET_DISPLAY_SCALE, RoundingMode.HALF_EVEN)
+                } else {
+                    null
+                }
+            return WidgetSnapshot(
+                fromCode = from?.iso4217Alpha() ?: fromCode,
+                toCode = to?.iso4217Alpha() ?: toCode,
+                converted = converted,
+                date = date,
+                hasAnyCachedRate = baseCode != null,
+            )
+        }
+    }
+}
+
+private data class WidgetSnapshot(
+    val fromCode: String,
+    val toCode: String,
+    val converted: BigDecimal?,
+    val date: String?,
+    val hasAnyCachedRate: Boolean,
+) {
+    fun rateLine(context: Context): String =
+        if (converted != null) {
+            context.getString(
+                R.string.widget_rate_line,
+                fromCode,
+                converted.toPlainString(),
+                toCode,
+            )
+        } else {
+            context.getString(R.string.widget_no_rate)
+        }
+
+    fun footerLine(context: Context): String =
+        when {
+            date != null -> context.getString(R.string.widget_footer_date, date)
+            hasAnyCachedRate -> context.getString(R.string.widget_no_rate)
+            else -> context.getString(R.string.widget_footer_empty)
+        }
+}

--- a/app/src/main/res/drawable/ic_cloud_off.xml
+++ b/app/src/main/res/drawable/ic_cloud_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4c-1.48,0 -2.85,0.43 -4.01,1.17l1.46,1.46C10.21,6.23 11.08,6 12,6c3.04,0 5.5,2.46 5.5,5.5v0.5H19c1.66,0 3,1.34 3,3 0,1.13 -0.64,2.11 -1.56,2.62l1.45,1.45C23.16,18.16 24,16.68 24,15c0,-2.64 -2.05,-4.78 -4.65,-4.96zM3,5.27l2.75,2.74C2.56,8.15 0,10.77 0,14c0,3.31 2.69,6 6,6h11.73l2,2L21,20.73 4.27,4 3,5.27zM7.73,10l8,8H6c-2.21,0 -4,-1.79 -4,-4s1.79,-4 4,-4h1.73z" />
+</vector>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="?android:attr/colorBackground" />
+</shape>

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -28,14 +28,10 @@
             android:paddingHorizontal="@dimen/margin1x"
             android:paddingVertical="@dimen/margin1x" />
 
-        <TextView
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/cart_empty_hint"
-            style="@style/TextAppearance.Material3.BodyMedium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/margin3x"
-            android:gravity="center"
-            android:text="@string/cart_empty_hint"
             android:visibility="gone" />
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_root"
     android:layout_width="match_parent"
@@ -7,6 +8,32 @@
     android:baselineAligned="false"
     android:fitsSystemWindows="true"
     android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/offlineBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="?attr/colorErrorContainer"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="0dp"
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/offlineBannerText"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="12dp"
+            android:gravity="center_vertical"
+            android:padding="12dp"
+            android:textColor="?attr/colorOnErrorContainer"
+            app:drawableStartCompat="@drawable/ic_cloud_off"
+            app:drawableTint="?attr/colorOnErrorContainer"
+            tools:text="Offline • Rates from 2 hours ago" />
+
+    </com.google.android.material.card.MaterialCardView>
 
     <include
         layout="@layout/main_display"

--- a/app/src/main/res/layout/widget_currency.xml
+++ b/app/src/main/res/layout/widget_currency.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/widget_rate_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        tools:ignore="UnusedAttribute" />
+
+    <TextView
+        android:id="@+id/widget_footer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="11sp"
+        tools:ignore="UnusedAttribute" />
+</LinearLayout>

--- a/app/src/main/res/menu/cart.xml
+++ b/app/src/main/res/menu/cart.xml
@@ -9,6 +9,12 @@
         app:showAsAction="never" />
 
     <item
+        android:orderInCategory="1"
+        android:id="@+id/cart_share_csv"
+        android:title="@string/cart_menu_share_csv"
+        app:showAsAction="never" />
+
+    <item
         android:orderInCategory="9"
         android:id="@+id/cart_save"
         android:title="@string/cart_menu_save"

--- a/app/src/main/res/menu/cart.xml
+++ b/app/src/main/res/menu/cart.xml
@@ -15,6 +15,12 @@
         app:showAsAction="never" />
 
     <item
+        android:orderInCategory="2"
+        android:id="@+id/cart_share_pdf"
+        android:title="@string/cart_menu_share_pdf"
+        app:showAsAction="never" />
+
+    <item
         android:orderInCategory="9"
         android:id="@+id/cart_save"
         android:title="@string/cart_menu_save"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="cart_menu_import">Import from file</string>
     <string name="cart_menu_clear">Clear</string>
     <string name="cart_menu_share_csv">Share as CSV</string>
+    <string name="cart_menu_share_pdf">Share as PDF</string>
     <string name="cart_save_name_hint">Cart name</string>
     <string name="cart_default_saved_name">My cart</string>
     <string name="cart_saved_toast">Saved as “%s”</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="info_conversion">%1$s %2$s ≈ %3$s %4$s</string>
     <string name="info_date_latest">Rates as of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
     <string name="info_date_historical">Historical rates of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
+    <string name="offline_banner_with_date">Offline • Rates from %1$s</string>
+    <string name="offline_banner_no_data">Offline • No cached rates yet</string>
     <string name="copied_to_clipboard">Copied &lt;b>%s&lt;/b> to clipboard</string>
 
     <string name="historical_rates_dialog_title">Historical rates</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,13 @@
     <string name="tooltip_filter_starred">Show only starred currencies.</string>
     <string name="currency_dropdown_api_hint">Something missing? Different data providers offer different currencies. Go to the settings to try another one!\u00A0\uD83E\uDD17</string>
 
+    <!-- Home-screen widget -->
+    <string name="widget_description">Latest conversion rate for your last-used currency pair.</string>
+    <string name="widget_rate_line">1 %1$s = %2$s %3$s</string>
+    <string name="widget_footer_date">As of %s</string>
+    <string name="widget_footer_empty">Open the app to load rates.</string>
+    <string name="widget_no_rate">Rate unavailable</string>
+
     <!-- Shopping cart -->
     <string name="cart_title">Shopping cart</string>
     <string name="cart_empty_hint">Your cart is empty. Tap “Add item” to start.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="cart_menu_export">Export to file</string>
     <string name="cart_menu_import">Import from file</string>
     <string name="cart_menu_clear">Clear</string>
+    <string name="cart_menu_share_csv">Share as CSV</string>
     <string name="cart_save_name_hint">Cart name</string>
     <string name="cart_default_saved_name">My cart</string>
     <string name="cart_saved_toast">Saved as “%s”</string>

--- a/app/src/main/res/xml/currency_widget_info.xml
+++ b/app/src/main/res/xml/currency_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/widget_currency"
+    android:minWidth="180dp"
+    android:minHeight="60dp"
+    android:previewLayout="@layout/widget_currency"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="1"
+    android:targetCellWidth="2"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Named subpath under cacheDir where transient share artifacts (CSV, PDF) live.
+         The exported name in the FileProvider URI stays stable across app updates
+         even if the on-disk directory layout changes. -->
+    <cache-path
+        name="cart-exports"
+        path="cart-exports/" />
+</paths>

--- a/app/src/test/kotlin/de/salomax/currencies/util/MathUtilsTest.kt
+++ b/app/src/test/kotlin/de/salomax/currencies/util/MathUtilsTest.kt
@@ -1,11 +1,14 @@
 package de.salomax.currencies.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 @RunWith(MockitoJUnitRunner::class)
 class MathUtilsTest {
@@ -30,6 +33,61 @@ class MathUtilsTest {
         assertEquals(2, bd("0.99991").getSignificantDecimalPlaces(2))
         assertEquals(2, bd("0.999991").getSignificantDecimalPlaces(2))
         assertEquals(5, bd("0.9999991").getSignificantDecimalPlaces(5))
+    }
+
+    @Test
+    fun `isNeutralFeeStack is true only for exactly one`() {
+        assertTrue(bd("1").isNeutralFeeStack())
+        assertTrue(bd("1.0").isNeutralFeeStack())
+        assertTrue(bd("1.000000").isNeutralFeeStack())
+        assertTrue(BigDecimal.ONE.isNeutralFeeStack())
+    }
+
+    @Test
+    fun `isNeutralFeeStack is false for any non-unit stack`() {
+        assertFalse(bd("1.0001").isNeutralFeeStack())
+        assertFalse(bd("0.9999").isNeutralFeeStack())
+        assertFalse(bd("1.025").isNeutralFeeStack())
+        assertFalse(bd("0.975").isNeutralFeeStack())
+        assertFalse(BigDecimal.ZERO.isNeutralFeeStack())
+    }
+
+    @Test
+    fun `feePercentDelta converts multiplicative stack to signed percent`() {
+        assertEquals(bd("2.50"), bd("1.025").feePercentDelta())
+        assertEquals(bd("-2.50"), bd("0.975").feePercentDelta())
+        assertEquals(bd("0.00"), bd("1").feePercentDelta())
+        assertEquals(bd("100.00"), bd("2").feePercentDelta())
+        assertEquals(bd("-100.00"), bd("0").feePercentDelta())
+    }
+
+    @Test
+    fun `feePercentDelta composes stacked multiplicative fees`() {
+        // 2.5% payment + 1% conversion applied multiplicatively → 1.03525
+        val stack = bd("1.025").multiply(bd("1.01"))
+        // HALF_EVEN rounds the trailing 5 down because the last kept digit (2) is even
+        assertEquals(bd("3.52"), stack.feePercentDelta())
+        assertEquals(bd("3.53"), stack.feePercentDelta(roundingMode = RoundingMode.HALF_UP))
+    }
+
+    @Test
+    fun `feePercentDelta honours custom scale`() {
+        assertEquals(bd("2.5"), bd("1.025").feePercentDelta(scale = 1))
+        assertEquals(bd("2.5000"), bd("1.025").feePercentDelta(scale = 4))
+    }
+
+    @Test
+    fun `feePercentDelta HALF_EVEN vs HALF_UP diverge on ties`() {
+        // 1.00005 -> 0.005% exactly at the scale-2 boundary; last kept digit is 0 (even)
+        assertEquals(bd("0.00"), bd("1.00005").feePercentDelta(roundingMode = RoundingMode.HALF_EVEN))
+        assertEquals(bd("0.01"), bd("1.00005").feePercentDelta(roundingMode = RoundingMode.HALF_UP))
+    }
+
+    @Test
+    fun `feePercentDelta preserves sub-cent precision for tiny stacks`() {
+        assertEquals(bd("0.01"), bd("1.0001").feePercentDelta())
+        assertEquals(bd("0.00"), bd("1.00001").feePercentDelta())
+        assertEquals(bd("0.0001"), bd("1.000001").feePercentDelta(scale = 4))
     }
 
     private fun bd(value: String) = BigDecimal(value)


### PR DESCRIPTION
## Summary

Recovery PR consolidating the 8 downstream commits of the improvements-roadmap stack (#66–#73). PR #65 landed on the umbrella; the rest were auto-closed when their upstream base branches were deleted post-merge. This PR contains the identical rebased content of the closed PRs, targeting the umbrella directly.

Closes: #66 #67 #68 #69 #70 #71 #72 #73 (superseded by this recovery PR)

## Commits

- test(math-utils): fee-stack unit tests
- feat(logging): Timber with rotating local file tree
- feat(net): shared OkHttp client with cache + Timber-bridged logging
- feat(ux): offline banner with last-updated timestamp
- feat(cart): CSV share via FileProvider
- feat(cart): PDF share via built-in PdfDocument
- feat(widget): home-screen widget with last-used pair rate
- feat(cart): Compose pilot — migrate empty-state hint

## Test plan
- [x] Full CI matrix (Fdroid + Play) on the same content passed at each intermediate PR
- [ ] Re-run CI on the rebased tip