### PR TITLE
Cart: keep totals card pinned to the bottom when the keypad opens (fixes #96)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -845,13 +845,21 @@ class CartActivity : BaseActivity() {
     // focus while the app keypad is open), dismiss the app keypad. Rising-edge
     // tracking via [systemImeVisible] avoids retriggering `closeKeypad` on
     // redundant inset dispatches while the IME stays visible.
+    //
+    // Installing our own listener on cart_root disables its `fitsSystemWindows`
+    // auto-padding (that's how the view API works — a custom listener takes
+    // over), so we re-apply the system-bar insets as padding ourselves. Without
+    // this the toolbar slides under the status bar.
     private fun installImeVisibilityGuard() {
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.cart_root)) { _, insets ->
+        val root = findViewById<View>(R.id.cart_root)
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
             val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
             if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
                 closeKeypad()
             }
             systemImeVisible = imeVisible
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
             insets
         }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -23,6 +23,8 @@ import androidx.appcompat.widget.AppCompatImageButton
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -145,6 +147,12 @@ class CartActivity : BaseActivity() {
     private var activeStateObserver: Observer<String?>? = null
     private var keypadBackCallback: OnBackPressedCallback? = null
 
+    // Tracks the last observed IME visibility so the WindowInsets listener
+    // only reacts to rising edges — a name-field focus that opens the system
+    // keyboard should dismiss the app keypad, but repeated inset dispatches
+    // while the IME is already visible shouldn't retrigger `closeKeypad`.
+    private var systemImeVisible = false
+
     // Pending, un-debounced name edits from the composable rows. Flushed
     // synchronously by [flushPendingCommits] before any save/share/snapshot.
     private val pendingNames = mutableMapOf<String, String>()
@@ -193,6 +201,19 @@ class CartActivity : BaseActivity() {
         this.keypadRegular = findViewById(R.id.cart_keypad_regular)
         this.keypadExtended = findViewById(R.id.cart_keypad_extended)
         this.contentColumn = findViewById(R.id.cart_content)
+
+        // Only one keyboard should be visible at a time: if the system IME
+        // rises (e.g. the user tapped a row's name field while the app keypad
+        // was open), dismiss the app keypad. The reverse direction is already
+        // handled inside `openKeypadFor`, which calls `hideSystemIme`.
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.cart_root)) { _, insets ->
+            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+            if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
+                closeKeypad()
+            }
+            systemImeVisible = imeVisible
+            insets
+        }
 
         // Registered before the keypad callback so the keypad's (which is
         // added second) wins when it's enabled. When the keypad is closed

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -147,10 +147,7 @@ class CartActivity : BaseActivity() {
     private var activeStateObserver: Observer<String?>? = null
     private var keypadBackCallback: OnBackPressedCallback? = null
 
-    // Tracks the last observed IME visibility so the WindowInsets listener
-    // only reacts to rising edges — a name-field focus that opens the system
-    // keyboard should dismiss the app keypad, but repeated inset dispatches
-    // while the IME is already visible shouldn't retrigger `closeKeypad`.
+    // Rising-edge latch for the IME-visibility guard; see [installImeVisibilityGuard].
     private var systemImeVisible = false
 
     // Pending, un-debounced name edits from the composable rows. Flushed
@@ -201,19 +198,7 @@ class CartActivity : BaseActivity() {
         this.keypadRegular = findViewById(R.id.cart_keypad_regular)
         this.keypadExtended = findViewById(R.id.cart_keypad_extended)
         this.contentColumn = findViewById(R.id.cart_content)
-
-        // Only one keyboard should be visible at a time: if the system IME
-        // rises (e.g. the user tapped a row's name field while the app keypad
-        // was open), dismiss the app keypad. The reverse direction is already
-        // handled inside `openKeypadFor`, which calls `hideSystemIme`.
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.cart_root)) { _, insets ->
-            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-            if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
-                closeKeypad()
-            }
-            systemImeVisible = imeVisible
-            insets
-        }
+        installImeVisibilityGuard()
 
         // Registered before the keypad callback so the keypad's (which is
         // added second) wins when it's enabled. When the keypad is closed
@@ -853,6 +838,23 @@ class CartActivity : BaseActivity() {
     // `closeKeypad`; every keypad button routes through the reflection
     // targets below.
     // ------------------------------------------------------------------
+
+    // Only one keyboard should be visible at a time. `openKeypadFor` calls
+    // `hideSystemIme` when opening the app keypad; this listener handles the
+    // reverse — when the system IME rises (e.g. a row's name field takes
+    // focus while the app keypad is open), dismiss the app keypad. Rising-edge
+    // tracking via [systemImeVisible] avoids retriggering `closeKeypad` on
+    // redundant inset dispatches while the IME stays visible.
+    private fun installImeVisibilityGuard() {
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.cart_root)) { _, insets ->
+            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+            if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
+                closeKeypad()
+            }
+            systemImeVisible = imeVisible
+            insets
+        }
+    }
 
     /**
      * Show the keypad for the row identified by [itemId], seeding a fresh

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -874,10 +874,11 @@ class CartActivity : BaseActivity() {
             .translationY(0f)
             .setDuration(KEYPAD_ANIM_MS)
             .start()
-        // Mirror the system-IME resize behaviour: pad the content column by the
-        // keypad's height so the totals card slides above it instead of being
-        // hidden underneath.
-        setContentBottomInsetToKeypad()
+        // Leave the totals card / add-item button pinned to the bottom of the
+        // screen (behind the keypad) and only inset the items list so its
+        // Compose content stops at the keypad's top edge instead of rendering
+        // underneath. Keeps the summary from being pushed above the keypad.
+        setItemsBottomInsetForKeypad()
     }
 
     private fun hideKeypad() {
@@ -889,32 +890,36 @@ class CartActivity : BaseActivity() {
             .setDuration(KEYPAD_ANIM_MS)
             .withEndAction { keypadContainer.visibility = View.GONE }
             .start()
-        contentColumn.setPadding(
-            contentColumn.paddingLeft,
-            contentColumn.paddingTop,
-            contentColumn.paddingRight,
-            0,
-        )
+        setItemsBottomInset(0)
     }
 
-    private fun setContentBottomInsetToKeypad() {
+    private fun setItemsBottomInsetForKeypad() {
         val apply = {
-            val h =
+            val keypadH =
                 keypadContainer.height.takeIf { it > 0 }
                     ?: keypadContainer.layoutParams.height
-            contentColumn.setPadding(
-                contentColumn.paddingLeft,
-                contentColumn.paddingTop,
-                contentColumn.paddingRight,
-                h,
-            )
+            // keypad is anchored to the bottom of cart_root; cart_content fills
+            // the same area, so its own height is our reference. The overlap
+            // is the amount by which the items view extends behind the keypad
+            // once the fixed footer (add button + totals card) has taken its
+            // own space at the bottom.
+            val overlap = itemsView.bottom - (contentColumn.height - keypadH)
+            setItemsBottomInset(overlap.coerceAtLeast(0))
         }
-        // If the keypad hasn't laid out yet (first open), wait one pass.
-        if (keypadContainer.height > 0) {
+        if (keypadContainer.height > 0 && itemsView.height > 0) {
             apply()
         } else {
             keypadContainer.post(apply)
         }
+    }
+
+    private fun setItemsBottomInset(bottom: Int) {
+        itemsView.setPadding(
+            itemsView.paddingLeft,
+            itemsView.paddingTop,
+            itemsView.paddingRight,
+            bottom,
+        )
     }
 
     private fun detachActiveField() {


### PR DESCRIPTION
## Summary
- Fixes #96. Tapping a cart row's value used to push the entire cart column upward so the add-item button + totals card sat above the keypad, crushing the item list into a sliver at the top.
- Root cause: `setContentBottomInsetToKeypad` added `keypadContainer.height` as bottom padding to the whole `cart_content` LinearLayout, so every child (items list *and* the fixed footer) got lifted.
- New behavior: leave the fixed footer where it is (behind the keypad) and pad only the items `ComposeView` by the actual overlap between its layout bottom and the keypad's top. The LazyColumn stops exactly at the keypad edge, no rows render behind the keypad, and the summary stays pinned to the bottom.

## Test plan
- [ ] Open Shopping cart with several items.
- [ ] Tap an item's value — the keypad slides up over the totals card / add-item button; those don't jump upward.
- [ ] The item list still occupies the space between the toolbar and the top of the keypad; scrolling reveals rows that were previously hidden.
- [ ] Close the keypad (back-press or outside tap) — items list returns to its full height and the totals card is visible again.
- [ ] Toggle the extended keypad (`.` long-press or wherever the switch is) — no visual glitches on the items area since both keypad variants share the same 320dp container height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)