### PR TITLE
Anchor chart min/max lines to visible range (fixes #112)

### DIFF
--- a/.github/workflows/detekt.yaml
+++ b/.github/workflows/detekt.yaml
@@ -26,7 +26,8 @@ jobs:
           distribution: temurin
       - name: Install detekt CLI
         run: |
-          curl -sSLo detekt-cli.zip \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            -o detekt-cli.zip \
             "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}.zip"
           unzip -q detekt-cli.zip
           echo "$PWD/detekt-cli-${DETEKT_VERSION}/bin" >> "$GITHUB_PATH"

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
@@ -104,10 +104,11 @@ class TimelineActivity : BaseActivity() {
                         timelineModel.getRates().map { rates ->
                             rates?.entries?.map { entry -> entry.key to entry.value.value.toFloat() }
                         }
-                    val highlightMinLive =
-                        timelineModel.getRatesMin().map { it.first?.value?.toDouble() }
-                    val highlightMaxLive =
-                        timelineModel.getRatesMax().map { it.first?.value?.toDouble() }
+                    // Range extremes (scrub-independent) so the chart's min/max
+                    // reference lines stay pinned to the visible period's
+                    // absolute low/high while the finger drags.
+                    val highlightMinLive = timelineModel.getRatesRangeMin()
+                    val highlightMaxLive = timelineModel.getRatesRangeMax()
                     TimelineChart(
                         entriesLive = entriesLive,
                         showGridLive = db.isChartGridEnabled(),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -261,11 +261,21 @@ class TimelineViewModel(
             }
         }
 
-    fun getRatesMin(): LiveData<Triple<Rate?, LocalDate?, Int>> = extremeLiveData(pickMax = false)
+    fun getRatesMin(): LiveData<Triple<Rate?, LocalDate?, Int>> = extremeLiveData(pickMax = false, respectScrub = true)
 
-    fun getRatesMax(): LiveData<Triple<Rate?, LocalDate?, Int>> = extremeLiveData(pickMax = true)
+    fun getRatesMax(): LiveData<Triple<Rate?, LocalDate?, Int>> = extremeLiveData(pickMax = true, respectScrub = true)
 
-    private fun extremeLiveData(pickMax: Boolean): LiveData<Triple<Rate?, LocalDate?, Int>> =
+    // Range-wide extremes for the on-chart reference lines: intentionally
+    // ignore the scrub position so the horizontal min/max lines stay anchored
+    // to the visible period's absolute extremes while the finger drags.
+    fun getRatesRangeMin(): LiveData<Double?> = extremeLiveData(pickMax = false, respectScrub = false).map { it.first?.value?.toDouble() }
+
+    fun getRatesRangeMax(): LiveData<Double?> = extremeLiveData(pickMax = true, respectScrub = false).map { it.first?.value?.toDouble() }
+
+    private fun extremeLiveData(
+        pickMax: Boolean,
+        respectScrub: Boolean,
+    ): LiveData<Triple<Rate?, LocalDate?, Int>> =
         MediatorLiveData<Triple<Rate?, LocalDate?, Int>>().apply {
             var scrubDate: LocalDate? = null
             var rates: Set<Map.Entry<LocalDate, Rate?>>? = null
@@ -289,9 +299,11 @@ class TimelineViewModel(
                 update()
             }
 
-            addSource(scrubDateLiveData) {
-                scrubDate = it
-                update()
+            if (respectScrub) {
+                addSource(scrubDateLiveData) {
+                    scrubDate = it
+                    update()
+                }
             }
 
             addSource(getDecimalPlaces()) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -268,9 +268,12 @@ class TimelineViewModel(
     // Range-wide extremes for the on-chart reference lines: intentionally
     // ignore the scrub position so the horizontal min/max lines stay anchored
     // to the visible period's absolute extremes while the finger drags.
-    fun getRatesRangeMin(): LiveData<Double?> = extremeLiveData(pickMax = false, respectScrub = false).map { it.first?.value?.toDouble() }
+    fun getRatesRangeMin(): LiveData<Double?> = rangeExtreme(pickMax = false)
 
-    fun getRatesRangeMax(): LiveData<Double?> = extremeLiveData(pickMax = true, respectScrub = false).map { it.first?.value?.toDouble() }
+    fun getRatesRangeMax(): LiveData<Double?> = rangeExtreme(pickMax = true)
+
+    private fun rangeExtreme(pickMax: Boolean): LiveData<Double?> =
+        extremeLiveData(pickMax = pickMax, respectScrub = false).map { it.first?.value?.toDouble() }
 
     private fun extremeLiveData(
         pickMax: Boolean,


### PR DESCRIPTION
## Summary
- The horizontal min/max reference lines on the timeline chart were shifting while scrubbing because they read from the scrub-aware `getRatesMin`/`getRatesMax` LiveData.
- Add scrub-independent `getRatesRangeMin`/`getRatesRangeMax` in `TimelineViewModel` and feed those into the chart's `highlightMinLive`/`highlightMaxLive`.
- Summary card values remain scrub-aware (consistent with the average row).

Fixes #112.

## Test plan
- [ ] Open a pair's graph on Year view with "Highlight min and max" enabled.
- [ ] Touch and drag the finger across the chart.
- [ ] Expected: the two horizontal reference lines stay pinned to the visible range's absolute min/max.
- [ ] Summary MAX / MIN rows still update as the scrub position moves (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)