### PR TITLE
fix(share): use typed amount and fee-aware result in share text

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -209,8 +209,7 @@ class MainActivity : BaseActivity() {
     }
 
     private fun shareCurrentConversion() {
-        val conversion = tvInfoConversion.text?.toString().orEmpty()
-        if (conversion.isBlank()) return
+        val conversion = buildShareConversion() ?: return
         val footer = buildShareFooter(viewModel.getExchangeRates().value)
         val text = if (footer != null) "$conversion\n-- $footer" else conversion
         val intent =
@@ -219,6 +218,47 @@ class MainActivity : BaseActivity() {
                 putExtra(Intent.EXTRA_TEXT, text)
             }
         startActivity(Intent.createChooser(intent, null))
+    }
+
+    // Compose the shared conversion line from the on-screen values so it
+    // honors the currently typed amount and the active fee stack (matching
+    // what the user sees), rather than the "1 base ≈ result" info footer
+    // which is always unit-scaled and fee-free.
+    private fun buildShareConversion(): String? {
+        val base = viewModel.getBaseCurrency().value ?: return null
+        val dest = viewModel.getDestinationCurrency().value ?: return null
+        val rates = viewModel.getExchangeRates().value?.rates ?: return null
+        if (rates.none { it.currency == base } || rates.none { it.currency == dest }) return null
+        val amount = viewModel.getCurrentBaseValueAsNumber().value ?: BigDecimal.ZERO
+        val result = viewModel.getResultAsNumber().value ?: BigDecimal.ZERO
+        val places = viewModel.getDecimalPlaces().value ?: AMOUNT_DECIMAL_PLACES
+        val main =
+            getString(
+                R.string.info_conversion,
+                amount.toHumanReadableNumber(this, trim = true, decimalPlaces = places),
+                base.iso4217Alpha(),
+                result.toHumanReadableNumber(this, trim = true, decimalPlaces = places),
+                dest.iso4217Alpha(),
+            )
+        val extra = buildShareFeeExtra(base, dest)
+        return if (extra != null) "$main\n$extra" else main
+    }
+
+    // "True cost" (ORIGINAL side) or "Original value" (CONVERTED side) line —
+    // mirrors the small annotation shown under the result when a fee applies.
+    private fun buildShareFeeExtra(
+        base: Currency,
+        dest: Currency,
+    ): String? {
+        viewModel.getTrueCost().value?.let { trueCost ->
+            return getString(R.string.fee_true_cost_prefix) +
+                ltrIsolate("${trueCost.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)} ${base.iso4217Alpha()}")
+        }
+        viewModel.getOriginalValue().value?.let { originalValue ->
+            return getString(R.string.fee_original_value_prefix) +
+                ltrIsolate("${originalValue.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)} ${dest.iso4217Alpha()}")
+        }
+        return null
     }
 
     private fun buildShareFooter(rates: ExchangeRates?): String? {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -250,13 +250,11 @@ class MainActivity : BaseActivity() {
         base: Currency,
         dest: Currency,
     ): String? {
-        viewModel.getTrueCost().value?.let { trueCost ->
-            return getString(R.string.fee_true_cost_prefix) +
-                ltrIsolate("${trueCost.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)} ${base.iso4217Alpha()}")
+        viewModel.getTrueCost().value?.let {
+            return buildFeeAmountLine(R.string.fee_true_cost_prefix, it, base)
         }
-        viewModel.getOriginalValue().value?.let { originalValue ->
-            return getString(R.string.fee_original_value_prefix) +
-                ltrIsolate("${originalValue.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)} ${dest.iso4217Alpha()}")
+        viewModel.getOriginalValue().value?.let {
+            return buildFeeAmountLine(R.string.fee_original_value_prefix, it, dest)
         }
         return null
     }
@@ -535,9 +533,20 @@ class MainActivity : BaseActivity() {
             target.visibility = View.GONE
             return
         }
-        val amount = value.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)
-        target.text = getString(prefixRes) + ltrIsolate("$amount ${currency?.iso4217Alpha().orEmpty()}")
+        target.text = buildFeeAmountLine(prefixRes, value, currency)
         target.visibility = View.VISIBLE
+    }
+
+    // "<prefix><amount> <ISO>" with the amount+ISO isolated LTR so a
+    // right-aligned prefix in an RTL locale doesn't flip the number/code
+    // pair. Shared by the on-screen fee annotations and the share sheet.
+    private fun buildFeeAmountLine(
+        prefixRes: Int,
+        value: BigDecimal,
+        currency: Currency?,
+    ): String {
+        val amount = value.toHumanReadableNumber(this, decimalPlaces = AMOUNT_DECIMAL_PLACES)
+        return getString(prefixRes) + ltrIsolate("$amount ${currency?.iso4217Alpha().orEmpty()}")
     }
 
     private fun observeExchangeRates(rates: ExchangeRates?) {


### PR DESCRIPTION
Closes #94.

## Summary
- `shareCurrentConversion` was reading the on-screen info footer (`tvInfoConversion`), which is always the unit-scaled, fee-free `"1 base ≈ result"` line — so Share always produced `1 USD ≈ 0.85 EUR` regardless of the typed amount or active fees.
- Rebuild the share line from the same LiveData the main screen already renders: typed base amount + fee-aware converted result + current decimal-places preference.
- When a fee stack applies, append the same "True cost" / "Original value" annotation shown under the result. Which one is appended follows the active Fee Side toggle (`getTrueCost` for ORIGINAL, `getOriginalValue` for CONVERTED).

## Test plan
- [ ] USD → ILS, no fees, type `100` → Share sheet text starts with `100 USD ≈ … ILS` (not `1 USD`).
- [ ] Same, then configure an active global exchange fee → shared text reflects the fee-adjusted converted amount and appends `True cost: …` (ORIGINAL side) or `Original value: …` (CONVERTED side).
- [ ] Empty input → text uses `0` on both sides (or, if base/dest not resolved yet, share is a no-op).
- [ ] Footer `-- Based on <provider>, <date>` still appended when rates carry provider + timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)