### PR TITLE
feat(calculator): cycle-toggle parens key on extended keypad (closes #104)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CalculatorExpression.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CalculatorExpression.kt
@@ -106,6 +106,18 @@ private fun String.padTrailingToken(): String {
 // have already been normalised to ASCII) and appends the missing `)`s so a
 // half-typed expression still evaluates instead of collapsing to FALLBACK.
 private fun String.closeUnbalancedParens(): String {
-    val missing = count { it == '(' } - count { it == ')' }
+    val missing = unclosedParens()
     return if (missing > 0) this + ")".repeat(missing) else this
 }
+
+// Balance-count of `(` minus `)`. Positive = `(`s waiting to be closed;
+// negative = extra `)`s (rejected upstream, so callers can treat <=0 as
+// "already balanced"). One-pass fold keeps it cheap on the keystroke path.
+internal fun String.unclosedParens(): Int =
+    fold(0) { n, c ->
+        when (c) {
+            '(' -> n + 1
+            ')' -> n - 1
+            else -> n
+        }
+    }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CalculatorExpression.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CalculatorExpression.kt
@@ -11,6 +11,12 @@ const val OPERATOR_MINUS = "\u2212" // − (minus sign, not hyphen)
 const val OPERATOR_MULTIPLY = "\u00D7" // ×
 const val OPERATOR_DIVIDE = "\u00F7" // ÷
 
+// Parentheses use plain ASCII in both display and evaluator — no glyph
+// normalisation needed. Kept as constants so the paren-cycle button, the
+// state-machine, and the auto-close padder all agree on the same character.
+const val PAREN_OPEN = "("
+const val PAREN_CLOSE = ")"
+
 // Single source of truth pairing each display glyph with the ASCII operator
 // EvalEx understands. Drives both [OPERATOR_REGEX] and [normaliseGlyphsToAscii]
 // so adding an operator is a one-line change instead of three coordinated ones.
@@ -25,6 +31,11 @@ private val DISPLAY_TO_ASCII: Map<String, String> =
     )
 
 val OPERATOR_REGEX = Regex("[${DISPLAY_TO_ASCII.keys.joinToString("")}]")
+
+// Any character that means "the calculation row still has structure worth
+// keeping" — operators plus parentheses. Used by delete() to decide whether a
+// trimmed calc string can drop back to base row, or must stay in calc mode.
+val CALC_TOKEN_REGEX = Regex("[${DISPLAY_TO_ASCII.keys.joinToString("")}()]")
 
 // Returned whenever the expression can't be evaluated (parse error, division
 // by zero, unbalanced parens, …). Keeps the UI contract stable across parser
@@ -57,6 +68,7 @@ fun String.evaluateCalculatorExpression(): String {
         normaliseGlyphsToAscii()
             .expandPercent()
             .padTrailingToken()
+            .closeUnbalancedParens()
     // EvalEx.evaluate() throws checked ParseException/EvaluationException
     // (parse errors, unbalanced parens, division by zero, …). Every failure
     // collapses to FALLBACK_RESULT — same contract the UI relied on with
@@ -88,4 +100,12 @@ private fun String.expandPercent(): String =
 private fun String.padTrailingToken(): String {
     val neutral = TRAILING_TOKEN_PADDING[trim().lastOrNull()] ?: return this
     return this + neutral
+}
+
+// Auto-close support: `(1+2` evaluates as `(1+2)`. Counts unclosed `(` (that
+// have already been normalised to ASCII) and appends the missing `)`s so a
+// half-typed expression still evaluates instead of collapsing to FALLBACK.
+private fun String.closeUnbalancedParens(): String {
+    val missing = count { it == '(' } - count { it == ')' }
+    return if (missing > 0) this + ")".repeat(missing) else this
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/ParenButton.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/ParenButton.kt
@@ -1,0 +1,41 @@
+package com.eliormachlev.currencix.util
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.util.TypedValue
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.eliormachlev.currencix.R
+
+// Both paren glyphs are always drawn on the cycle-toggle button; only the
+// spans change to hint which one will be inserted next.
+private const val PAREN_BUTTON_LABEL = "()"
+
+/**
+ * Paint the shared `()` cycle-toggle keypad button so the glyph that would be
+ * inserted by the *next* tap sits in bold + operator-green and the other in a
+ * muted secondary tone. Reused by both the main and cart activities so the
+ * highlight looks the same wherever the extended keypad is shown.
+ */
+fun TextView.paintParenCycle(next: Char) {
+    val activeColor = ContextCompat.getColor(context, R.color.color_keypad_operators)
+    val mutedColor = context.resolveThemeColor(android.R.attr.textColorSecondary)
+    val activeIndex = if (next == '(') 0 else 1
+    val mutedIndex = 1 - activeIndex
+    text =
+        SpannableString(PAREN_BUTTON_LABEL).apply {
+            setSpan(ForegroundColorSpan(activeColor), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            setSpan(StyleSpan(Typeface.BOLD), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            setSpan(ForegroundColorSpan(mutedColor), mutedIndex, mutedIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+}
+
+private fun Context.resolveThemeColor(attr: Int): Int {
+    val tv = TypedValue()
+    theme.resolveAttribute(attr, tv, true)
+    return if (tv.resourceId != 0) ContextCompat.getColor(this, tv.resourceId) else tv.data
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -1081,12 +1081,7 @@ class CartActivity : BaseActivity() {
 
     fun calculationEvent(view: View) = keypadEvent(view) { it.addOperator((view as AppCompatButton).text.toString()) }
 
-    // Cycle-toggle: dispatches to open or close paren based on the *current*
-    // state's next-paren hint (same rule the button's highlight is drawn from).
-    fun parensEvent(view: View) =
-        keypadEvent(view) { state ->
-            if (state.nextParen.value == ')') state.addCloseParen() else state.addOpenParen()
-        }
+    fun parensEvent(view: View) = keypadEvent(view) { it.applyNextParen() }
 
     // Every keypad button does the same two-step: haptic tap on the button,
     // then forward the action to whichever row's calculator state is active.

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -36,6 +36,7 @@ import com.eliormachlev.currencix.model.FeeSide
 import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.repository.CartExporter
 import com.eliormachlev.currencix.repository.CartFileResult
+import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CART_EXPORT_DISPLAY_SCALE
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
 import com.eliormachlev.currencix.util.buildCartShareChooser
@@ -44,6 +45,7 @@ import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.paddedDialogContainer
+import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
 import com.eliormachlev.currencix.util.roundForDisplay
 import com.eliormachlev.currencix.util.toCsv
@@ -145,6 +147,7 @@ class CartActivity : BaseActivity() {
     private val activeItemId = MutableLiveData<String?>(null)
     private val liveExpression = MutableLiveData("")
     private var activeStateObserver: Observer<String?>? = null
+    private var activeParenObserver: Observer<Char>? = null
     private var keypadBackCallback: OnBackPressedCallback? = null
 
     // Rising-edge latch for the IME-visibility guard; see [installImeVisibilityGuard].
@@ -889,11 +892,18 @@ class CartActivity : BaseActivity() {
         val observer = Observer<String?> { liveExpression.value = state.toExpressionString() }
         state.baseValueText.observeForever(observer)
         state.calculationValueText.observeForever(observer)
+        val parenObserver = Observer<Char> { next -> parenButton()?.paintParenCycle(next) }
+        state.nextParen.observeForever(parenObserver)
         activeCalculatorState = state
         activeItemId.value = itemId
         activeStateObserver = observer
+        activeParenObserver = parenObserver
         showKeypad()
     }
+
+    // The `()` cycle-toggle key on the extended keypad. Absent from the basic
+    // layout, so callers must tolerate null.
+    private fun parenButton(): AppCompatButton? = keypadExtended.findViewById(R.id.btn_parens)
 
     /** Hide the keypad and unbind whichever row was being edited. */
     fun closeKeypad() {
@@ -968,6 +978,13 @@ class CartActivity : BaseActivity() {
             state.baseValueText.removeObserver(observer)
             state.calculationValueText.removeObserver(observer)
         }
+        val parenObserver = activeParenObserver
+        if (state != null && parenObserver != null) {
+            state.nextParen.removeObserver(parenObserver)
+        }
+        // Reset the paren button to its rest state — `(` is the only sensible
+        // next glyph when no field is being edited.
+        parenButton()?.paintParenCycle('(')
         // Commit the current keypad expression to the VM so the row's
         // persisted value matches what the user just typed.
         val id = activeItemId.value
@@ -978,6 +995,7 @@ class CartActivity : BaseActivity() {
         activeCalculatorState = null
         activeItemId.value = null
         activeStateObserver = null
+        activeParenObserver = null
         liveExpression.value = ""
     }
 
@@ -1063,6 +1081,13 @@ class CartActivity : BaseActivity() {
 
     fun calculationEvent(view: View) = keypadEvent(view) { it.addOperator((view as AppCompatButton).text.toString()) }
 
+    // Cycle-toggle: dispatches to open or close paren based on the *current*
+    // state's next-paren hint (same rule the button's highlight is drawn from).
+    fun parensEvent(view: View) =
+        keypadEvent(view) { state ->
+            if (state.nextParen.value == ')') state.addCloseParen() else state.addOpenParen()
+        }
+
     // Every keypad button does the same two-step: haptic tap on the button,
     // then forward the action to whichever row's calculator state is active.
     private inline fun keypadEvent(
@@ -1086,16 +1111,16 @@ class CartActivity : BaseActivity() {
 private fun CalculatorInputState.seedExpression(expression: String) {
     val trimmed = expression.trim()
     if (trimmed.isEmpty()) return
-    if (!trimmed.contains(OPERATOR_REGEX)) {
+    if (!trimmed.contains(CALC_TOKEN_REGEX)) {
         replayDigits(trimmed)
         return
     }
-    // Split on operator boundaries while keeping operators as separate
-    // tokens — mirrors how the state serialises them back out.
+    // Split on operator/paren boundaries while keeping each structural token
+    // as its own entry — mirrors how the state serialises them back out.
     val tokens = mutableListOf<String>()
     val buf = StringBuilder()
     trimmed.forEach { ch ->
-        if (ch.toString().matches(OPERATOR_REGEX)) {
+        if (ch.toString().matches(CALC_TOKEN_REGEX)) {
             if (buf.isNotBlank()) tokens += buf.toString().trim()
             tokens += ch.toString()
             buf.clear()
@@ -1108,7 +1133,12 @@ private fun CalculatorInputState.seedExpression(expression: String) {
     // the first operator and the calculation row afterwards — so every
     // operand goes through the same path.
     tokens.forEach { token ->
-        if (token.matches(OPERATOR_REGEX)) addOperator(token) else replayDigits(token)
+        when {
+            token == "(" -> addOpenParen()
+            token == ")" -> addCloseParen()
+            token.matches(OPERATOR_REGEX) -> addOperator(token)
+            else -> replayDigits(token)
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -46,6 +46,7 @@ import com.eliormachlev.currencix.util.getDecimalSeparator
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.ltrIsolate
+import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.stripTimePattern
@@ -462,8 +463,7 @@ class MainActivity : BaseActivity() {
         viewModel.getResultAsNumber().observe(this) { spinnerFrom.setCurrentSum(it) }
         viewModel.isExtendedKeypadEnabled.observe(this) { observeKeypadState(it) }
         viewModel.nextParen().observe(this) { next ->
-            val btn = findViewById<AppCompatButton>(R.id.btn_parens) ?: return@observe
-            renderParenButton(btn, next)
+            findViewById<AppCompatButton>(R.id.btn_parens)?.paintParenCycle(next)
         }
         viewModel.isHapticFeedbackEnabled.observe(this) { hapticEnabled = it }
         viewModel.getFeeSide().observe(this) { observeFeeSide(it) }
@@ -709,31 +709,6 @@ class MainActivity : BaseActivity() {
         if (viewModel.nextParen().value == ')') viewModel.closeParen() else viewModel.openParen()
     }
 
-    // Repaint the `()` button so the glyph that *will* be inserted next lights
-    // up in bold + operator-green and the other sits in a muted secondary tone
-    // — the "which paren is armed" hint the issue asks for.
-    private fun renderParenButton(
-        button: AppCompatButton,
-        next: Char,
-    ) {
-        val activeColor = getColor(R.color.color_keypad_operators)
-        val mutedColor = resolveThemeColor(android.R.attr.textColorSecondary)
-        val activeIndex = if (next == '(') 0 else 1
-        val mutedIndex = 1 - activeIndex
-        button.text =
-            SpannableString(PAREN_BUTTON_LABEL).apply {
-                setSpan(ForegroundColorSpan(activeColor), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                setSpan(StyleSpan(Typeface.BOLD), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                setSpan(ForegroundColorSpan(mutedColor), mutedIndex, mutedIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-    }
-
-    private fun resolveThemeColor(attr: Int): Int {
-        val tv = TypedValue()
-        theme.resolveAttribute(attr, tv, true)
-        return if (tv.resourceId != 0) getColor(tv.resourceId) else tv.data
-    }
-
     // capture hardware keyboard input
     override fun onKeyDown(
         keyCode: Int,
@@ -831,10 +806,6 @@ class MainActivity : BaseActivity() {
         }
     }
 }
-
-// Both glyphs are drawn — one bold+green, one grey — so the button always
-// shows the pair while hinting which one will be inserted next.
-private const val PAREN_BUTTON_LABEL = "()"
 
 private const val WORDMARK_TITLE_SP = 26f
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -461,6 +461,10 @@ class MainActivity : BaseActivity() {
         viewModel.getCurrentBaseValueAsNumber().observe(this) { spinnerTo.setCurrentSum(it) }
         viewModel.getResultAsNumber().observe(this) { spinnerFrom.setCurrentSum(it) }
         viewModel.isExtendedKeypadEnabled.observe(this) { observeKeypadState(it) }
+        viewModel.nextParen().observe(this) { next ->
+            val btn = findViewById<AppCompatButton>(R.id.btn_parens) ?: return@observe
+            renderParenButton(btn, next)
+        }
         viewModel.isHapticFeedbackEnabled.observe(this) { hapticEnabled = it }
         viewModel.getFeeSide().observe(this) { observeFeeSide(it) }
         viewModel.getTrueCost().observe(this) { observeTrueCost(it) }
@@ -697,6 +701,39 @@ class MainActivity : BaseActivity() {
             ?.invoke(viewModel)
     }
 
+    /*
+     * keyboard: parentheses (cycle-toggle between `(` and `)`)
+     */
+    fun parensEvent(view: View) {
+        haptic(view)
+        if (viewModel.nextParen().value == ')') viewModel.closeParen() else viewModel.openParen()
+    }
+
+    // Repaint the `()` button so the glyph that *will* be inserted next lights
+    // up in bold + operator-green and the other sits in a muted secondary tone
+    // — the "which paren is armed" hint the issue asks for.
+    private fun renderParenButton(
+        button: AppCompatButton,
+        next: Char,
+    ) {
+        val activeColor = getColor(R.color.color_keypad_operators)
+        val mutedColor = resolveThemeColor(android.R.attr.textColorSecondary)
+        val activeIndex = if (next == '(') 0 else 1
+        val mutedIndex = 1 - activeIndex
+        button.text =
+            SpannableString(PAREN_BUTTON_LABEL).apply {
+                setSpan(ForegroundColorSpan(activeColor), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                setSpan(StyleSpan(Typeface.BOLD), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                setSpan(ForegroundColorSpan(mutedColor), mutedIndex, mutedIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+    }
+
+    private fun resolveThemeColor(attr: Int): Int {
+        val tv = TypedValue()
+        theme.resolveAttribute(attr, tv, true)
+        return if (tv.resourceId != 0) getColor(tv.resourceId) else tv.data
+    }
+
     // capture hardware keyboard input
     override fun onKeyDown(
         keyCode: Int,
@@ -717,6 +754,8 @@ class MainActivity : BaseActivity() {
         when {
             key.isDigit() -> viewModel.addNumber(key.toString())
             key == '.' || key == ',' -> viewModel.addDecimal()
+            key == '(' -> viewModel.openParen()
+            key == ')' -> viewModel.closeParen()
             else -> return false
         }
         return true
@@ -792,6 +831,10 @@ class MainActivity : BaseActivity() {
         }
     }
 }
+
+// Both glyphs are drawn — one bold+green, one grey — so the button always
+// shows the pair while hinting which one will be inserted next.
+private const val PAREN_BUTTON_LABEL = "()"
 
 private const val WORDMARK_TITLE_SP = 26f
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -706,7 +706,7 @@ class MainActivity : BaseActivity() {
      */
     fun parensEvent(view: View) {
         haptic(view)
-        if (viewModel.nextParen().value == ')') viewModel.closeParen() else viewModel.openParen()
+        viewModel.applyNextParen()
     }
 
     // capture hardware keyboard input

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
@@ -154,6 +154,15 @@ internal class CalculatorInputState {
         }
     }
 
+    // Cycle-toggle entry point for the shared `()` keypad button — dispatches
+    // to open/close using the same rule the button's highlight is drawn from,
+    // so pressing the button always inserts whichever glyph is highlighted.
+    // Recomputes fresh instead of reading `nextParen.value` so the dispatch
+    // stays correct even when the LiveData has no observers attached yet.
+    fun applyNextParen() {
+        if (nextParenFor(_calculationValueText.value) == ')') addCloseParen() else addOpenParen()
+    }
+
     fun addOperator(operator: String) {
         if (isInCalculationMode()) {
             val current = _calculationValueText.value!!

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
@@ -7,6 +7,7 @@ import com.eliormachlev.currencix.util.OPERATOR_MULTIPLY
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
 import com.eliormachlev.currencix.util.PAREN_CLOSE
 import com.eliormachlev.currencix.util.PAREN_OPEN
+import com.eliormachlev.currencix.util.unclosedParens
 
 /**
  * Holds the mutable keypad state — the lower "base" row and the optional upper
@@ -27,21 +28,17 @@ internal class CalculatorInputState {
     val baseValueText: LiveData<String?> = _baseValueText
     val calculationValueText: LiveData<String?> = _calculationValueText
 
-    // Which glyph the paren-cycle button should insert next — `(` while the
-    // expression is either empty or in a position where an operand may start,
-    // `)` once there is an unclosed `(` and the trailing token is value-like.
-    // Seeded with `(` up-front and driven from `setCalc` (not `Transformations.map`
-    // or `MediatorLiveData.addSource`) so the value stays current even when no
-    // observer is attached — otherwise the button's XML `textColor` leaves both
-    // glyphs painted green at rest before the first observation.
-    private val _nextParen = MutableLiveData('(')
+    // Driven from `setCalc` (not `LiveData.map` / `MediatorLiveData.addSource`)
+    // so the value stays current even without an active observer — otherwise
+    // the button's XML `textColor` paints both glyphs green at rest and unit
+    // tests reading `.value` see null.
+    private val _nextParen = MutableLiveData(nextParenFor(null))
     val nextParen: LiveData<Char> = _nextParen
 
-    // Single write path for the calculation row so `_nextParen` never lags —
-    // every mutation must go through here.
     private fun setCalc(value: String?) {
         _calculationValueText.value = value
-        _nextParen.value = nextParenFor(value)
+        val newParen = nextParenFor(value)
+        if (_nextParen.value != newParen) _nextParen.value = newParen
     }
 
     fun isInCalculationMode(): Boolean = _calculationValueText.value.isNullOrBlank().not()
@@ -156,7 +153,7 @@ internal class CalculatorInputState {
         // a completed value — refuse `(` -> `()` or `5+` -> `5+)` so unbalanced
         // junk never enters the expression
         val trimmed = current.trimEnd()
-        if (unclosedParens(current) > 0 && isCompletedValueTail(trimmed.lastOrNull())) {
+        if (current.unclosedParens() > 0 && isCompletedValueTail(trimmed.lastOrNull())) {
             setCalc(trimmed + PAREN_CLOSE)
         }
     }
@@ -164,10 +161,8 @@ internal class CalculatorInputState {
     // Cycle-toggle entry point for the shared `()` keypad button — dispatches
     // to open/close using the same rule the button's highlight is drawn from,
     // so pressing the button always inserts whichever glyph is highlighted.
-    // Recomputes fresh instead of reading `nextParen.value` so the dispatch
-    // stays correct even when the LiveData has no observers attached yet.
     fun applyNextParen() {
-        if (nextParenFor(_calculationValueText.value) == ')') addCloseParen() else addOpenParen()
+        if (_nextParen.value == ')') addCloseParen() else addOpenParen()
     }
 
     fun addOperator(operator: String) {
@@ -195,7 +190,7 @@ internal class CalculatorInputState {
 
     private fun nextParenFor(calc: String?): Char {
         if (calc.isNullOrBlank()) return '('
-        val canClose = unclosedParens(calc) > 0 && isCompletedValueTail(calc.trimEnd().lastOrNull())
+        val canClose = calc.unclosedParens() > 0 && isCompletedValueTail(calc.trimEnd().lastOrNull())
         return if (canClose) ')' else '('
     }
 
@@ -210,6 +205,4 @@ internal class CalculatorInputState {
     private fun isValueContinuationTail(c: Char?): Boolean = isCompletedValueTail(c) || c == '.'
 
     private fun withImplicitMultBeforeOpen(prefix: String): String = "$prefix $OPERATOR_MULTIPLY $PAREN_OPEN"
-
-    private fun unclosedParens(s: String): Int = s.count { it == '(' } - s.count { it == ')' }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
@@ -2,7 +2,12 @@ package com.eliormachlev.currencix.viewmodel.main
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.map
+import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
+import com.eliormachlev.currencix.util.OPERATOR_MULTIPLY
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
+import com.eliormachlev.currencix.util.PAREN_CLOSE
+import com.eliormachlev.currencix.util.PAREN_OPEN
 
 /**
  * Holds the mutable keypad state — the lower "base" row and the optional upper
@@ -22,6 +27,13 @@ internal class CalculatorInputState {
 
     val baseValueText: LiveData<String?> = _baseValueText
     val calculationValueText: LiveData<String?> = _calculationValueText
+
+    // Which glyph the paren-cycle button should insert next — `(` while the
+    // expression is either empty or in a position where an operand may start,
+    // `)` once there is an unclosed `(` and the trailing token is value-like.
+    // Derived from calculationValueText so the button lights up automatically
+    // as the user types, without a separate counter to keep in sync.
+    val nextParen: LiveData<Char> = _calculationValueText.map { nextParenFor(it) }
 
     fun isInCalculationMode(): Boolean = _calculationValueText.value.isNullOrBlank().not()
 
@@ -94,9 +106,10 @@ internal class CalculatorInputState {
             var next = _calculationValueText.value!!.trim().dropLast(1)
             // if last char is a number: trim any dangling space
             if (next.isNotEmpty() && next.last().isDigit()) next = next.trim()
-            // if only a number is left without an operator, drop out of calc mode
+            // drop back to base row only once no operator or paren remains —
+            // otherwise `(5)` deleting to `(` would collapse and lose the paren
             _calculationValueText.value =
-                if (!next.contains(OPERATOR_REGEX)) null else next
+                if (!next.contains(CALC_TOKEN_REGEX)) null else next
         } else {
             val current = _baseValueText.value!!
             if (current.length > 1) {
@@ -110,6 +123,35 @@ internal class CalculatorInputState {
     fun clear() {
         _baseValueText.value = "0"
         _calculationValueText.value = null
+    }
+
+    fun addOpenParen() {
+        if (!isInCalculationMode()) {
+            // seed calc row from base like operators do; drop base "0" so the
+            // user gets a clean `(` instead of `0 × (`
+            val base = _baseValueText.value.orEmpty()
+            _calculationValueText.value =
+                if (base.isEmpty() || base == "0") PAREN_OPEN else withImplicitMultBeforeOpen(base)
+            return
+        }
+        val current = _calculationValueText.value!!
+        val trimmed = current.trimEnd()
+        // after a value-continuation token (digit, `)`, `%`, `.`) insert an
+        // implicit multiplication so EvalEx sees `5*(...)` instead of parse error
+        _calculationValueText.value =
+            if (isValueContinuationTail(trimmed.lastOrNull())) withImplicitMultBeforeOpen(trimmed) else current + PAREN_OPEN
+    }
+
+    fun addCloseParen() {
+        if (!isInCalculationMode()) return
+        val current = _calculationValueText.value!!
+        // only close when there is something to close AND the trailing token is
+        // a completed value — refuse `(` -> `()` or `5+` -> `5+)` so unbalanced
+        // junk never enters the expression
+        val trimmed = current.trimEnd()
+        if (unclosedParens(current) > 0 && isCompletedValueTail(trimmed.lastOrNull())) {
+            _calculationValueText.value = trimmed + PAREN_CLOSE
+        }
     }
 
     fun addOperator(operator: String) {
@@ -134,4 +176,24 @@ internal class CalculatorInputState {
             _calculationValueText.value = _baseValueText.value + " $operator "
         }
     }
+
+    private fun nextParenFor(calc: String?): Char {
+        if (calc.isNullOrBlank()) return '('
+        val canClose = unclosedParens(calc) > 0 && isCompletedValueTail(calc.trimEnd().lastOrNull())
+        return if (canClose) ')' else '('
+    }
+
+    // A "completed value" tail is safe to append `)` after — a digit, a `)`
+    // already there, or a `%` (which resolves to a number). A trailing `.` is
+    // *not* completed (`2.` needs padding first), and neither is an operator.
+    private fun isCompletedValueTail(c: Char?): Boolean = c != null && (c.isDigit() || c == ')' || c == '%')
+
+    // A "value continuation" tail is one where `(` is only legal if we insert
+    // an implicit `×` first — i.e. the completed-value cases plus a trailing
+    // decimal point that would otherwise collide with `(`.
+    private fun isValueContinuationTail(c: Char?): Boolean = isCompletedValueTail(c) || c == '.'
+
+    private fun withImplicitMultBeforeOpen(prefix: String): String = "$prefix $OPERATOR_MULTIPLY $PAREN_OPEN"
+
+    private fun unclosedParens(s: String): Int = s.count { it == '(' } - s.count { it == ')' }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputState.kt
@@ -2,7 +2,6 @@ package com.eliormachlev.currencix.viewmodel.main
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.map
 import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.OPERATOR_MULTIPLY
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
@@ -31,9 +30,19 @@ internal class CalculatorInputState {
     // Which glyph the paren-cycle button should insert next — `(` while the
     // expression is either empty or in a position where an operand may start,
     // `)` once there is an unclosed `(` and the trailing token is value-like.
-    // Derived from calculationValueText so the button lights up automatically
-    // as the user types, without a separate counter to keep in sync.
-    val nextParen: LiveData<Char> = _calculationValueText.map { nextParenFor(it) }
+    // Seeded with `(` up-front and driven from `setCalc` (not `Transformations.map`
+    // or `MediatorLiveData.addSource`) so the value stays current even when no
+    // observer is attached — otherwise the button's XML `textColor` leaves both
+    // glyphs painted green at rest before the first observation.
+    private val _nextParen = MutableLiveData('(')
+    val nextParen: LiveData<Char> = _nextParen
+
+    // Single write path for the calculation row so `_nextParen` never lags —
+    // every mutation must go through here.
+    private fun setCalc(value: String?) {
+        _calculationValueText.value = value
+        _nextParen.value = nextParenFor(value)
+    }
 
     fun isInCalculationMode(): Boolean = _calculationValueText.value.isNullOrBlank().not()
 
@@ -45,16 +54,16 @@ internal class CalculatorInputState {
                 // last input was "0": replace it with any other number
                 lastToken == "0" -> {
                     if (value != "0" && value != "00" && value != "000") {
-                        _calculationValueText.value = current.trim().dropLast(1) + value
+                        setCalc(current.trim().dropLast(1) + value)
                     }
                 }
                 // last input was an operator: collapse "00"/"000" down to "0"
                 current.split(" ").last().isEmpty() &&
                     (value == "00" || value == "000") -> {
-                    _calculationValueText.value = current + "0"
+                    setCalc(current + "0")
                 }
                 else -> {
-                    _calculationValueText.value = current + value
+                    setCalc(current + value)
                 }
             }
         } else {
@@ -76,12 +85,11 @@ internal class CalculatorInputState {
 
     fun addPercent() {
         if (!isInCalculationMode()) {
-            _calculationValueText.value = _baseValueText.value
+            setCalc(_baseValueText.value)
         }
         val current = _calculationValueText.value?.trim() ?: return
         if (current.isNotEmpty() && (current.last().isDigit() || current.last() == '.')) {
-            _calculationValueText.value =
-                if (current.last() == '.') current.dropLast(1) + "%" else current + "%"
+            setCalc(if (current.last() == '.') current.dropLast(1) + "%" else current + "%")
         }
     }
 
@@ -91,7 +99,7 @@ internal class CalculatorInputState {
             if (!current.substringAfterLast(" ").contains(".")) {
                 // if last char is not a number: add 0 first
                 val prefix = if (!current.trim().last().isDigit()) current + "0" else current
-                _calculationValueText.value = "$prefix."
+                setCalc("$prefix.")
             }
         } else {
             val current = _baseValueText.value!!
@@ -108,8 +116,7 @@ internal class CalculatorInputState {
             if (next.isNotEmpty() && next.last().isDigit()) next = next.trim()
             // drop back to base row only once no operator or paren remains —
             // otherwise `(5)` deleting to `(` would collapse and lose the paren
-            _calculationValueText.value =
-                if (!next.contains(CALC_TOKEN_REGEX)) null else next
+            setCalc(if (!next.contains(CALC_TOKEN_REGEX)) null else next)
         } else {
             val current = _baseValueText.value!!
             if (current.length > 1) {
@@ -122,7 +129,7 @@ internal class CalculatorInputState {
 
     fun clear() {
         _baseValueText.value = "0"
-        _calculationValueText.value = null
+        setCalc(null)
     }
 
     fun addOpenParen() {
@@ -130,16 +137,16 @@ internal class CalculatorInputState {
             // seed calc row from base like operators do; drop base "0" so the
             // user gets a clean `(` instead of `0 × (`
             val base = _baseValueText.value.orEmpty()
-            _calculationValueText.value =
-                if (base.isEmpty() || base == "0") PAREN_OPEN else withImplicitMultBeforeOpen(base)
+            setCalc(if (base.isEmpty() || base == "0") PAREN_OPEN else withImplicitMultBeforeOpen(base))
             return
         }
         val current = _calculationValueText.value!!
         val trimmed = current.trimEnd()
         // after a value-continuation token (digit, `)`, `%`, `.`) insert an
         // implicit multiplication so EvalEx sees `5*(...)` instead of parse error
-        _calculationValueText.value =
-            if (isValueContinuationTail(trimmed.lastOrNull())) withImplicitMultBeforeOpen(trimmed) else current + PAREN_OPEN
+        setCalc(
+            if (isValueContinuationTail(trimmed.lastOrNull())) withImplicitMultBeforeOpen(trimmed) else current + PAREN_OPEN,
+        )
     }
 
     fun addCloseParen() {
@@ -150,7 +157,7 @@ internal class CalculatorInputState {
         // junk never enters the expression
         val trimmed = current.trimEnd()
         if (unclosedParens(current) > 0 && isCompletedValueTail(trimmed.lastOrNull())) {
-            _calculationValueText.value = trimmed + PAREN_CLOSE
+            setCalc(trimmed + PAREN_CLOSE)
         }
     }
 
@@ -170,19 +177,19 @@ internal class CalculatorInputState {
             when {
                 // already an operator at the end: swap it
                 lastChar.toString().matches(OPERATOR_REGEX) -> {
-                    _calculationValueText.value = current.trim().dropLast(1) + "$operator "
+                    setCalc(current.trim().dropLast(1) + "$operator ")
                 }
                 // trailing '.': drop it, then append operator
                 lastChar == '.' -> {
-                    _calculationValueText.value = current.trim().dropLast(1) + " $operator "
+                    setCalc(current.trim().dropLast(1) + " $operator ")
                 }
                 else -> {
-                    _calculationValueText.value = current.trim() + " $operator "
+                    setCalc(current.trim() + " $operator ")
                 }
             }
         } else {
             // switch to calculation mode, seeded from the base row
-            _calculationValueText.value = _baseValueText.value + " $operator "
+            setCalc(_baseValueText.value + " $operator ")
         }
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -779,6 +779,14 @@ class MainViewModel(
 
     internal fun division() = input.addOperator(OPERATOR_DIVIDE)
 
+    internal fun openParen() = input.addOpenParen()
+
+    internal fun closeParen() = input.addCloseParen()
+
+    // Which paren the cycle-toggle keypad button should insert next — drives
+    // the bold/green vs grey highlight on the two-glyph `()` button.
+    internal fun nextParen(): LiveData<Char> = input.nextParen
+
     /*
      * selected currencies *************************************************************************
      */

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -783,6 +783,10 @@ class MainViewModel(
 
     internal fun closeParen() = input.addCloseParen()
 
+    // Cycle-toggle for the shared `()` keypad button — inserts whichever
+    // glyph is currently highlighted.
+    internal fun applyNextParen() = input.applyNextParen()
+
     // Which paren the cycle-toggle keypad button should insert next — drives
     // the bold/green vs grey highlight on the two-glyph `()` button.
     internal fun nextParen(): LiveData<Char> = input.nextParen

--- a/app/src/main/res/layout/main_keypad_extended.xml
+++ b/app/src/main/res/layout/main_keypad_extended.xml
@@ -123,6 +123,20 @@
             app:layout_constraintStart_toEndOf="@id/btn_9"
             app:layout_constraintTop_toTopOf="@+id/btn_7" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_parens"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="parensEvent"
+            android:text="()"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            android:textColor="@color/color_keypad_operators"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_6"
+            app:layout_constraintTop_toTopOf="@+id/btn_6" />
+
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/btn_delete"
             android:layout_width="0dp"
@@ -132,10 +146,10 @@
             android:longClickable="true"
             android:onClick="deleteEvent"
             android:src="@drawable/ic_backspace"
-            app:layout_constraintBottom_toBottomOf="@+id/btn_4"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_000"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/btn_6"
-            app:layout_constraintTop_toTopOf="@+id/btn_4" />
+            app:layout_constraintStart_toEndOf="@id/btn_000"
+            app:layout_constraintTop_toTopOf="@+id/btn_000" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_4"
@@ -172,7 +186,7 @@
             android:text="6"
             android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
             app:layout_constraintBottom_toBottomOf="@id/btn_4"
-            app:layout_constraintEnd_toStartOf="@id/btn_delete"
+            app:layout_constraintEnd_toStartOf="@id/btn_parens"
             app:layout_constraintStart_toEndOf="@id/btn_5"
             app:layout_constraintTop_toTopOf="@id/btn_4" />
 
@@ -211,7 +225,7 @@
             android:text="3"
             android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
             app:layout_constraintBottom_toBottomOf="@+id/btn_1"
-            app:layout_constraintEnd_toStartOf="@id/btn_delete"
+            app:layout_constraintEnd_toStartOf="@id/btn_decimal"
             app:layout_constraintStart_toEndOf="@id/btn_2"
             app:layout_constraintTop_toTopOf="@+id/btn_1" />
 
@@ -250,7 +264,7 @@
             android:text="000"
             android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
             app:layout_constraintBottom_toBottomOf="@+id/btn_0"
-            app:layout_constraintEnd_toStartOf="@+id/btn_decimal"
+            app:layout_constraintEnd_toStartOf="@+id/btn_delete"
             app:layout_constraintStart_toEndOf="@+id/btn_00"
             app:layout_constraintTop_toTopOf="@+id/btn_0" />
 
@@ -262,9 +276,9 @@
             android:onClick="decimalEvent"
             android:text="."
             android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
-            app:layout_constraintBottom_toBottomOf="@+id/btn_0"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/btn_000"
-            app:layout_constraintTop_toTopOf="@+id/btn_0" />
+            app:layout_constraintStart_toEndOf="@+id/btn_3"
+            app:layout_constraintTop_toTopOf="@+id/btn_1" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/test/kotlin/com/eliormachlev/currencix/util/CalculatorExpressionTest.kt
+++ b/app/src/test/kotlin/com/eliormachlev/currencix/util/CalculatorExpressionTest.kt
@@ -51,4 +51,24 @@ class CalculatorExpressionTest {
         listOf(OPERATOR_PLUS, OPERATOR_MINUS, OPERATOR_MULTIPLY, OPERATOR_DIVIDE)
             .forEach { assert(it.matches(OPERATOR_REGEX)) { "expected $it to match OPERATOR_REGEX" } }
     }
+
+    @Test
+    fun `parenthesised expression respects grouping`() {
+        assertEquals("108", "(100 ${OPERATOR_PLUS} 20) ${OPERATOR_MULTIPLY} 0.9".evaluateCalculatorExpression())
+    }
+
+    @Test
+    fun `unclosed parens are auto-closed at eval time`() {
+        // half-typed `(1+2` evaluates as `(1+2)` = 3 instead of falling back
+        assertEquals("3", "(1 ${OPERATOR_PLUS} 2".evaluateCalculatorExpression())
+        // multiple missing closers all get padded
+        assertEquals("6", "((1 ${OPERATOR_PLUS} 2) ${OPERATOR_MULTIPLY} 2".evaluateCalculatorExpression())
+    }
+
+    @Test
+    fun `calc token regex matches parens as well as operators`() {
+        assertEquals(true, "(".contains(CALC_TOKEN_REGEX))
+        assertEquals(true, ")".contains(CALC_TOKEN_REGEX))
+        assertEquals(true, OPERATOR_PLUS.contains(CALC_TOKEN_REGEX))
+    }
 }

--- a/app/src/test/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputStateTest.kt
+++ b/app/src/test/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputStateTest.kt
@@ -212,6 +212,27 @@ class CalculatorInputStateTest {
     }
 
     @Test
+    fun `applyNextParen cycles open then close then open`() {
+        val s = state()
+        // no calc yet → next=`(` → inserts `(`
+        s.applyNextParen()
+        assertEquals(PAREN_OPEN, s.calc)
+        // still `(` (no value inside yet, close not offered) → inserts another `(`
+        s.applyNextParen()
+        assertEquals(PAREN_OPEN + PAREN_OPEN, s.calc)
+        s.addNumber("3")
+        // now closable → inserts `)`
+        s.applyNextParen()
+        assertEquals("${PAREN_OPEN}${PAREN_OPEN}3$PAREN_CLOSE", s.calc)
+        // still one unclosed `(` and last is `)` → close again
+        s.applyNextParen()
+        assertEquals("${PAREN_OPEN}${PAREN_OPEN}3$PAREN_CLOSE$PAREN_CLOSE", s.calc)
+        // balanced → cycles back to `(`
+        s.applyNextParen()
+        assertEquals("${PAREN_OPEN}${PAREN_OPEN}3$PAREN_CLOSE$PAREN_CLOSE $OPERATOR_MULTIPLY $PAREN_OPEN", s.calc)
+    }
+
+    @Test
     fun `delete inside parenthesised expression keeps calc mode alive`() {
         val s = state()
         s.addOpenParen()

--- a/app/src/test/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputStateTest.kt
+++ b/app/src/test/kotlin/com/eliormachlev/currencix/viewmodel/main/CalculatorInputStateTest.kt
@@ -5,6 +5,8 @@ import com.eliormachlev.currencix.util.OPERATOR_DIVIDE
 import com.eliormachlev.currencix.util.OPERATOR_MINUS
 import com.eliormachlev.currencix.util.OPERATOR_MULTIPLY
 import com.eliormachlev.currencix.util.OPERATOR_PLUS
+import com.eliormachlev.currencix.util.PAREN_CLOSE
+import com.eliormachlev.currencix.util.PAREN_OPEN
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -159,6 +161,65 @@ class CalculatorInputStateTest {
         s.addDecimal() // calc = "4 + 2."
         s.addOperator(OPERATOR_DIVIDE) // calc = "4 + 2 ÷ "
         assertEquals("4 $OPERATOR_PLUS 2 $OPERATOR_DIVIDE ", s.calc)
+    }
+
+    @Test
+    fun `open paren from zero base enters calc mode with just paren`() {
+        val s = state()
+        s.addOpenParen()
+        assertTrue(s.isInCalculationMode())
+        assertEquals(PAREN_OPEN, s.calc)
+        // no value inside yet — closing is not offered, cycle still shows `(`
+        assertEquals('(', s.nextParen.value)
+    }
+
+    @Test
+    fun `open paren after value inserts implicit multiplication`() {
+        val s = state()
+        s.addNumber("5")
+        s.addOpenParen()
+        assertEquals("5 $OPERATOR_MULTIPLY $PAREN_OPEN", s.calc)
+    }
+
+    @Test
+    fun `open paren after operator appends cleanly`() {
+        val s = state()
+        s.addNumber("5")
+        s.addOperator(OPERATOR_PLUS)
+        s.addOpenParen()
+        assertEquals("5 $OPERATOR_PLUS $PAREN_OPEN", s.calc)
+    }
+
+    @Test
+    fun `close paren is offered once expression is closable`() {
+        val s = state()
+        s.addOpenParen()
+        s.addNumber("2")
+        assertEquals(')', s.nextParen.value)
+        s.addCloseParen()
+        assertEquals("${PAREN_OPEN}2$PAREN_CLOSE", s.calc)
+        // once balanced, next cycles back to `(`
+        assertEquals('(', s.nextParen.value)
+    }
+
+    @Test
+    fun `close paren is ignored when nothing to close`() {
+        val s = state()
+        s.addNumber("2")
+        s.addOperator(OPERATOR_PLUS)
+        s.addCloseParen() // no unclosed `(` — should no-op
+        assertEquals("2 $OPERATOR_PLUS ", s.calc)
+    }
+
+    @Test
+    fun `delete inside parenthesised expression keeps calc mode alive`() {
+        val s = state()
+        s.addOpenParen()
+        s.addNumber("5")
+        s.delete()
+        // "5" gone, only `(` remains — but a paren counts as calc structure
+        assertTrue(s.isInCalculationMode())
+        assertEquals(PAREN_OPEN, s.calc)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a single `()` cycle-toggle key to the extended keypad. It inserts `(` or `)` based on paren balance + trailing-token state, with the armed glyph drawn in bold operator-green and the other in muted secondary — matching the hint pattern suggested in #104.
- Right column of the extended keypad now runs `() → . → delete` from top to bottom (delete moves to the bottom-right).
- Auto-close at eval time: `closeUnbalancedParens` pads missing `)`s before EvalEx runs, so `(1+2` still evaluates as `3` without the user having to close manually.
- Hardware `(` / `)` keys are routed through the same state so a physical keyboard behaves the same way.
- Extracts `isCompletedValueTail` / `isValueContinuationTail` / `withImplicitMultBeforeOpen` helpers so the three sites that pick "which trailing char makes `(` or `)` legal" share a named predicate instead of duplicated char lists.

## Test plan
- [x] `./gradlew spotlessCheck` — clean
- [ ] `./gradlew testFdroidDebugUnitTest` — CI (no Android SDK locally); new tests cover `(100 + 20) × 0.9 = 108`, auto-close of unbalanced parens, implicit-mult on `<value>(`, `)` refused when unbalanced, delete keeping calc mode alive inside a paren
- [ ] Manual: type `(100 + 20) × 0.9`, verify `108`
- [ ] Manual: type `(1 + 2` without closing → result `3`
- [ ] Manual: verify `()` button highlight flips as the expression state changes
- [ ] Manual: verify delete button is now at bottom-right and `.` sits above it