### PR TITLE
fix(picker): grey out same-currency on opposite side (fixes #97)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -329,8 +329,16 @@ class CartActivity : BaseActivity() {
             activeItemId.value?.let { if (it !in currentIds) closeKeypad() }
             updateFeeVisuals()
         }
-        viewModel.getBaseCurrency().observe(this) { spinnerFrom.setSelection(it) }
-        viewModel.getDestinationCurrency().observe(this) { spinnerTo.setSelection(it) }
+        viewModel.getBaseCurrency().observe(this) {
+            spinnerFrom.setSelection(it)
+            // Keep the two sides distinct — grey out whatever's picked on
+            // the base side inside the destination picker.
+            spinnerTo.setDisabledCurrency(it)
+        }
+        viewModel.getDestinationCurrency().observe(this) {
+            spinnerTo.setSelection(it)
+            spinnerFrom.setDisabledCurrency(it)
+        }
         viewModel.getSubtotal().observe(this) { value ->
             subtotalLabel.text = formatAmount(value, viewModel.getBaseCurrency().value)
             updateFeeExtras()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -603,12 +603,16 @@ class MainActivity : BaseActivity() {
 
     private fun observeBaseCurrency(currency: Currency?) {
         spinnerFrom.setSelection(currency)
+        // Whatever's picked on the base side must not be pickable on the
+        // destination side — grey it out in the "to" picker.
+        spinnerTo.setDisabledCurrency(currency)
         currency ?: return
         findRateFor(currency)?.let { spinnerTo.setCurrentRate(Rate(currency, it)) }
     }
 
     private fun observeDestinationCurrency(currency: Currency?) {
         spinnerTo.setSelection(currency)
+        spinnerFrom.setDisabledCurrency(currency)
         currency ?: return
         findRateFor(currency)?.let { spinnerFrom.setCurrentRate(Rate(currency, it)) }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -73,6 +73,12 @@ private const val ROW_MIN_HEIGHT_DP = 56
 private const val DRAG_ELEVATION_ALPHA = 0.85f
 private const val API_HINT_ALPHA = 0.7f
 
+// Alpha for a currency row that can't be picked in the current context
+// (e.g. it's already selected on the opposite side of the same pair, so
+// picking it here would produce a same-currency conversion). Same weight as
+// [API_HINT_ALPHA] so disabled rows read as ambient, not error.
+private const val DISABLED_ROW_ALPHA = 0.4f
+
 internal data class CurrencyPickerConversion(
     val baseRate: Rate,
     val baseSum: BigDecimal,
@@ -80,11 +86,13 @@ internal data class CurrencyPickerConversion(
 )
 
 @Composable
+@Suppress("LongParameterList")
 internal fun SearchableCurrencyPicker(
     rates: List<Rate>,
     stars: List<Currency>,
     filterStarred: Boolean,
     conversion: CurrencyPickerConversion?,
+    disabledCurrency: Currency?,
     onRateClicked: (Rate) -> Unit,
     onStarClicked: (Rate) -> Unit,
     onToggleStarredFilter: () -> Unit,
@@ -128,6 +136,7 @@ internal fun SearchableCurrencyPicker(
             nonStarredItems = nonStarredFiltered,
             conversion = conversion,
             allowReorder = allowReorder,
+            disabledCurrency = disabledCurrency,
             modifier = Modifier.weight(1f).fillMaxWidth(),
             onRateClicked = onRateClicked,
             onStarClicked = onStarClicked,
@@ -226,6 +235,7 @@ private fun CurrencyList(
     nonStarredItems: List<Rate>,
     conversion: CurrencyPickerConversion?,
     allowReorder: Boolean,
+    disabledCurrency: Currency?,
     modifier: Modifier = Modifier,
     onRateClicked: (Rate) -> Unit,
     onStarClicked: (Rate) -> Unit,
@@ -255,6 +265,7 @@ private fun CurrencyList(
                     items = starredItems,
                     conversion = conversion,
                     allowReorder = allowReorder,
+                    disabledCurrency = disabledCurrency,
                     onRateClicked = onRateClicked,
                     onStarClicked = onStarClicked,
                     onDragEnded = onDragEnded,
@@ -266,6 +277,7 @@ private fun CurrencyList(
                 rate = rate,
                 isStarred = false,
                 conversion = conversion,
+                isDisabled = rate.currency == disabledCurrency,
                 onClick = { onRateClicked(rate) },
                 onStarClick = { onStarClicked(rate) },
                 modifier = Modifier.fillMaxWidth().animateItem(),
@@ -283,6 +295,7 @@ private fun FavoritesSection(
     items: SnapshotStateList<Rate>,
     conversion: CurrencyPickerConversion?,
     allowReorder: Boolean,
+    disabledCurrency: Currency?,
     onRateClicked: (Rate) -> Unit,
     onStarClicked: (Rate) -> Unit,
     onDragEnded: () -> Unit,
@@ -311,6 +324,7 @@ private fun FavoritesSection(
                     rate = rate,
                     isStarred = true,
                     conversion = conversion,
+                    isDisabled = rate.currency == disabledCurrency,
                     onClick = { onRateClicked(rate) },
                     onStarClick = { onStarClicked(rate) },
                     modifier =
@@ -372,10 +386,12 @@ private fun FavoritesSection(
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun CurrencyRow(
     rate: Rate,
     isStarred: Boolean,
     conversion: CurrencyPickerConversion?,
+    isDisabled: Boolean,
     onClick: () -> Unit,
     onStarClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -386,7 +402,10 @@ private fun CurrencyRow(
     // and dismissed the dialog. Split the click regions: the flag+text area
     // is the dismiss-on-select target, the star's own IconButton is a
     // separate target that only toggles. Drag modifier still lives on the
-    // outer Row via `modifier`.
+    // outer Row via `modifier`. When [isDisabled] the flag+text region is
+    // greyed and unclickable (typically because the same currency is already
+    // selected on the opposite side of the pair), but the star toggle stays
+    // interactive — favoriting is independent of picker selection.
     Row(
         modifier = modifier.heightIn(min = ROW_MIN_HEIGHT_DP.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -395,7 +414,8 @@ private fun CurrencyRow(
             modifier =
                 Modifier
                     .weight(1f)
-                    .clickable(onClick = onClick)
+                    .clickable(enabled = !isDisabled, onClick = onClick)
+                    .alpha(if (isDisabled) DISABLED_ROW_ALPHA else 1f)
                     .padding(
                         horizontal = dimensionResource(id = R.dimen.margin2x),
                         vertical = dimensionResource(id = R.dimen.margin1x),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
@@ -96,6 +96,13 @@ class SearchableSpinner : AppCompatSpinner {
         spinnerDialog.setCurrentSum(currentSum)
     }
 
+    // Currency that should be greyed out and unselectable in this spinner's
+    // picker — used to keep the two sides of a pair distinct. Callers push
+    // the opposite side's current selection whenever it changes.
+    fun setDisabledCurrency(currency: Currency?) {
+        spinnerDialog.setDisabledCurrency(currency)
+    }
+
     private fun findActivity(context: Context?): FragmentActivity? =
         when (context) {
             is FragmentActivity -> context

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
+import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
 import com.eliormachlev.currencix.view.compose.AppTheme
@@ -30,12 +31,22 @@ class SearchableSpinnerDialog(
     private val currentRateState = mutableStateOf<Rate?>(null)
     private val currentSumState = mutableStateOf(BigDecimal.ONE)
 
+    // Currency that must not be selectable in this picker instance — grey
+    // out and disable clicks on the matching row. Used to prevent picking
+    // the same currency as the opposite side of the pair (main screen, cart,
+    // and fee-manager specific-pair pickers).
+    private val disabledCurrencyState = mutableStateOf<Currency?>(null)
+
     fun setCurrentRate(currentRate: Rate) {
         currentRateState.value = currentRate
     }
 
     fun setCurrentSum(currentSum: BigDecimal) {
         currentSumState.value = currentSum
+    }
+
+    fun setDisabledCurrency(currency: Currency?) {
+        disabledCurrencyState.value = currency
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -83,6 +94,7 @@ class SearchableSpinnerDialog(
                             stars = stars.orEmpty(),
                             filterStarred = filterStarred,
                             conversion = conversion,
+                            disabledCurrency = disabledCurrencyState.value,
                             onRateClicked = { rate ->
                                 onRateClicked?.invoke(rate, rates?.rates?.indexOf(rate) ?: -1)
                                 dismiss()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -612,9 +612,24 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
         val nameInput = buildNameInput(ctx, existing?.name)
         val fromLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_from) }
-        val fromButton = buildCurrencyPickerButton(ctx, pickedFrom, placeholder) { pickedFrom = it }
+        val fromButton =
+            buildCurrencyPickerButton(
+                ctx,
+                pickedFrom,
+                placeholder,
+                // Opposite side's current pick — greyed out in this picker so
+                // the user can't save a same-currency specific-pair fee (e.g.
+                // AUD → AUD is meaningless).
+                disabled = { pickedTo },
+            ) { pickedFrom = it }
         val toLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_to) }
-        val toButton = buildCurrencyPickerButton(ctx, pickedTo, placeholder) { pickedTo = it }
+        val toButton =
+            buildCurrencyPickerButton(
+                ctx,
+                pickedTo,
+                placeholder,
+                disabled = { pickedFrom },
+            ) { pickedTo = it }
         val bothWays =
             CheckBox(ctx).apply {
                 text = getString(R.string.fee_pair_both_ways)
@@ -726,20 +741,28 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         ctx: Context,
         initial: String?,
         placeholder: String,
+        disabled: () -> String? = { null },
         onPicked: (String) -> Unit,
     ): MaterialButton =
         outlinedMaterialButton(ctx).apply {
             applyCurrencyIcon(this, initial, placeholder, ctx)
             setOnClickListener {
-                openCurrencyPicker { iso ->
+                // Resolve the disabled side lazily at click time so a "from"
+                // picked *after* the button was built still greys out inside
+                // the "to" picker (and vice-versa).
+                openCurrencyPicker(disabled = disabled()?.let(Currency::fromString)) { iso ->
                     applyCurrencyIcon(this, iso, placeholder, ctx)
                     onPicked(iso)
                 }
             }
         }
 
-    private fun openCurrencyPicker(onPicked: (String) -> Unit) {
+    private fun openCurrencyPicker(
+        disabled: Currency? = null,
+        onPicked: (String) -> Unit,
+    ) {
         val dialog = SearchableSpinnerDialog(requireContext())
+        dialog.setDisabledCurrency(disabled)
         dialog.onRateClicked = { rate, _ -> onPicked(rate.currency.iso4217Alpha()) }
         dialog.show(parentFragmentManager, null)
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -197,6 +197,7 @@ class MainViewModel(
             object : MediatorLiveData<Currency?>() {
                 var destination: Currency? = null
                 var rates: ExchangeRates? = null
+                var base: Currency? = null
 
                 init {
                     addSource(destinationCurrency) {
@@ -207,14 +208,30 @@ class MainViewModel(
                         rates = it
                         update()
                     }
+                    // Cross-observe the resolved base so a stale-prefs
+                    // collision (both sides pointing at the same currency on
+                    // first read after an install/migration/import) is
+                    // corrected to a distinct fallback on the destination
+                    // side. The grey-out picker prevents users from ever
+                    // creating this state; this is the belt-and-braces
+                    // safety net for state loaded from disk.
+                    addSource(currentBaseCurrency) {
+                        base = it
+                        update()
+                    }
                 }
 
                 private fun update() {
+                    val available = rates?.rates ?: return
+                    val stored = available.find { it.currency == destination }?.currency
+                    val fallback = available.firstOrNull()?.currency
+                    val picked = stored ?: fallback
                     this.value =
-                        // last used is present in the current currency set
-                        rates?.rates?.find { it.currency == destination }?.currency
-                            // not present, so just return the first of the set
-                            ?: rates?.rates?.firstOrNull()?.currency
+                        if (picked != null && picked == base) {
+                            available.firstOrNull { it.currency != base }?.currency ?: picked
+                        } else {
+                            picked
+                        }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Grey out and disable the row for the opposite side's currency in the currency picker on the main screen, cart, and specific-pair fee dialog. Star toggle stays interactive.
- Wire the greyed-out currency through `SearchableSpinner` / `SearchableSpinnerDialog` into the picker Composable (`SearchableCurrencyPicker`) via a new `disabledCurrency: Currency?` param.
- In `FeeManagerFragment`, the disabled currency is resolved lazily at click time so a "from" picked *after* the button is built greys out inside the "to" picker (and vice-versa).
- Belt-and-braces: `MainViewModel.currentDestinationCurrency` now cross-observes `currentBaseCurrency` and falls back to the first different currency if a stale persisted destination collides with the base on load.

## Test plan
- [ ] Fresh install: base and destination default to two different currencies on the main screen.
- [ ] Main screen: opening the "to" picker greys out the currency currently selected on the "from" side (and vice-versa), and tapping the greyed row does nothing.
- [ ] Cart: same behaviour across both spinners.
- [ ] Fee manager → specific-pair dialog: picking a "from" currency greys it out in the "to" picker (and vice-versa), so you cannot save a same-currency specific-pair fee.
- [ ] Star icon on the greyed row still toggles favorite state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)