### PR TITLE
feat(fees): named exchanges/banks, inactive toggle, and single-select picker

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/Fee.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/Fee.kt
@@ -6,18 +6,26 @@ import java.math.BigDecimal
  * A single fee entry that can be stacked with others when converting
  * currencies. All entries store the [percent] as a positive number;
  * whether the fee is added or subtracted is controlled by [isMarkup].
+ *
+ * Every fee carries a user-facing [name] (may be empty for legacy entries)
+ * and an [isActive] flag that lets the user temporarily skip it without
+ * deleting the entry.
  */
 sealed class Fee {
     abstract val id: String
+    abstract val name: String
     abstract val percent: BigDecimal
     abstract val isMarkup: Boolean
+    abstract val isActive: Boolean
     abstract val type: FeeType
 
     /** Applies to every conversion, no matter which currencies are involved. */
     data class GlobalExchange(
         override val id: String,
+        override val name: String,
         override val percent: BigDecimal,
         override val isMarkup: Boolean,
+        override val isActive: Boolean = true,
     ) : Fee() {
         override val type: FeeType get() = FeeType.GLOBAL_EXCHANGE
     }
@@ -25,8 +33,10 @@ sealed class Fee {
     /** Bank / card fee that also applies to every conversion. */
     data class GlobalBank(
         override val id: String,
+        override val name: String,
         override val percent: BigDecimal,
         override val isMarkup: Boolean,
+        override val isActive: Boolean = true,
     ) : Fee() {
         override val type: FeeType get() = FeeType.GLOBAL_BANK
     }
@@ -37,11 +47,13 @@ sealed class Fee {
      */
     data class SpecificPair(
         override val id: String,
+        override val name: String,
         override val percent: BigDecimal,
         override val isMarkup: Boolean,
         val from: String,
         val to: String,
         val bothWays: Boolean,
+        override val isActive: Boolean = true,
     ) : Fee() {
         override val type: FeeType get() = FeeType.SPECIFIC_PAIR
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/FeeCalculator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/FeeCalculator.kt
@@ -100,8 +100,9 @@ object FeeCalculator {
         activeId: String?,
     ): List<T> {
         if (candidates.isEmpty()) return emptyList()
-        val chosen = activeId?.let { id -> candidates.firstOrNull { it.id == id } }
-            ?: candidates.first()
+        val chosen =
+            activeId?.let { id -> candidates.firstOrNull { it.id == id } }
+                ?: candidates.first()
         return listOf(chosen)
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/FeeCalculator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/FeeCalculator.kt
@@ -8,12 +8,20 @@ private val PERCENTAGE_DIVISOR = BigDecimal("100")
 /**
  * Pure fee-stacking math. Extracted from MainViewModel so it can be exercised
  * without an Android [android.app.Application] context.
+ *
+ * Inactive fees ([Fee.isActive] == false) are always skipped — the flag lets
+ * the user temporarily silence an entry without deleting it.
+ *
+ * Global exchange and global bank/card fees are **single-select**: at most one
+ * of each participates in the stack, chosen by the picker IDs (falling back to
+ * the first active entry of that category when the pick is unset or stale).
+ * Specific-pair fees still stack together across every active match.
  */
 object FeeCalculator {
     /**
      * Return only those fees that apply for the given base/destination pair.
      * Global fees always apply; pair-specific fees match by ISO code, optionally
-     * in both directions.
+     * in both directions. Inactive entries are filtered out.
      */
     fun applicableFees(
         all: List<Fee>,
@@ -22,21 +30,26 @@ object FeeCalculator {
     ): List<Fee> {
         val baseCode = base?.iso4217Alpha()
         val destCode = dest?.iso4217Alpha()
-        return all.filter { fee ->
-            when (fee) {
-                is Fee.GlobalExchange, is Fee.GlobalBank -> true
-                is Fee.SpecificPair -> {
-                    if (baseCode == null || destCode == null) {
-                        false
-                    } else if (fee.from == baseCode && fee.to == destCode) {
-                        true
-                    } else {
-                        fee.bothWays && fee.from == destCode && fee.to == baseCode
-                    }
+        return all.filter { fee -> fee.isActive && matchesPair(fee, baseCode, destCode) }
+    }
+
+    private fun matchesPair(
+        fee: Fee,
+        baseCode: String?,
+        destCode: String?,
+    ): Boolean =
+        when (fee) {
+            is Fee.GlobalExchange, is Fee.GlobalBank -> true
+            is Fee.SpecificPair -> {
+                if (baseCode == null || destCode == null) {
+                    false
+                } else if (fee.from == baseCode && fee.to == destCode) {
+                    true
+                } else {
+                    fee.bothWays && fee.from == destCode && fee.to == baseCode
                 }
             }
         }
-    }
 
     /**
      * Multiplicative stack factor for a subset of fees:
@@ -54,19 +67,41 @@ object FeeCalculator {
 
     /**
      * Combined multiplicative fee factor for the given base/destination pair,
-     * computed as `specific * globalExchange * globalBank`.
+     * computed as `specific * globalExchange * globalBank`. Global exchange
+     * and bank contributions are single-select via [activeExchangeId] /
+     * [activeBankId]; when a pick is null or no longer present, falls back to
+     * the first active entry of that category.
      */
     fun totalStack(
         all: List<Fee>,
         base: Currency?,
         dest: Currency?,
+        activeExchangeId: String? = null,
+        activeBankId: String? = null,
     ): BigDecimal {
         val applicable = applicableFees(all, base, dest)
         val specific = stackFactor(applicable.filterIsInstance<Fee.SpecificPair>())
-        val exchange = stackFactor(applicable.filterIsInstance<Fee.GlobalExchange>())
-        val bank = stackFactor(applicable.filterIsInstance<Fee.GlobalBank>())
+        val exchange = stackFactor(pickActive(applicable.filterIsInstance<Fee.GlobalExchange>(), activeExchangeId))
+        val bank = stackFactor(pickActive(applicable.filterIsInstance<Fee.GlobalBank>(), activeBankId))
         return specific
             .multiply(exchange, MathContext.DECIMAL128)
             .multiply(bank, MathContext.DECIMAL128)
+    }
+
+    /**
+     * Resolve the single-select choice: prefer the entry whose id matches
+     * [activeId]; otherwise fall back to the first entry (preserving legacy
+     * "one-and-only fee" behavior for users who haven't picked yet).
+     * Returns a 0-or-1 element list so it can be passed straight to
+     * [stackFactor].
+     */
+    private fun <T : Fee> pickActive(
+        candidates: List<T>,
+        activeId: String?,
+    ): List<T> {
+        if (candidates.isEmpty()) return emptyList()
+        val chosen = activeId?.let { id -> candidates.firstOrNull { it.id == id } }
+            ?: candidates.first()
+        return listOf(chosen)
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
@@ -283,6 +283,8 @@ class Database(
     private val keyPureBlackEnabled = "_pureBlackEnabled"
     private val keyFeesJson = "_fees_json"
     private val keyFeeSide = "_fee_side"
+    private val keyActiveExchangeId = "_active_exchange_id"
+    private val keyActiveBankId = "_active_bank_id"
     private val keyPreviewConversionEnabled = "_previewConversionEnabled"
     private val keyKeyboardType = "_keyboardType"
     private val keyHapticFeedback = "_hapticFeedback"
@@ -396,6 +398,30 @@ class Database(
         prefs.edit().putString(keyFeeSide, side.name).apply()
     }
 
+    // Active-picker IDs — which single named exchange / bank-or-card entry
+    // participates in the fee stack. `null` means "no explicit pick"; the
+    // FeeCalculator falls back to the first active entry of that category.
+
+    fun getActiveExchangeId(): LiveData<String?> = SharedPreferenceStringLiveData(prefs, keyActiveExchangeId, null)
+
+    fun getActiveExchangeIdBlocking(): String? = prefs.getString(keyActiveExchangeId, null)
+
+    fun setActiveExchangeId(id: String?) {
+        prefs.edit().apply {
+            if (id == null) remove(keyActiveExchangeId) else putString(keyActiveExchangeId, id)
+        }.apply()
+    }
+
+    fun getActiveBankId(): LiveData<String?> = SharedPreferenceStringLiveData(prefs, keyActiveBankId, null)
+
+    fun getActiveBankIdBlocking(): String? = prefs.getString(keyActiveBankId, null)
+
+    fun setActiveBankId(id: String?) {
+        prefs.edit().apply {
+            if (id == null) remove(keyActiveBankId) else putString(keyActiveBankId, id)
+        }.apply()
+    }
+
     private fun parseFeeSide(raw: String?): FeeSide =
         runCatching { FeeSide.valueOf(raw ?: FeeSide.ORIGINAL.name) }
             .getOrDefault(FeeSide.ORIGINAL)
@@ -436,6 +462,7 @@ class Database(
                     listOf(
                         Fee.GlobalExchange(
                             id = UUID.randomUUID().toString(),
+                            name = "",
                             percent = percent,
                             isMarkup = true,
                         ),
@@ -460,8 +487,10 @@ class Database(
         list.forEach { fee ->
             val obj = JSONObject()
             obj.put("id", fee.id)
+            obj.put("name", fee.name)
             obj.put("percent", fee.percent.toPlainString())
             obj.put("isMarkup", fee.isMarkup)
+            obj.put("isActive", fee.isActive)
             obj.put("type", fee.type.wire)
             if (fee is Fee.SpecificPair) {
                 obj.put("from", fee.from)
@@ -485,19 +514,25 @@ class Database(
     private fun parseFeeEntry(obj: JSONObject?): Fee? {
         obj ?: return null
         val id = obj.optString("id", "").ifEmpty { UUID.randomUUID().toString() }
+        val name = obj.optString("name", "")
         val percent = obj.optString("percent", "0").toBigDecimalOrNull() ?: return null
         val isMarkup = obj.optBoolean("isMarkup", true)
+        // Pre-name/isActive rows default to active so legacy configurations
+        // continue to apply after upgrade.
+        val isActive = obj.optBoolean("isActive", true)
         return when (FeeType.fromWire(obj.optString("type"))) {
-            FeeType.GLOBAL_EXCHANGE -> Fee.GlobalExchange(id, percent, isMarkup)
-            FeeType.GLOBAL_BANK -> Fee.GlobalBank(id, percent, isMarkup)
+            FeeType.GLOBAL_EXCHANGE -> Fee.GlobalExchange(id, name, percent, isMarkup, isActive)
+            FeeType.GLOBAL_BANK -> Fee.GlobalBank(id, name, percent, isMarkup, isActive)
             FeeType.SPECIFIC_PAIR ->
                 Fee.SpecificPair(
                     id = id,
+                    name = name,
                     percent = percent,
                     isMarkup = isMarkup,
                     from = obj.optString("from", ""),
                     to = obj.optString("to", ""),
                     bothWays = obj.optBoolean("bothWays", false),
+                    isActive = isActive,
                 )
             null -> null
         }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
@@ -407,9 +407,11 @@ class Database(
     fun getActiveExchangeIdBlocking(): String? = prefs.getString(keyActiveExchangeId, null)
 
     fun setActiveExchangeId(id: String?) {
-        prefs.edit().apply {
-            if (id == null) remove(keyActiveExchangeId) else putString(keyActiveExchangeId, id)
-        }.apply()
+        prefs
+            .edit()
+            .apply {
+                if (id == null) remove(keyActiveExchangeId) else putString(keyActiveExchangeId, id)
+            }.apply()
     }
 
     fun getActiveBankId(): LiveData<String?> = SharedPreferenceStringLiveData(prefs, keyActiveBankId, null)
@@ -417,9 +419,11 @@ class Database(
     fun getActiveBankIdBlocking(): String? = prefs.getString(keyActiveBankId, null)
 
     fun setActiveBankId(id: String?) {
-        prefs.edit().apply {
-            if (id == null) remove(keyActiveBankId) else putString(keyActiveBankId, id)
-        }.apply()
+        prefs
+            .edit()
+            .apply {
+                if (id == null) remove(keyActiveBankId) else putString(keyActiveBankId, id)
+            }.apply()
     }
 
     private fun parseFeeSide(raw: String?): FeeSide =

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -14,6 +14,17 @@ import com.eliormachlev.currencix.R
 const val CHOICE_DESC_ALPHA = 0.7f
 
 /**
+ * Apply the platform ripple background used by every clickable row inside
+ * our dialog bodies and preference-picker sheets. Extracted so every row —
+ * choice rows, add rows, trailing icon buttons — reads from the same source.
+ */
+fun View.applySelectableRowBackground() {
+    val ta = context.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
+    background = ta.getDrawable(0)
+    ta.recycle()
+}
+
+/**
  * Vertical LinearLayout with the standard dialog horizontal padding — the
  * common shape used for the "custom view" body of choice-picker and
  * fee-editor dialogs across cart and preferences.
@@ -51,9 +62,7 @@ fun choiceExplainerRow(
             gravity = Gravity.CENTER_VERTICAL
             setPadding(0, padV, 0, padV)
             isClickable = true
-            val ta = ctx.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
-            background = ta.getDrawable(0)
-            ta.recycle()
+            applySelectableRowBackground()
             setOnClickListener { onClick() }
         }
     if (leadingView != null) row.addView(leadingView)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -31,15 +31,17 @@ fun paddedDialogContainer(
 
 /**
  * Build a clickable "title + one-line explainer" row for a picker dialog.
- * Optional [leadingView] (e.g. a RadioButton) sits left of the text column;
- * text column expands to fill remaining width when present, otherwise takes
- * the full row.
+ * Optional [leadingView] (e.g. a RadioButton) sits left of the text column
+ * and optional [trailingView] (e.g. an edit icon with its own click listener)
+ * sits right. The text column expands to fill remaining width when either
+ * side view is present, otherwise takes the full row.
  */
 fun choiceExplainerRow(
     ctx: Context,
     title: CharSequence,
     description: CharSequence,
     leadingView: View? = null,
+    trailingView: View? = null,
     onClick: () -> Unit,
 ): LinearLayout {
     val padV = ctx.resources.getDimensionPixelSize(R.dimen.margin2x)
@@ -72,8 +74,9 @@ fun choiceExplainerRow(
                 },
             )
         }
+    val hasSideView = leadingView != null || trailingView != null
     val textLp =
-        if (leadingView != null) {
+        if (hasSideView) {
             LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
         } else {
             LinearLayout.LayoutParams(
@@ -82,5 +85,6 @@ fun choiceExplainerRow(
             )
         }
     row.addView(textCol, textLp)
+    if (trailingView != null) row.addView(trailingView)
     return row
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -7,10 +7,12 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ImageSpan
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
@@ -38,8 +40,8 @@ import java.util.UUID
 // Preference keys for UI-only rows. The leading __ marks them as ignored by
 // the settings back-up/restore pipeline.
 private const val PREF_KEY_FEE_SIDE = "__fee_side"
-private const val PREF_KEY_ACTIVE_EXCHANGE = "__active_exchange"
-private const val PREF_KEY_ACTIVE_BANK = "__active_bank"
+private const val PREF_KEY_GLOBAL_EXCHANGE = "__global_exchange"
+private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 
 // Sign-toggle button geometry (dp) and text size (sp).
 private const val SIGN_TOGGLE_BUTTON_HEIGHT_DP = 56f
@@ -56,18 +58,11 @@ private const val ARROW_BOTH_WAYS = "\u2194"
 // Summary parts separator, e.g. "USD → EUR · Inactive".
 private const val SUMMARY_SEPARATOR = "  ·  "
 
-// Show the active-picker row only when the user has a real choice to make
-// (i.e. ≥2 entries in the category). With 0 or 1 entries the FeeCalculator
-// fallback picks the sole entry (or nothing), so the picker adds no value.
-private const val MIN_ENTRIES_FOR_PICKER = 2
-
 class FeeManagerFragment : PreferenceFragmentCompat() {
     private lateinit var db: Database
 
-    private lateinit var activeExchangePref: Preference
-    private lateinit var activeBankPref: Preference
-    private lateinit var categoryExchange: PreferenceCategory
-    private lateinit var categoryBank: PreferenceCategory
+    private lateinit var globalExchangePref: Preference
+    private lateinit var globalBankPref: Preference
     private lateinit var categoryPair: PreferenceCategory
 
     override fun onCreatePreferences(
@@ -80,23 +75,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
         screen.addPreference(buildFeeSidePreference(ctx))
 
-        activeExchangePref =
-            buildActivePickerPreference(
-                ctx = ctx,
-                key = PREF_KEY_ACTIVE_EXCHANGE,
-                titleRes = R.string.fee_active_exchange_title,
-            )
-        activeBankPref =
-            buildActivePickerPreference(
-                ctx = ctx,
-                key = PREF_KEY_ACTIVE_BANK,
-                titleRes = R.string.fee_active_bank_title,
-            )
-        screen.addPreference(activeExchangePref)
-        screen.addPreference(activeBankPref)
+        globalExchangePref =
+            buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_EXCHANGE, R.string.fee_section_global_exchange)
+        globalBankPref =
+            buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_BANK, R.string.fee_section_global_bank)
+        screen.addPreference(globalExchangePref)
+        screen.addPreference(globalBankPref)
 
-        categoryExchange = addCategory(screen, ctx, R.string.fee_section_global_exchange)
-        categoryBank = addCategory(screen, ctx, R.string.fee_section_global_bank)
         categoryPair = addCategory(screen, ctx, R.string.fee_section_specific_pair)
 
         preferenceScreen = screen
@@ -210,7 +195,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .show()
     }
 
-    private fun buildActivePickerPreference(
+    private fun buildGlobalSelectorPreference(
         ctx: Context,
         key: String,
         titleRes: Int,
@@ -219,28 +204,27 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             this.key = key
             title = getString(titleRes)
             isIconSpaceReserved = false
-            isVisible = false // populated when fees load
         }
 
     private fun renderFees(fees: List<Fee>) {
-        val activeExchangeId = db.getActiveExchangeIdBlocking()
-        val activeBankId = db.getActiveBankIdBlocking()
-
-        populate(
-            category = categoryExchange,
+        renderGlobalSelector(
+            pref = globalExchangePref,
             entries = fees.filterIsInstance<Fee.GlobalExchange>(),
-            summaryFor = { null },
+            activeId = db.getActiveExchangeIdBlocking(),
+            sectionTitleRes = R.string.fee_section_global_exchange,
+            onPicked = { id -> db.setActiveExchangeId(id) },
             onAdd = {
                 showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
-                    db.addFee(
+                    val fee =
                         Fee.GlobalExchange(
                             id = UUID.randomUUID().toString(),
                             name = name,
                             percent = percent,
                             isMarkup = isMarkup,
                             isActive = isActive,
-                        ),
-                    )
+                        )
+                    db.addFee(fee)
+                    if (db.getActiveExchangeIdBlocking() == null) db.setActiveExchangeId(fee.id)
                 }
             },
             onEdit = { fee ->
@@ -259,21 +243,24 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 }
             },
         )
-        populate(
-            category = categoryBank,
+        renderGlobalSelector(
+            pref = globalBankPref,
             entries = fees.filterIsInstance<Fee.GlobalBank>(),
-            summaryFor = { null },
+            activeId = db.getActiveBankIdBlocking(),
+            sectionTitleRes = R.string.fee_section_global_bank,
+            onPicked = { id -> db.setActiveBankId(id) },
             onAdd = {
                 showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
-                    db.addFee(
+                    val fee =
                         Fee.GlobalBank(
                             id = UUID.randomUUID().toString(),
                             name = name,
                             percent = percent,
                             isMarkup = isMarkup,
                             isActive = isActive,
-                        ),
-                    )
+                        )
+                    db.addFee(fee)
+                    if (db.getActiveBankIdBlocking() == null) db.setActiveBankId(fee.id)
                 }
             },
             onEdit = { fee ->
@@ -310,72 +297,144 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 }
             },
         )
-
-        renderActivePicker(
-            preference = activeExchangePref,
-            entries = fees.filterIsInstance<Fee.GlobalExchange>(),
-            activeId = activeExchangeId,
-            onPicked = { id -> db.setActiveExchangeId(id) },
-        )
-        renderActivePicker(
-            preference = activeBankPref,
-            entries = fees.filterIsInstance<Fee.GlobalBank>(),
-            activeId = activeBankId,
-            onPicked = { id -> db.setActiveBankId(id) },
-        )
     }
 
-    private fun <T : Fee> renderActivePicker(
-        preference: Preference,
+    private fun <T : Fee> renderGlobalSelector(
+        pref: Preference,
         entries: List<T>,
         activeId: String?,
+        sectionTitleRes: Int,
         onPicked: (String) -> Unit,
+        onAdd: () -> Unit,
+        onEdit: (T) -> Unit,
     ) {
-        val activeEntries = entries.filter { it.isActive }
-        if (activeEntries.size < MIN_ENTRIES_FOR_PICKER) {
-            preference.isVisible = false
-            return
+        val sectionTitle = getString(sectionTitleRes)
+        val active = entries.filter { it.isActive }
+        val effective = active.firstOrNull { it.id == activeId } ?: active.firstOrNull()
+
+        if (effective == null) {
+            pref.title = sectionTitle
+            pref.summary = getString(R.string.fee_empty)
+        } else {
+            pref.title = displayNameOf(effective)
+            pref.summary = formatFeeDescription(effective)
         }
-        preference.isVisible = true
-
-        val explicit = activeId?.let { id -> activeEntries.firstOrNull { it.id == id } }
-        val effective = explicit ?: activeEntries.first()
-        val displayName = displayNameOf(effective)
-        preference.summary =
-            if (explicit == null) getString(R.string.fee_active_auto, displayName) else displayName
-
-        preference.setOnPreferenceClickListener {
-            showActivePickerDialog(activeEntries, effective.id, preference.title.toString()) { picked ->
-                onPicked(picked)
-                renderActivePicker(preference, entries, picked, onPicked)
-            }
+        pref.setOnPreferenceClickListener {
+            showGlobalPickerDialog(
+                entries = entries,
+                effectiveId = effective?.id,
+                title = sectionTitle,
+                onPicked = { picked ->
+                    onPicked(picked)
+                    // Re-render immediately; underlying LiveData will also fire but this
+                    // avoids a visible lag while the picker dialog dismisses.
+                    renderGlobalSelector(pref, entries, picked, sectionTitleRes, onPicked, onAdd, onEdit)
+                },
+                onAdd = onAdd,
+                onEdit = onEdit,
+            )
             true
         }
     }
 
-    private fun <T : Fee> showActivePickerDialog(
+    private fun <T : Fee> showGlobalPickerDialog(
         entries: List<T>,
-        currentId: String,
+        effectiveId: String?,
         title: String,
         onPicked: (String) -> Unit,
+        onAdd: () -> Unit,
+        onEdit: (T) -> Unit,
     ) {
         val ctx = requireContext()
-        val labels = entries.map { formatEntryForPicker(it) }.toTypedArray()
-        val currentIndex = entries.indexOfFirst { it.id == currentId }.coerceAtLeast(0)
+        val container = paddedDialogContainer(ctx)
+        val dialogHolder = arrayOfNulls<AlertDialog>(1)
+        val radios = mutableListOf<RadioButton>()
 
-        MaterialAlertDialogBuilder(ctx)
-            .setTitle(title)
-            .setSingleChoiceItems(labels, currentIndex) { dialog, which ->
-                onPicked(entries[which].id)
-                dialog.dismiss()
-            }.setNegativeButton(android.R.string.cancel, null)
-            .show()
+        entries.forEachIndexed { index, fee ->
+            val radio =
+                RadioButton(ctx).apply {
+                    isChecked = fee.id == effectiveId
+                    isClickable = false
+                }
+            radios += radio
+            val editButton = buildEditIconButton(ctx) {
+                dialogHolder[0]?.dismiss()
+                onEdit(fee)
+            }
+            container.addView(
+                choiceExplainerRow(
+                    ctx = ctx,
+                    title = displayNameOf(fee),
+                    description = formatFeeDescription(fee),
+                    leadingView = radio,
+                    trailingView = editButton,
+                ) {
+                    radios.forEachIndexed { i, r -> r.isChecked = i == index }
+                    onPicked(fee.id)
+                    dialogHolder[0]?.dismiss()
+                },
+            )
+        }
+
+        container.addView(buildAddRow(ctx) {
+            dialogHolder[0]?.dismiss()
+            onAdd()
+        })
+
+        dialogHolder[0] =
+            MaterialAlertDialogBuilder(ctx)
+                .setTitle(title)
+                .setView(container)
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
     }
 
-    private fun formatEntryForPicker(fee: Fee): String {
+    private fun buildEditIconButton(
+        ctx: Context,
+        onClick: () -> Unit,
+    ): ImageButton =
+        ImageButton(ctx, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+            setImageResource(R.drawable.ic_edit)
+            contentDescription = getString(R.string.fee_edit_percent)
+            setOnClickListener { onClick() }
+        }
+
+    private fun buildAddRow(
+        ctx: Context,
+        onClick: () -> Unit,
+    ): View {
+        val padV = ctx.resources.getDimensionPixelSize(R.dimen.margin2x)
+        return LinearLayout(ctx).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, padV, 0, padV)
+            isClickable = true
+            val ta = ctx.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
+            background = ta.getDrawable(0)
+            ta.recycle()
+            setOnClickListener { onClick() }
+            addView(
+                ImageButton(ctx, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+                    setImageResource(R.drawable.ic_add)
+                    isClickable = false
+                },
+            )
+            addView(
+                TextView(ctx).apply {
+                    text = getString(R.string.fee_add)
+                    setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_TitleMedium)
+                },
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+            )
+        }
+    }
+
+    private fun formatFeeDescription(fee: Fee): CharSequence {
         val percent = formatPercent(fee.percent, fee.isMarkup)
-        val name = displayNameOf(fee)
-        return "$name  ·  $percent"
+        if (fee.isActive) return percent
+        return SpannableStringBuilder(percent)
+            .append(SUMMARY_SEPARATOR)
+            .append(getString(R.string.fee_inactive_marker))
     }
 
     private fun displayNameOf(fee: Fee): String = fee.name.ifBlank { getString(R.string.fee_untitled) }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -396,7 +396,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         ctx: Context,
         onClick: () -> Unit,
     ): ImageButton =
-        ImageButton(ctx, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+        ImageButton(ctx, null, androidx.appcompat.R.attr.borderlessButtonStyle).apply {
             setImageResource(R.drawable.ic_edit)
             contentDescription = getString(R.string.fee_edit_percent)
             setOnClickListener { onClick() }
@@ -417,7 +417,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             ta.recycle()
             setOnClickListener { onClick() }
             addView(
-                ImageButton(ctx, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+                ImageButton(ctx, null, androidx.appcompat.R.attr.borderlessButtonStyle).apply {
                     setImageResource(R.drawable.ic_add)
                     isClickable = false
                 },

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -80,16 +80,18 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
         screen.addPreference(buildFeeSidePreference(ctx))
 
-        activeExchangePref = buildActivePickerPreference(
-            ctx = ctx,
-            key = PREF_KEY_ACTIVE_EXCHANGE,
-            titleRes = R.string.fee_active_exchange_title,
-        )
-        activeBankPref = buildActivePickerPreference(
-            ctx = ctx,
-            key = PREF_KEY_ACTIVE_BANK,
-            titleRes = R.string.fee_active_bank_title,
-        )
+        activeExchangePref =
+            buildActivePickerPreference(
+                ctx = ctx,
+                key = PREF_KEY_ACTIVE_EXCHANGE,
+                titleRes = R.string.fee_active_exchange_title,
+            )
+        activeBankPref =
+            buildActivePickerPreference(
+                ctx = ctx,
+                key = PREF_KEY_ACTIVE_BANK,
+                titleRes = R.string.fee_active_bank_title,
+            )
         screen.addPreference(activeExchangePref)
         screen.addPreference(activeBankPref)
 
@@ -376,8 +378,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         return "$name  ·  $percent"
     }
 
-    private fun displayNameOf(fee: Fee): String =
-        fee.name.ifBlank { getString(R.string.fee_untitled) }
+    private fun displayNameOf(fee: Fee): String = fee.name.ifBlank { getString(R.string.fee_untitled) }
 
     private fun <T : Fee> populate(
         category: PreferenceCategory,
@@ -578,9 +579,15 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false)
 
         listOf(
-            nameLabel, nameInput,
-            fromLabel, fromButton, toLabel, toButton,
-            bothWays, percentLabel, percentInput,
+            nameLabel,
+            nameInput,
+            fromLabel,
+            fromButton,
+            toLabel,
+            toButton,
+            bothWays,
+            percentLabel,
+            percentInput,
         ).forEach { container.addView(it) }
         addSignToggleWithTopMargin(container, signToggle.view)
         container.addView(activeCheckbox)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -51,11 +51,11 @@ private const val SIGN_TOGGLE_TEXT_SIZE_SP = 20f
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
 
-// Trailing/leading icon buttons in picker rows. 40dp total with 10dp padding
-// yields a ~20dp visible glyph — smaller than the default 24dp icon so it
-// doesn't overpower the row's text.
-private const val ROW_ICON_BUTTON_SIZE_DP = 40f
-private const val ROW_ICON_PADDING_DP = 10f
+// Trailing/leading icon buttons in picker rows. 48dp total with 12dp padding
+// yields a 24dp visible glyph — matches the Material3 IconButton dimensions
+// used by the saved-carts list so all in-app row-affordance icons look alike.
+private const val ROW_ICON_BUTTON_SIZE_DP = 48f
+private const val ROW_ICON_PADDING_DP = 12f
 
 // Arrows used in the "specific pair" summary.
 private const val ARROW_ONE_WAY = "\u2192"

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -35,9 +35,11 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.math.BigDecimal
 import java.util.UUID
 
-// Preference key for the "fee side" row — the leading __ marks it as
-// UI-only state that's ignored by the settings back-up/restore pipeline.
+// Preference keys for UI-only rows. The leading __ marks them as ignored by
+// the settings back-up/restore pipeline.
 private const val PREF_KEY_FEE_SIDE = "__fee_side"
+private const val PREF_KEY_ACTIVE_EXCHANGE = "__active_exchange"
+private const val PREF_KEY_ACTIVE_BANK = "__active_bank"
 
 // Sign-toggle button geometry (dp) and text size (sp).
 private const val SIGN_TOGGLE_BUTTON_HEIGHT_DP = 56f
@@ -51,9 +53,19 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 private const val ARROW_ONE_WAY = "\u2192"
 private const val ARROW_BOTH_WAYS = "\u2194"
 
+// Summary parts separator, e.g. "USD → EUR · Inactive".
+private const val SUMMARY_SEPARATOR = "  ·  "
+
+// Show the active-picker row only when the user has a real choice to make
+// (i.e. ≥2 entries in the category). With 0 or 1 entries the FeeCalculator
+// fallback picks the sole entry (or nothing), so the picker adds no value.
+private const val MIN_ENTRIES_FOR_PICKER = 2
+
 class FeeManagerFragment : PreferenceFragmentCompat() {
     private lateinit var db: Database
 
+    private lateinit var activeExchangePref: Preference
+    private lateinit var activeBankPref: Preference
     private lateinit var categoryExchange: PreferenceCategory
     private lateinit var categoryBank: PreferenceCategory
     private lateinit var categoryPair: PreferenceCategory
@@ -67,6 +79,19 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val screen: PreferenceScreen = preferenceManager.createPreferenceScreen(ctx)
 
         screen.addPreference(buildFeeSidePreference(ctx))
+
+        activeExchangePref = buildActivePickerPreference(
+            ctx = ctx,
+            key = PREF_KEY_ACTIVE_EXCHANGE,
+            titleRes = R.string.fee_active_exchange_title,
+        )
+        activeBankPref = buildActivePickerPreference(
+            ctx = ctx,
+            key = PREF_KEY_ACTIVE_BANK,
+            titleRes = R.string.fee_active_bank_title,
+        )
+        screen.addPreference(activeExchangePref)
+        screen.addPreference(activeBankPref)
 
         categoryExchange = addCategory(screen, ctx, R.string.fee_section_global_exchange)
         categoryBank = addCategory(screen, ctx, R.string.fee_section_global_bank)
@@ -183,22 +208,52 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .show()
     }
 
+    private fun buildActivePickerPreference(
+        ctx: Context,
+        key: String,
+        titleRes: Int,
+    ): Preference =
+        Preference(ctx).apply {
+            this.key = key
+            title = getString(titleRes)
+            isIconSpaceReserved = false
+            isVisible = false // populated when fees load
+        }
+
     private fun renderFees(fees: List<Fee>) {
+        val activeExchangeId = db.getActiveExchangeIdBlocking()
+        val activeBankId = db.getActiveBankIdBlocking()
+
         populate(
             category = categoryExchange,
             entries = fees.filterIsInstance<Fee.GlobalExchange>(),
             summaryFor = { null },
             onAdd = {
-                showPercentSignDialog(existing = null) { percent, isMarkup ->
-                    db.addFee(Fee.GlobalExchange(UUID.randomUUID().toString(), percent, isMarkup))
+                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
+                    db.addFee(
+                        Fee.GlobalExchange(
+                            id = UUID.randomUUID().toString(),
+                            name = name,
+                            percent = percent,
+                            isMarkup = isMarkup,
+                            isActive = isActive,
+                        ),
+                    )
                 }
             },
             onEdit = { fee ->
-                showPercentSignDialog(
+                showGlobalFeeDialog(
                     existing = fee,
                     onDelete = { db.deleteFee(fee.id) },
-                ) { percent, isMarkup ->
-                    db.updateFee(fee.copy(percent = percent, isMarkup = isMarkup))
+                ) { name, percent, isMarkup, isActive ->
+                    db.updateFee(
+                        fee.copy(
+                            name = name,
+                            percent = percent,
+                            isMarkup = isMarkup,
+                            isActive = isActive,
+                        ),
+                    )
                 }
             },
         )
@@ -207,16 +262,31 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             entries = fees.filterIsInstance<Fee.GlobalBank>(),
             summaryFor = { null },
             onAdd = {
-                showPercentSignDialog(existing = null) { percent, isMarkup ->
-                    db.addFee(Fee.GlobalBank(UUID.randomUUID().toString(), percent, isMarkup))
+                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
+                    db.addFee(
+                        Fee.GlobalBank(
+                            id = UUID.randomUUID().toString(),
+                            name = name,
+                            percent = percent,
+                            isMarkup = isMarkup,
+                            isActive = isActive,
+                        ),
+                    )
                 }
             },
             onEdit = { fee ->
-                showPercentSignDialog(
+                showGlobalFeeDialog(
                     existing = fee,
                     onDelete = { db.deleteFee(fee.id) },
-                ) { percent, isMarkup ->
-                    db.updateFee(fee.copy(percent = percent, isMarkup = isMarkup))
+                ) { name, percent, isMarkup, isActive ->
+                    db.updateFee(
+                        fee.copy(
+                            name = name,
+                            percent = percent,
+                            isMarkup = isMarkup,
+                            isActive = isActive,
+                        ),
+                    )
                 }
             },
         )
@@ -238,7 +308,76 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 }
             },
         )
+
+        renderActivePicker(
+            preference = activeExchangePref,
+            entries = fees.filterIsInstance<Fee.GlobalExchange>(),
+            activeId = activeExchangeId,
+            onPicked = { id -> db.setActiveExchangeId(id) },
+        )
+        renderActivePicker(
+            preference = activeBankPref,
+            entries = fees.filterIsInstance<Fee.GlobalBank>(),
+            activeId = activeBankId,
+            onPicked = { id -> db.setActiveBankId(id) },
+        )
     }
+
+    private fun <T : Fee> renderActivePicker(
+        preference: Preference,
+        entries: List<T>,
+        activeId: String?,
+        onPicked: (String) -> Unit,
+    ) {
+        val activeEntries = entries.filter { it.isActive }
+        if (activeEntries.size < MIN_ENTRIES_FOR_PICKER) {
+            preference.isVisible = false
+            return
+        }
+        preference.isVisible = true
+
+        val explicit = activeId?.let { id -> activeEntries.firstOrNull { it.id == id } }
+        val effective = explicit ?: activeEntries.first()
+        val displayName = displayNameOf(effective)
+        preference.summary =
+            if (explicit == null) getString(R.string.fee_active_auto, displayName) else displayName
+
+        preference.setOnPreferenceClickListener {
+            showActivePickerDialog(activeEntries, effective.id, preference.title.toString()) { picked ->
+                onPicked(picked)
+                renderActivePicker(preference, entries, picked, onPicked)
+            }
+            true
+        }
+    }
+
+    private fun <T : Fee> showActivePickerDialog(
+        entries: List<T>,
+        currentId: String,
+        title: String,
+        onPicked: (String) -> Unit,
+    ) {
+        val ctx = requireContext()
+        val labels = entries.map { formatEntryForPicker(it) }.toTypedArray()
+        val currentIndex = entries.indexOfFirst { it.id == currentId }.coerceAtLeast(0)
+
+        MaterialAlertDialogBuilder(ctx)
+            .setTitle(title)
+            .setSingleChoiceItems(labels, currentIndex) { dialog, which ->
+                onPicked(entries[which].id)
+                dialog.dismiss()
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun formatEntryForPicker(fee: Fee): String {
+        val percent = formatPercent(fee.percent, fee.isMarkup)
+        val name = displayNameOf(fee)
+        return "$name  ·  $percent"
+    }
+
+    private fun displayNameOf(fee: Fee): String =
+        fee.name.ifBlank { getString(R.string.fee_untitled) }
 
     private fun <T : Fee> populate(
         category: PreferenceCategory,
@@ -261,8 +400,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             entries.forEach { fee ->
                 category.addPreference(
                     Preference(ctx).apply {
-                        title = formatPercent(fee.percent, fee.isMarkup)
-                        summary = summaryFor(fee)
+                        title = formatFeeTitle(fee)
+                        summary = buildFeeSummary(summaryFor(fee), fee.isActive)
                         isIconSpaceReserved = false
                         setOnPreferenceClickListener {
                             onEdit(fee)
@@ -284,6 +423,24 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         )
     }
 
+    private fun formatFeeTitle(fee: Fee): CharSequence {
+        val percent = formatPercent(fee.percent, fee.isMarkup)
+        return if (fee.name.isBlank()) percent else "${fee.name}  ·  $percent"
+    }
+
+    private fun buildFeeSummary(
+        base: CharSequence?,
+        isActive: Boolean,
+    ): CharSequence? {
+        val inactive = if (!isActive) getString(R.string.fee_inactive_marker) else null
+        return when {
+            base == null && inactive == null -> null
+            base == null -> inactive
+            inactive == null -> base
+            else -> SpannableStringBuilder(base).append(SUMMARY_SEPARATOR).append(inactive)
+        }
+    }
+
     private fun formatPercent(
         percent: BigDecimal,
         isMarkup: Boolean,
@@ -297,23 +454,51 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         return "$sign ${percent.toHumanReadableNumber(requireContext(), suffix = "%")}"
     }
 
-    private fun showPercentSignDialog(
+    private fun buildNameInput(
+        ctx: Context,
+        initial: String?,
+    ): EditText =
+        EditText(ctx).apply {
+            hint = getString(R.string.fee_edit_name_hint)
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_WORDS
+            if (initial != null) setText(initial)
+        }
+
+    private fun buildActiveCheckbox(
+        ctx: Context,
+        initial: Boolean,
+    ): CheckBox =
+        CheckBox(ctx).apply {
+            text = getString(R.string.fee_edit_active)
+            isChecked = initial
+        }
+
+    private fun showGlobalFeeDialog(
         existing: Fee?,
         onDelete: (() -> Unit)? = null,
-        onConfirm: (BigDecimal, Boolean) -> Unit,
+        onConfirm: (name: String, percent: BigDecimal, isMarkup: Boolean, isActive: Boolean) -> Unit,
     ) {
         val ctx = requireContext()
         val padV = resources.getDimensionPixelSize(R.dimen.margin2x)
         val container = paddedDialogContainer(ctx, topPadding = padV)
+
+        val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
+        val nameInput = buildNameInput(ctx, existing?.name)
+        val percentLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_percent) }
         val percentInput =
             EditText(ctx).apply {
-                hint = getString(R.string.fee_edit_percent)
                 inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
                 if (existing != null) setText(existing.percent.toPlainString())
             }
         val signGroup = buildSignToggle(ctx, existing?.isMarkup)
+        val activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false)
+
+        container.addView(nameLabel)
+        container.addView(nameInput)
+        container.addView(percentLabel)
         container.addView(percentInput)
         addSignToggleWithTopMargin(container, signGroup.view)
+        container.addView(activeCheckbox)
 
         MaterialAlertDialogBuilder(ctx)
             .setTitle(R.string.fee_edit_percent)
@@ -322,7 +507,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 val percent =
                     percentInput.text.toString().toBigDecimalOrNull()
                         ?: BigDecimal.ZERO
-                onConfirm(percent.abs(), signGroup.isMarkup())
+                onConfirm(
+                    nameInput.text.toString().trim(),
+                    percent.abs(),
+                    signGroup.isMarkup(),
+                    activeCheckbox.isChecked,
+                )
             }.setNegativeButton(android.R.string.cancel, null)
             .withDeleteButton(onDelete)
             .show()
@@ -341,6 +531,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         var pickedTo: String? = existing?.to
         val placeholder = getString(R.string.fee_pair_pick_currency)
 
+        val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
+        val nameInput = buildNameInput(ctx, existing?.name)
         val fromLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_from) }
         val fromButton =
             MaterialButton(
@@ -383,10 +575,15 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 if (existing != null) setText(existing.percent.toPlainString())
             }
         val signToggle = buildSignToggle(ctx, existing?.isMarkup)
+        val activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false)
 
-        listOf(fromLabel, fromButton, toLabel, toButton, bothWays, percentLabel, percentInput)
-            .forEach { container.addView(it) }
+        listOf(
+            nameLabel, nameInput,
+            fromLabel, fromButton, toLabel, toButton,
+            bothWays, percentLabel, percentInput,
+        ).forEach { container.addView(it) }
         addSignToggleWithTopMargin(container, signToggle.view)
+        container.addView(activeCheckbox)
 
         MaterialAlertDialogBuilder(ctx)
             .setTitle(R.string.fee_section_specific_pair)
@@ -401,11 +598,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 onConfirm(
                     Fee.SpecificPair(
                         id = existing?.id ?: UUID.randomUUID().toString(),
+                        name = nameInput.text.toString().trim(),
                         percent = percent.abs(),
                         isMarkup = signToggle.isMarkup(),
                         from = from,
                         to = to,
                         bothWays = bothWays.isChecked,
+                        isActive = activeCheckbox.isChecked,
                     ),
                 )
             }.setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -357,10 +357,11 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                     isClickable = false
                 }
             radios += radio
-            val editButton = buildEditIconButton(ctx) {
-                dialogHolder[0]?.dismiss()
-                onEdit(fee)
-            }
+            val editButton =
+                buildEditIconButton(ctx) {
+                    dialogHolder[0]?.dismiss()
+                    onEdit(fee)
+                }
             container.addView(
                 choiceExplainerRow(
                     ctx = ctx,
@@ -376,10 +377,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             )
         }
 
-        container.addView(buildAddRow(ctx) {
-            dialogHolder[0]?.dismiss()
-            onAdd()
-        })
+        container.addView(
+            buildAddRow(ctx) {
+                dialogHolder[0]?.dismiss()
+                onAdd()
+            },
+        )
 
         dialogHolder[0] =
             MaterialAlertDialogBuilder(ctx)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -12,7 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.EditText
-import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
@@ -51,6 +51,12 @@ private const val SIGN_TOGGLE_TEXT_SIZE_SP = 20f
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
 
+// Trailing/leading icon buttons in picker rows. 40dp total with 10dp padding
+// yields a ~20dp visible glyph — smaller than the default 24dp icon so it
+// doesn't overpower the row's text.
+private const val ROW_ICON_BUTTON_SIZE_DP = 40f
+private const val ROW_ICON_PADDING_DP = 10f
+
 // Arrows used in the "specific pair" summary.
 private const val ARROW_ONE_WAY = "\u2192"
 private const val ARROW_BOTH_WAYS = "\u2194"
@@ -79,8 +85,11 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_EXCHANGE, R.string.fee_section_global_exchange)
         globalBankPref =
             buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_BANK, R.string.fee_section_global_bank)
-        screen.addPreference(globalExchangePref)
-        screen.addPreference(globalBankPref)
+        // Wrap each selector in its own category so the section header is
+        // visible on the top-level screen; without it users can't tell the
+        // exchange row from the bank/card row without opening the dialog.
+        addCategory(screen, ctx, R.string.fee_section_global_exchange).addPreference(globalExchangePref)
+        addCategory(screen, ctx, R.string.fee_section_global_bank).addPreference(globalBankPref)
 
         categoryPair = addCategory(screen, ctx, R.string.fee_section_specific_pair)
 
@@ -313,8 +322,11 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val effective = active.firstOrNull { it.id == activeId } ?: active.firstOrNull()
 
         if (effective == null) {
-            pref.title = sectionTitle
-            pref.summary = getString(R.string.fee_empty)
+            // Section title already appears as the category header above the
+            // row; use the empty-state message as the row title to avoid
+            // repeating it.
+            pref.title = getString(R.string.fee_empty)
+            pref.summary = null
         } else {
             pref.title = displayNameOf(effective)
             pref.summary = formatFeeDescription(effective)
@@ -395,12 +407,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     private fun buildEditIconButton(
         ctx: Context,
         onClick: () -> Unit,
-    ): ImageButton =
-        ImageButton(ctx, null, androidx.appcompat.R.attr.borderlessButtonStyle).apply {
-            setImageResource(R.drawable.ic_edit)
-            contentDescription = getString(R.string.fee_edit_percent)
-            setOnClickListener { onClick() }
-        }
+    ): View = buildRowIcon(ctx, R.drawable.ic_edit, getString(R.string.fee_edit_percent), onClick)
 
     private fun buildAddRow(
         ctx: Context,
@@ -416,12 +423,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             background = ta.getDrawable(0)
             ta.recycle()
             setOnClickListener { onClick() }
-            addView(
-                ImageButton(ctx, null, androidx.appcompat.R.attr.borderlessButtonStyle).apply {
-                    setImageResource(R.drawable.ic_add)
-                    isClickable = false
-                },
-            )
+            addView(buildRowIcon(ctx, R.drawable.ic_add, null, onClick = null))
             addView(
                 TextView(ctx).apply {
                     text = getString(R.string.fee_add)
@@ -429,6 +431,30 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 },
                 LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
             )
+        }
+    }
+
+    private fun buildRowIcon(
+        ctx: Context,
+        iconRes: Int,
+        contentDesc: String?,
+        onClick: (() -> Unit)?,
+    ): ImageView {
+        val sizePx = ROW_ICON_BUTTON_SIZE_DP.dpToPx().toInt()
+        val padPx = ROW_ICON_PADDING_DP.dpToPx().toInt()
+        return ImageView(ctx).apply {
+            setImageResource(iconRes)
+            setPadding(padPx, padPx, padPx, padPx)
+            contentDescription = contentDesc
+            layoutParams = LinearLayout.LayoutParams(sizePx, sizePx)
+            if (onClick != null) {
+                val ta = ctx.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
+                background = ta.getDrawable(0)
+                ta.recycle()
+                isClickable = true
+                isFocusable = true
+                setOnClickListener { onClick() }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -26,6 +26,7 @@ import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Fee
 import com.eliormachlev.currencix.model.FeeSide
 import com.eliormachlev.currencix.repository.Database
+import com.eliormachlev.currencix.util.applySelectableRowBackground
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.dpToPx
 import com.eliormachlev.currencix.util.paddedDialogContainer
@@ -216,76 +217,30 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
 
     private fun renderFees(fees: List<Fee>) {
-        renderGlobalSelector(
+        renderGlobalCategory(
             pref = globalExchangePref,
             entries = fees.filterIsInstance<Fee.GlobalExchange>(),
-            activeId = db.getActiveExchangeIdBlocking(),
             sectionTitleRes = R.string.fee_section_global_exchange,
-            onPicked = { id -> db.setActiveExchangeId(id) },
-            onAdd = {
-                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
-                    val fee =
-                        Fee.GlobalExchange(
-                            id = UUID.randomUUID().toString(),
-                            name = name,
-                            percent = percent,
-                            isMarkup = isMarkup,
-                            isActive = isActive,
-                        )
-                    db.addFee(fee)
-                    if (db.getActiveExchangeIdBlocking() == null) db.setActiveExchangeId(fee.id)
-                }
+            getActiveId = db::getActiveExchangeIdBlocking,
+            setActiveId = db::setActiveExchangeId,
+            create = { name, percent, isMarkup, isActive ->
+                Fee.GlobalExchange(UUID.randomUUID().toString(), name, percent, isMarkup, isActive)
             },
-            onEdit = { fee ->
-                showGlobalFeeDialog(
-                    existing = fee,
-                    onDelete = { db.deleteFee(fee.id) },
-                ) { name, percent, isMarkup, isActive ->
-                    db.updateFee(
-                        fee.copy(
-                            name = name,
-                            percent = percent,
-                            isMarkup = isMarkup,
-                            isActive = isActive,
-                        ),
-                    )
-                }
+            update = { existing, name, percent, isMarkup, isActive ->
+                existing.copy(name = name, percent = percent, isMarkup = isMarkup, isActive = isActive)
             },
         )
-        renderGlobalSelector(
+        renderGlobalCategory(
             pref = globalBankPref,
             entries = fees.filterIsInstance<Fee.GlobalBank>(),
-            activeId = db.getActiveBankIdBlocking(),
             sectionTitleRes = R.string.fee_section_global_bank,
-            onPicked = { id -> db.setActiveBankId(id) },
-            onAdd = {
-                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
-                    val fee =
-                        Fee.GlobalBank(
-                            id = UUID.randomUUID().toString(),
-                            name = name,
-                            percent = percent,
-                            isMarkup = isMarkup,
-                            isActive = isActive,
-                        )
-                    db.addFee(fee)
-                    if (db.getActiveBankIdBlocking() == null) db.setActiveBankId(fee.id)
-                }
+            getActiveId = db::getActiveBankIdBlocking,
+            setActiveId = db::setActiveBankId,
+            create = { name, percent, isMarkup, isActive ->
+                Fee.GlobalBank(UUID.randomUUID().toString(), name, percent, isMarkup, isActive)
             },
-            onEdit = { fee ->
-                showGlobalFeeDialog(
-                    existing = fee,
-                    onDelete = { db.deleteFee(fee.id) },
-                ) { name, percent, isMarkup, isActive ->
-                    db.updateFee(
-                        fee.copy(
-                            name = name,
-                            percent = percent,
-                            isMarkup = isMarkup,
-                            isActive = isActive,
-                        ),
-                    )
-                }
+            update = { existing, name, percent, isMarkup, isActive ->
+                existing.copy(name = name, percent = percent, isMarkup = isMarkup, isActive = isActive)
             },
         )
         populate(
@@ -303,6 +258,44 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                     onDelete = { db.deleteFee(fee.id) },
                 ) { updated ->
                     db.updateFee(updated.copy(id = fee.id))
+                }
+            },
+        )
+    }
+
+    /**
+     * Wire one global-fee category (exchange or bank/card) into its selector
+     * row. Callers supply the category-typed [create]/[update] factories so
+     * the sealed-class copy stays type-safe without a `when` on [Fee].
+     */
+    private fun <T : Fee> renderGlobalCategory(
+        pref: Preference,
+        entries: List<T>,
+        sectionTitleRes: Int,
+        getActiveId: () -> String?,
+        setActiveId: (String) -> Unit,
+        create: (name: String, percent: BigDecimal, isMarkup: Boolean, isActive: Boolean) -> T,
+        update: (existing: T, name: String, percent: BigDecimal, isMarkup: Boolean, isActive: Boolean) -> T,
+    ) {
+        renderGlobalSelector(
+            pref = pref,
+            entries = entries,
+            activeId = getActiveId(),
+            sectionTitleRes = sectionTitleRes,
+            onPicked = setActiveId,
+            onAdd = {
+                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive ->
+                    val fee = create(name, percent, isMarkup, isActive)
+                    db.addFee(fee)
+                    if (getActiveId() == null) setActiveId(fee.id)
+                }
+            },
+            onEdit = { fee ->
+                showGlobalFeeDialog(
+                    existing = fee,
+                    onDelete = { db.deleteFee(fee.id) },
+                ) { name, percent, isMarkup, isActive ->
+                    db.updateFee(update(fee, name, percent, isMarkup, isActive))
                 }
             },
         )
@@ -419,9 +412,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             gravity = Gravity.CENTER_VERTICAL
             setPadding(0, padV, 0, padV)
             isClickable = true
-            val ta = ctx.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
-            background = ta.getDrawable(0)
-            ta.recycle()
+            applySelectableRowBackground()
             setOnClickListener { onClick() }
             addView(buildRowIcon(ctx, R.drawable.ic_add, null, onClick = null))
             addView(
@@ -448,9 +439,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             contentDescription = contentDesc
             layoutParams = LinearLayout.LayoutParams(sizePx, sizePx)
             if (onClick != null) {
-                val ta = ctx.obtainStyledAttributes(intArrayOf(android.R.attr.selectableItemBackground))
-                background = ta.getDrawable(0)
-                ta.recycle()
+                applySelectableRowBackground()
                 isClickable = true
                 isFocusable = true
                 setOnClickListener { onClick() }
@@ -623,35 +612,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
         val nameInput = buildNameInput(ctx, existing?.name)
         val fromLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_from) }
-        val fromButton =
-            MaterialButton(
-                ctx,
-                null,
-                com.google.android.material.R.attr.materialButtonOutlinedStyle,
-            ).apply {
-                applyCurrencyIcon(this, pickedFrom, placeholder, ctx)
-                setOnClickListener {
-                    openCurrencyPicker { iso ->
-                        pickedFrom = iso
-                        applyCurrencyIcon(this, iso, placeholder, ctx)
-                    }
-                }
-            }
+        val fromButton = buildCurrencyPickerButton(ctx, pickedFrom, placeholder) { pickedFrom = it }
         val toLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_to) }
-        val toButton =
-            MaterialButton(
-                ctx,
-                null,
-                com.google.android.material.R.attr.materialButtonOutlinedStyle,
-            ).apply {
-                applyCurrencyIcon(this, pickedTo, placeholder, ctx)
-                setOnClickListener {
-                    openCurrencyPicker { iso ->
-                        pickedTo = iso
-                        applyCurrencyIcon(this, iso, placeholder, ctx)
-                    }
-                }
-            }
+        val toButton = buildCurrencyPickerButton(ctx, pickedTo, placeholder) { pickedTo = it }
         val bothWays =
             CheckBox(ctx).apply {
                 text = getString(R.string.fee_pair_both_ways)
@@ -737,11 +700,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val btnWidth = SIGN_TOGGLE_BUTTON_WIDTH_DP.dpToPx().toInt()
 
         fun makeButton(labelRes: Int): MaterialButton =
-            MaterialButton(
-                ctx,
-                null,
-                com.google.android.material.R.attr.materialButtonOutlinedStyle,
-            ).apply {
+            outlinedMaterialButton(ctx).apply {
                 id = View.generateViewId()
                 text = getString(labelRes)
                 textSize = SIGN_TOGGLE_TEXT_SIZE_SP
@@ -755,6 +714,29 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         group.check(if (initialMarkup == false) btnMinus.id else btnPlus.id)
         return SignToggle(group, btnPlus.id, btnMinus.id)
     }
+
+    private fun outlinedMaterialButton(ctx: Context): MaterialButton =
+        MaterialButton(
+            ctx,
+            null,
+            com.google.android.material.R.attr.materialButtonOutlinedStyle,
+        )
+
+    private fun buildCurrencyPickerButton(
+        ctx: Context,
+        initial: String?,
+        placeholder: String,
+        onPicked: (String) -> Unit,
+    ): MaterialButton =
+        outlinedMaterialButton(ctx).apply {
+            applyCurrencyIcon(this, initial, placeholder, ctx)
+            setOnClickListener {
+                openCurrencyPicker { iso ->
+                    applyCurrencyIcon(this, iso, placeholder, ctx)
+                    onPicked(iso)
+                }
+            }
+        }
 
     private fun openCurrencyPicker(onPicked: (String) -> Unit) {
         val dialog = SearchableSpinnerDialog(requireContext())

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -39,17 +39,27 @@ class CartViewModel(
     // without a suspend hop.
     private var lastFees: List<Fee> = emptyList()
     private var lastRates: ExchangeRates? = null
+    private var lastActiveExchangeId: String? = db.getActiveExchangeIdBlocking()
+    private var lastActiveBankId: String? = db.getActiveBankIdBlocking()
     private val feesObserver = Observer<List<Fee>> { lastFees = it }
     private val ratesObserver = Observer<ExchangeRates?> { lastRates = it }
+    private val activeExchange: LiveData<String?> = db.getActiveExchangeId()
+    private val activeBank: LiveData<String?> = db.getActiveBankId()
+    private val activeExchangeObserver = Observer<String?> { lastActiveExchangeId = it }
+    private val activeBankObserver = Observer<String?> { lastActiveBankId = it }
 
     init {
         fees.observeForever(feesObserver)
         rates.observeForever(ratesObserver)
+        activeExchange.observeForever(activeExchangeObserver)
+        activeBank.observeForever(activeBankObserver)
     }
 
     override fun onCleared() {
         fees.removeObserver(feesObserver)
         rates.removeObserver(ratesObserver)
+        activeExchange.removeObserver(activeExchangeObserver)
+        activeBank.removeObserver(activeBankObserver)
         super.onCleared()
     }
 
@@ -304,7 +314,7 @@ class CartViewModel(
     fun currentFeeStack(): BigDecimal {
         val cart = current.value ?: return BigDecimal.ONE
         val (base, dest) = cart.resolvedPair()
-        return FeeCalculator.totalStack(lastFees, base, dest)
+        return FeeCalculator.totalStack(lastFees, base, dest, lastActiveExchangeId, lastActiveBankId)
     }
 
     /** Snapshot used by the "Share" flow — computed against the latest fees & rates. */
@@ -314,7 +324,7 @@ class CartViewModel(
         val evaluated = cart.items.map { it to evaluateItem(it) }
         val subtotal = evaluated.fold(BigDecimal.ZERO) { acc, (_, value) -> acc + value }
         val (base, dest) = cart.resolvedPair()
-        val stack = FeeCalculator.totalStack(lastFees, base, dest)
+        val stack = FeeCalculator.totalStack(lastFees, base, dest, lastActiveExchangeId, lastActiveBankId)
         val converted = convertAmount(subtotal, base, dest, lastRates)
         val total = applyFeeSide(converted, stack, cart.feeSide)
         return CartSnapshot(
@@ -395,7 +405,7 @@ class CartViewModel(
         val (base, dest) = cart.resolvedPair()
         val subtotal = subtotalOf(cart)
         val converted = convertAmount(subtotal, base, dest, rates)
-        val stack = FeeCalculator.totalStack(feeList, base, dest)
+        val stack = FeeCalculator.totalStack(feeList, base, dest, lastActiveExchangeId, lastActiveBankId)
         return applyFeeSide(converted, stack, side)
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -80,6 +80,8 @@ class MainViewModel(
     // fees
     private val fees: LiveData<List<Fee>>
     private val feeSide: LiveData<FeeSide>
+    private val activeExchangeId: LiveData<String?>
+    private val activeBankId: LiveData<String?>
 
     // Background timeline prefetcher: fires whenever the selected base/target
     // resolves (including cold-start defaults) so the graph screen paints
@@ -126,6 +128,8 @@ class MainViewModel(
 
         fees = db.getFees()
         feeSide = db.getFeeSide()
+        activeExchangeId = db.getActiveExchangeId()
+        activeBankId = db.getActiveBankId()
 
         //
         exchangeRates =
@@ -449,6 +453,8 @@ class MainViewModel(
             var destinationCurrency: Currency? = null
             var feeList: List<Fee>? = null
             var side: FeeSide? = null
+            var exchangeId: String? = null
+            var bankId: String? = null
 
             init {
                 // rates changed
@@ -481,6 +487,15 @@ class MainViewModel(
                     side = it
                     calculateResult()
                 }
+                // active picker changed
+                addSource(activeExchangeId) {
+                    exchangeId = it
+                    calculateResult()
+                }
+                addSource(activeBankId) {
+                    bankId = it
+                    calculateResult()
+                }
             }
 
             private fun calculateResult() {
@@ -502,6 +517,8 @@ class MainViewModel(
                                         feeList.orEmpty(),
                                         baseCurrency,
                                         destinationCurrency,
+                                        exchangeId,
+                                        bankId,
                                     )
                                 if (stack.compareTo(BigDecimal.ZERO) == 0) {
                                     fair
@@ -523,7 +540,14 @@ class MainViewModel(
     internal fun feeStackFor(
         base: Currency?,
         dest: Currency?,
-    ): BigDecimal = FeeCalculator.totalStack(fees.value.orEmpty(), base, dest)
+    ): BigDecimal =
+        FeeCalculator.totalStack(
+            fees.value.orEmpty(),
+            base,
+            dest,
+            activeExchangeId.value,
+            activeBankId.value,
+        )
 
     /**
      * The combined multiplicative fee factor for the current pair.
@@ -535,6 +559,8 @@ class MainViewModel(
             var feeList: List<Fee>? = null
             var base: Currency? = null
             var dest: Currency? = null
+            var exchangeId: String? = null
+            var bankId: String? = null
 
             init {
                 addSource(fees) {
@@ -549,10 +575,18 @@ class MainViewModel(
                     dest = it
                     update()
                 }
+                addSource(activeExchangeId) {
+                    exchangeId = it
+                    update()
+                }
+                addSource(activeBankId) {
+                    bankId = it
+                    update()
+                }
             }
 
             private fun update() {
-                this.value = FeeCalculator.totalStack(feeList.orEmpty(), base, dest)
+                this.value = FeeCalculator.totalStack(feeList.orEmpty(), base, dest, exchangeId, bankId)
             }
         }
 

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -28,6 +28,15 @@
     <string name="fee_side_summary_original">Displayed converted amount stays at mid-market; fees are shown separately as \"true cost\".</string>
     <string name="fee_side_summary_converted">Fees are baked into the displayed converted amount.</string>
     <string name="fee_empty">No fees yet</string>
+    <string name="fee_edit_name">Name</string>
+    <string name="fee_edit_name_hint">e.g. Wise, Revolut, Chase</string>
+    <string name="fee_edit_active">Active</string>
+    <string name="fee_inactive_marker">Inactive</string>
+    <string name="fee_untitled">Untitled</string>
+    <string name="fee_active_exchange_title">Active exchange</string>
+    <string name="fee_active_bank_title">Active bank/card</string>
+    <string name="fee_active_none">None</string>
+    <string name="fee_active_auto">%s (auto)</string>
     <string name="previewConversion_key" translatable="false">KEY_PREVIEW_CONVERSION</string>
     <string name="previewConversion_title">Conversion preview</string>
     <string name="previewConversion_summary">Show the current conversion for each rate in the currency picker.</string>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -33,10 +33,6 @@
     <string name="fee_edit_active">Active</string>
     <string name="fee_inactive_marker">Inactive</string>
     <string name="fee_untitled">Untitled</string>
-    <string name="fee_active_exchange_title">Active exchange</string>
-    <string name="fee_active_bank_title">Active bank/card</string>
-    <string name="fee_active_none">None</string>
-    <string name="fee_active_auto">%s (auto)</string>
     <string name="previewConversion_key" translatable="false">KEY_PREVIEW_CONVERSION</string>
     <string name="previewConversion_title">Conversion preview</string>
     <string name="previewConversion_summary">Show the current conversion for each rate in the currency picker.</string>

--- a/app/src/test/kotlin/com/eliormachlev/currencix/model/FeeCalculatorTest.kt
+++ b/app/src/test/kotlin/com/eliormachlev/currencix/model/FeeCalculatorTest.kt
@@ -13,13 +13,29 @@ class FeeCalculatorTest {
         id: String,
         percent: String,
         markup: Boolean = true,
-    ) = Fee.GlobalExchange(id = id, percent = bd(percent), isMarkup = markup)
+        isActive: Boolean = true,
+        name: String = "",
+    ) = Fee.GlobalExchange(
+        id = id,
+        name = name,
+        percent = bd(percent),
+        isMarkup = markup,
+        isActive = isActive,
+    )
 
     private fun globalBank(
         id: String,
         percent: String,
         markup: Boolean = true,
-    ) = Fee.GlobalBank(id = id, percent = bd(percent), isMarkup = markup)
+        isActive: Boolean = true,
+        name: String = "",
+    ) = Fee.GlobalBank(
+        id = id,
+        name = name,
+        percent = bd(percent),
+        isMarkup = markup,
+        isActive = isActive,
+    )
 
     private fun pair(
         id: String,
@@ -28,13 +44,17 @@ class FeeCalculatorTest {
         to: String,
         bothWays: Boolean = false,
         markup: Boolean = true,
+        isActive: Boolean = true,
+        name: String = "",
     ) = Fee.SpecificPair(
         id = id,
+        name = name,
         percent = bd(percent),
         isMarkup = markup,
         from = from,
         to = to,
         bothWays = bothWays,
+        isActive = isActive,
     )
 
     private fun near(
@@ -149,5 +169,95 @@ class FeeCalculatorTest {
         val stack = FeeCalculator.totalStack(fees, Currency.USD, Currency.EUR)
         // 1 + 0.1/100 = 1.001 exactly
         assertEquals(0, stack.round(MathContext.DECIMAL128).compareTo(bd("1.001")))
+    }
+
+    @Test
+    fun `inactive fees are skipped entirely`() {
+        val fees =
+            listOf(
+                globalExchange("g", "2", isActive = false),
+                globalBank("b", "1", isActive = false),
+                pair("p", "3", from = "USD", to = "EUR", isActive = false),
+            )
+        assertEquals(
+            0,
+            FeeCalculator.totalStack(fees, Currency.USD, Currency.EUR).compareTo(BigDecimal.ONE),
+        )
+    }
+
+    @Test
+    fun `active picker selects one of several global exchange fees`() {
+        val fees =
+            listOf(
+                globalExchange("wise", "2"),
+                globalExchange("revolut", "5"),
+            )
+        // Wise picked → 1.02 (not multiplicative 1.02 * 1.05 = 1.071)
+        near("1.02", FeeCalculator.totalStack(fees, null, null, activeExchangeId = "wise"))
+        near("1.05", FeeCalculator.totalStack(fees, null, null, activeExchangeId = "revolut"))
+    }
+
+    @Test
+    fun `active picker falls back to first active when id is null`() {
+        val fees =
+            listOf(
+                globalExchange("wise", "2"),
+                globalExchange("revolut", "5"),
+            )
+        near("1.02", FeeCalculator.totalStack(fees, null, null, activeExchangeId = null))
+    }
+
+    @Test
+    fun `active picker skips inactive matches then falls back`() {
+        val fees =
+            listOf(
+                globalExchange("wise", "2", isActive = false),
+                globalExchange("revolut", "5"),
+            )
+        // Picking the inactive one still falls through to the first *active* entry.
+        near("1.05", FeeCalculator.totalStack(fees, null, null, activeExchangeId = "wise"))
+    }
+
+    @Test
+    fun `active picker id that doesn't exist falls back to first active`() {
+        val fees =
+            listOf(
+                globalExchange("wise", "2"),
+                globalExchange("revolut", "5"),
+            )
+        near("1.02", FeeCalculator.totalStack(fees, null, null, activeExchangeId = "ghost"))
+    }
+
+    @Test
+    fun `single active bank picker independent of exchange picker`() {
+        val fees =
+            listOf(
+                globalExchange("wise", "2"),
+                globalExchange("revolut", "5"),
+                globalBank("chase", "1"),
+                globalBank("amex", "3"),
+            )
+        // wise (1.02) * amex (1.03) = 1.0506
+        near(
+            "1.0506",
+            FeeCalculator.totalStack(
+                fees,
+                null,
+                null,
+                activeExchangeId = "wise",
+                activeBankId = "amex",
+            ),
+        )
+    }
+
+    @Test
+    fun `specific-pair fees still stack together regardless of picker`() {
+        val fees =
+            listOf(
+                pair("p1", "2", from = "USD", to = "EUR"),
+                pair("p2", "1", from = "USD", to = "EUR"),
+            )
+        // both apply: 1.02 * 1.01 = 1.0302
+        near("1.0302", FeeCalculator.totalStack(fees, Currency.USD, Currency.EUR))
     }
 }


### PR DESCRIPTION
## Summary

Extends the fee mechanism so users can organize their fees like real-world providers:

- **Named entries.** Every `GlobalExchange`, `GlobalBank`, and `SpecificPair` fee carries a user-authored `name` (e.g. "Wise", "Revolut", "Chase") — appears in the fee list and the picker dialogs.
- **Active toggle.** Each entry has an `isActive` flag; inactive fees are skipped without being deleted, so users can temporarily silence a fee they still want to keep configured.
- **Single-select picker.** For the two "global" categories, users pick which named entry participates in the fee stack — no more silent double-stacking when they've configured multiple providers. Specific-pair fees continue to stack (they're always disjoint by pair).

Compound math (`+50` and `-2` → `+47`) is unchanged and intentional — multiplicative stacking is how real bank + exchange fees actually chain.

## Migration

- Legacy fee rows deserialize with `isActive=true` and `name=""` — no behavior change for anyone with a single global exchange or bank fee.
- Users who had two or more stacked global fees will see only the first apply going forward. The new picker lets them switch which one, or they can mark the extras inactive to keep them for later.
- The two new prefs live in the existing `PREFS_APP` namespace and are dumped/restored by `BackupManager` automatically — no schema bump.

## Test plan

- [ ] `./gradlew check assembleFdroidDebug` passes on CI
- [ ] With one exchange fee: main screen still shows the same effective %
- [ ] Add a second exchange fee → new "Active exchange" row appears in settings
- [ ] Toggle a fee inactive in the edit dialog → main-screen fee stack drops it
- [ ] Restore a pre-upgrade backup → fees load with names blank and `isActive=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)