### PR TITLE
Cart: swipe-to-delete rows with red trashcan (closes #108)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -1,11 +1,13 @@
 package com.eliormachlev.currencix.view.cart.compose
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
@@ -18,7 +20,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxState
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
@@ -45,6 +52,89 @@ import kotlinx.coroutines.delay
 private const val NAME_EDIT_DEBOUNCE_MS = 300L
 private const val ROW_PREVIEW_SCALE = 2
 private val FIELD_MIN_HEIGHT = 48.dp
+
+// Distance from the trailing edge to the trashcan icon when the row slides.
+// Matches Material's SwipeToDismiss sample so the icon reads as "emerging"
+// from the row rather than pinned to the screen edge.
+private val SWIPE_ICON_TRAILING_PADDING = 24.dp
+
+/**
+ * Wrap [CartItemRow] in a Material3 [SwipeToDismissBox] so a trailing-edge
+ * swipe (right-to-left in LTR, left-to-right in RTL) reveals a red delete
+ * background and, past the dismissal threshold, calls [onDelete] — the
+ * same code path the explicit delete button uses. Rows in edit mode
+ * ([isActive]) reject the gesture so the user can't wipe out a row
+ * while typing into it; the existing button is left in place as an
+ * always-available fallback.
+ */
+@Composable
+@Suppress("LongParameterList")
+fun SwipeableCartItemRow(
+    item: CartItem,
+    currency: String,
+    isActive: Boolean,
+    liveExpression: String?,
+    onNameCommit: (String) -> Unit,
+    onNamePending: (String) -> Unit,
+    onExpressionTap: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dismissState =
+        rememberSwipeToDismissBoxState(
+            confirmValueChange = { target ->
+                if (target == SwipeToDismissBoxValue.EndToStart) {
+                    onDelete()
+                    true
+                } else {
+                    false
+                }
+            },
+        )
+    SwipeToDismissBox(
+        state = dismissState,
+        backgroundContent = { SwipeDeleteBackground(dismissState) },
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = !isActive,
+        modifier = modifier,
+    ) {
+        CartItemRow(
+            item = item,
+            currency = currency,
+            isActive = isActive,
+            liveExpression = liveExpression,
+            onNameCommit = onNameCommit,
+            onNamePending = onNamePending,
+            onExpressionTap = onExpressionTap,
+            onDelete = onDelete,
+        )
+    }
+}
+
+@Composable
+private fun SwipeDeleteBackground(state: SwipeToDismissBoxState) {
+    // Only paint the background once the swipe is active — otherwise the
+    // OutlinedCard's ambient background would show red rectangles behind
+    // every row at rest.
+    val active = state.dismissDirection == SwipeToDismissBoxValue.EndToStart
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(dimensionResource(id = R.dimen.margin1x))
+                .background(if (active) MaterialTheme.colorScheme.error else Color.Transparent),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        if (active) {
+            Icon(
+                imageVector = Icons.Filled.Delete,
+                contentDescription = stringResource(id = R.string.cart_delete_item),
+                tint = MaterialTheme.colorScheme.onError,
+                modifier = Modifier.padding(end = SWIPE_ICON_TRAILING_PADDING),
+            )
+        }
+    }
+}
 
 @Composable
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -42,7 +42,7 @@ fun CartItemsList(
         ) {
             items(items = items, key = { it.id }) { item ->
                 val isActive = item.id == activeId
-                CartItemRow(
+                SwipeableCartItemRow(
                     item = item,
                     currency = currency,
                     isActive = isActive,
@@ -51,6 +51,7 @@ fun CartItemsList(
                     onNamePending = { onNamePending(item.id, it) },
                     onExpressionTap = { onExpressionTap(item) },
                     onDelete = { onDelete(item.id) },
+                    modifier = Modifier.animateItem(),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Wrap each `CartItemRow` in a Material3 `SwipeToDismissBox`; a trailing-edge swipe reveals a `colorError` background with a centered trashcan icon.
- Past-threshold release calls `onDelete` — the same code path as the existing delete button.
- Mid-edit rows (`isActive == true`) reject the swipe so the active-keypad row can't be wiped out during typing.
- Delete button stays in place as the discoverable non-gesture path.

## Test plan
- [ ] Add an item, swipe it right-to-left → red bg + trashcan appears, past threshold row disappears and count drops.
- [ ] Repeat with device set to an RTL locale (e.g. Arabic) → swipe left-to-right removes.
- [ ] Open the keypad on a row, try to swipe → gesture rejects and the row stays.
- [ ] Explicit trashcan button still deletes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)