### PR TITLE
Diacritic-insensitive language/currency picker search (fixes #103)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/TextUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/TextUtils.kt
@@ -9,6 +9,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
+import java.text.Normalizer
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -44,6 +45,12 @@ private val NUMERIC_INPUT_REGEX = Regex("[0-9,.\\s]+")
 // handing the string to NumberFormat.parse.
 private val WHITESPACE_REGEX = Regex("\\s+")
 
+// Unicode "Mark, Nonspacing" — combining diacritics that sit between/on top of
+// base letters (Hebrew niqqud, Arabic tashkeel, Latin accents after NFD, etc.).
+// Stripped for diacritic-insensitive substring search in language/currency
+// pickers so typing base letters keeps matching endonyms written with marks.
+private val NONSPACING_MARK_REGEX = Regex("\\p{Mn}+")
+
 /**
  * Parse HTML markup with `FROM_HTML_MODE_LEGACY` — the only mode used across
  * this app for lightweight `<b>`/`<br>` snippets in string resources.
@@ -69,6 +76,23 @@ fun ltrIsolate(s: String): String = "$LTR_ISOLATE$s$POP_DIRECTIONAL_ISOLATE"
  * Removes any Unicode RTL mark (U+200F) from the string.
  */
 fun String.stripRtlMark(): String = replace(RTL_MARK, "")
+
+/**
+ * Decomposes to NFD and drops combining diacritic marks so substring search
+ * matches base letters regardless of niqqud / tashkeel / accents.
+ */
+fun String.stripDiacritics(): String = Normalizer.normalize(this, Normalizer.Form.NFD).replace(NONSPACING_MARK_REGEX, "")
+
+/**
+ * Diacritic-insensitive `contains`: normalizes both sides via
+ * [stripDiacritics] before comparing. Case-insensitive by default so it's
+ * a drop-in replacement for `contains(query, ignoreCase = true)` in
+ * user-facing pickers.
+ */
+fun String.containsNormalized(
+    query: CharSequence,
+    ignoreCase: Boolean = true,
+): Boolean = stripDiacritics().contains(query.toString().stripDiacritics(), ignoreCase = ignoreCase)
 
 /**
  * Return the *used* Locale, based on the currently active resource folder,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/TextUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/TextUtils.kt
@@ -84,15 +84,13 @@ fun String.stripRtlMark(): String = replace(RTL_MARK, "")
 fun String.stripDiacritics(): String = Normalizer.normalize(this, Normalizer.Form.NFD).replace(NONSPACING_MARK_REGEX, "")
 
 /**
- * Diacritic-insensitive `contains`: normalizes both sides via
- * [stripDiacritics] before comparing. Case-insensitive by default so it's
- * a drop-in replacement for `contains(query, ignoreCase = true)` in
- * user-facing pickers.
+ * Canonical form for diacritic- and case-insensitive substring search:
+ * strip combining marks (see [stripDiacritics]) then lowercase. Both the
+ * query and each candidate string must go through this before comparing
+ * with plain `contains`; call sites should normalize the query **once**
+ * per filter pass so N candidates don't each re-normalize it.
  */
-fun String.containsNormalized(
-    query: CharSequence,
-    ignoreCase: Boolean = true,
-): Boolean = stripDiacritics().contains(query.toString().stripDiacritics(), ignoreCase = ignoreCase)
+fun String.normalizeForSearch(): String = stripDiacritics().lowercase()
 
 /**
  * Return the *used* Locale, based on the currently active resource folder,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -58,8 +58,8 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
-import com.eliormachlev.currencix.util.containsNormalized
 import com.eliormachlev.currencix.util.hasAppendedCurrencySymbol
+import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
@@ -490,34 +490,47 @@ private fun ApiHintRow() {
     }
 }
 
+// [normalizedQuery] must already be [normalizeForSearch]-ed by the caller —
+// filter passes iterate rates and call this once per row, so re-normalizing
+// the query per row would be pure waste.
 private fun matchesQuery(
     context: Context,
     rate: Rate,
-    query: String,
+    normalizedQuery: String,
 ): Boolean =
-    query.isEmpty() ||
-        rate.currency.fullName(context).containsNormalized(query) ||
-        rate.currency.iso4217Alpha().containsNormalized(query)
+    normalizedQuery.isEmpty() ||
+        rate.currency
+            .fullName(context)
+            .normalizeForSearch()
+            .contains(normalizedQuery) ||
+        rate.currency
+            .iso4217Alpha()
+            .normalizeForSearch()
+            .contains(normalizedQuery)
 
 private fun buildStarredList(
     context: Context,
     rates: List<Rate>,
     stars: List<Currency>,
     query: String,
-): List<Rate> =
-    stars
+): List<Rate> {
+    val normalizedQuery = query.normalizeForSearch()
+    return stars
         .mapNotNull { code -> rates.find { it.currency == code } }
-        .filter { matchesQuery(context, it, query) }
+        .filter { matchesQuery(context, it, normalizedQuery) }
+}
 
 private fun buildNonStarredList(
     context: Context,
     rates: List<Rate>,
     stars: List<Currency>,
     query: String,
-): List<Rate> =
-    rates
+): List<Rate> {
+    val normalizedQuery = query.normalizeForSearch()
+    return rates
         .filterNot { stars.contains(it.currency) }
-        .filter { matchesQuery(context, it, query) }
+        .filter { matchesQuery(context, it, normalizedQuery) }
+}
 
 private fun collectStarredOrder(
     items: List<Rate>,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -58,6 +58,7 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
+import com.eliormachlev.currencix.util.containsNormalized
 import com.eliormachlev.currencix.util.hasAppendedCurrencySymbol
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
@@ -495,8 +496,8 @@ private fun matchesQuery(
     query: String,
 ): Boolean =
     query.isEmpty() ||
-        rate.currency.fullName(context).contains(query, ignoreCase = true) ||
-        rate.currency.iso4217Alpha().contains(query, ignoreCase = true)
+        rate.currency.fullName(context).containsNormalized(query) ||
+        rate.currency.iso4217Alpha().containsNormalized(query)
 
 private fun buildStarredList(
     context: Context,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
@@ -17,7 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Language
-import com.eliormachlev.currencix.util.containsNormalized
+import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
 import com.google.android.material.radiobutton.MaterialRadioButton
 
@@ -119,7 +119,7 @@ class LanguagePickerPreference : ListPreference {
         override fun getItemId(position: Int): Long = getItem(position).hashCode().toLong()
 
         fun filter(query: String?) {
-            val q = query?.trim().orEmpty()
+            val q = query?.trim().orEmpty().normalizeForSearch()
             languages =
                 if (q.isEmpty()) {
                     allLanguages
@@ -175,13 +175,15 @@ class LanguagePickerPreference : ListPreference {
             return view!!
         }
 
+        // [normalizedQuery] must already be [normalizeForSearch]-ed by the caller
+        // so N language rows don't each re-normalize the query string.
         private fun Language.matches(
             context: Context,
-            query: String,
+            normalizedQuery: String,
         ): Boolean {
-            if (localizedName(context).containsNormalized(query)) return true
+            if (localizedName(context).normalizeForSearch().contains(normalizedQuery)) return true
             if (this == Language.SYSTEM) return false
-            return nativeName(context).containsNormalized(query)
+            return nativeName(context).normalizeForSearch().contains(normalizedQuery)
         }
 
         internal class ViewHolder {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Language
+import com.eliormachlev.currencix.util.containsNormalized
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
 import com.google.android.material.radiobutton.MaterialRadioButton
 
@@ -178,9 +179,9 @@ class LanguagePickerPreference : ListPreference {
             context: Context,
             query: String,
         ): Boolean {
-            if (localizedName(context).contains(query, ignoreCase = true)) return true
+            if (localizedName(context).containsNormalized(query)) return true
             if (this == Language.SYSTEM) return false
-            return nativeName(context).contains(query, ignoreCase = true)
+            return nativeName(context).containsNormalized(query)
         }
 
         internal class ViewHolder {


### PR DESCRIPTION
## Summary
- Language picker search silently failed after the first base letter of an endonym written with combining diacritics — typing 'עב' returned no Hebrew match because the stored entry is 'עִבְרִית' (hiriq sits between ע and ב).
- Add `String.stripDiacritics()` and `String.containsNormalized()` helpers in `TextUtils.kt` (NFD + strip `\p{Mn}` + case-insensitive contains).
- Wire both the language picker (`LanguagePickerPreference.matches`) and the currency picker (`SearchableCurrencyPicker.matchesQuery`) through the new helper. Same class of bug would affect Arabic tashkeel, Latin accents in localized currency names, etc.

Fixes #103.

## Test plan
- [ ] Settings → App Language → type 'ע' → Hebrew is shown.
- [ ] Type another letter → 'עב' → Hebrew still matches (previously dropped to no results).
- [ ] Same for 'עבר', 'עברי'…
- [ ] Language picker with an accented Latin endonym (e.g. 'Português') still matches when typing 'portugues' (no accent on query side).
- [ ] Currency picker search still matches by full name (e.g. 'dollar') and ISO code ('USD'), plus works when the localized name contains diacritics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)