### PR TITLE
Cart: pin item to top with heart toggle (closes #109)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/Cart.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/Cart.kt
@@ -5,11 +5,16 @@ package com.eliormachlev.currencix.model
  * [expression] like `"1.99"`, `"2 × 3.50"`, or `"10 + 5%"`. The expression
  * is stored verbatim so the user can re-edit it — evaluation happens at
  * display time via `String.evaluateCalculatorExpression()`.
+ *
+ * [pinned] items float to the top of the list at render time (sort happens
+ * in the composable, not in storage) so the user's underlying insertion /
+ * reorder order is preserved when they toggle pins on and off.
  */
 data class CartItem(
     val id: String,
     val name: String,
     val expression: String,
+    val pinned: Boolean = false,
 )
 
 /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
@@ -21,6 +21,7 @@ internal const val CART_KEY_FEE_SIDE = "feeSide"
 internal const val CART_ITEM_KEY_ID = "id"
 internal const val CART_ITEM_KEY_NAME = "name"
 internal const val CART_ITEM_KEY_EXPR = "expression"
+internal const val CART_ITEM_KEY_PINNED = "pinned"
 
 internal fun serializeCart(cart: SavedCart): JSONObject =
     JSONObject().apply {
@@ -43,6 +44,9 @@ private fun serializeCartItem(item: CartItem): JSONObject =
         put(CART_ITEM_KEY_ID, item.id)
         put(CART_ITEM_KEY_NAME, item.name)
         put(CART_ITEM_KEY_EXPR, item.expression)
+        // Only write the pin flag when set — keeps legacy-shape parity for
+        // unpinned rows and shrinks the on-disk payload for typical carts.
+        if (item.pinned) put(CART_ITEM_KEY_PINNED, true)
     }
 
 internal fun parseCart(obj: JSONObject?): SavedCart? {
@@ -82,6 +86,9 @@ private fun parseCartItem(obj: JSONObject?): CartItem? {
         id = obj.optString(CART_ITEM_KEY_ID, "").ifEmpty { UUID.randomUUID().toString() },
         name = obj.optString(CART_ITEM_KEY_NAME, ""),
         expression = obj.optString(CART_ITEM_KEY_EXPR, ""),
+        // Legacy payloads pre-pin default to false (matches the class-level
+        // default) so an old cart on disk round-trips as unpinned.
+        pinned = obj.optBoolean(CART_ITEM_KEY_PINNED, false),
     )
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -229,6 +229,10 @@ class CartActivity : BaseActivity() {
                     itemsView.hapticTap(hapticEnabled)
                     openKeypadFor(item.id, item.expression)
                 },
+                onTogglePin = { id ->
+                    itemsView.hapticTap(hapticEnabled)
+                    viewModel.togglePinned(id)
+                },
                 onDelete = { id ->
                     itemsView.hapticTap(hapticEnabled)
                     if (activeItemId.value == id) closeKeypad()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -56,6 +58,7 @@ fun CartItemRow(
     onNameCommit: (String) -> Unit,
     onNamePending: (String) -> Unit,
     onExpressionTap: () -> Unit,
+    onTogglePin: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val displayedExpression = if (isActive) liveExpression.orEmpty() else item.expression
@@ -74,6 +77,7 @@ fun CartItemRow(
                     .padding(dimensionResource(id = R.dimen.margin1x)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            PinToggle(pinned = item.pinned, onToggle = onTogglePin)
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
                     initial = item.name,
@@ -96,6 +100,32 @@ fun CartItemRow(
                 )
             }
         }
+    }
+}
+
+// Pin affordance — filled heart when pinned (primary tint), empty heart
+// otherwise (onSurfaceVariant tint). Same drawable pair the currency
+// picker uses for its favorites toggle, so users read the two the same
+// way. Lives on the row's leading edge, opposite the delete button.
+@Composable
+private fun PinToggle(
+    pinned: Boolean,
+    onToggle: () -> Unit,
+) {
+    IconButton(onClick = onToggle) {
+        Icon(
+            imageVector = if (pinned) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+            contentDescription =
+                stringResource(
+                    id = if (pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
+                ),
+            tint =
+                if (pinned) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.lifecycle.LiveData
@@ -24,6 +25,7 @@ fun CartItemsList(
     onNameCommit: (id: String, name: String) -> Unit,
     onNamePending: (id: String, name: String) -> Unit,
     onExpressionTap: (item: CartItem) -> Unit,
+    onTogglePin: (id: String) -> Unit,
     onDelete: (id: String) -> Unit,
 ) {
     AppTheme {
@@ -31,6 +33,10 @@ fun CartItemsList(
         val currency by currencySource.observeAsState(initial = "")
         val activeId by activeItemIdSource.observeAsState()
         val liveExpression by activeExpressionSource.observeAsState(initial = "")
+        // Sort pinned-first at render time so the underlying storage order is
+        // preserved when the user toggles pins on and off. `sortedByDescending`
+        // is stable, so items within each partition keep their relative order.
+        val displayItems = remember(items) { items.sortedByDescending { it.pinned } }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -40,7 +46,7 @@ fun CartItemsList(
                     vertical = dimensionResource(id = R.dimen.margin1x),
                 ),
         ) {
-            items(items = items, key = { it.id }) { item ->
+            items(items = displayItems, key = { it.id }) { item ->
                 val isActive = item.id == activeId
                 CartItemRow(
                     item = item,
@@ -50,6 +56,7 @@ fun CartItemsList(
                     onNameCommit = { onNameCommit(item.id, it) },
                     onNamePending = { onNamePending(item.id, it) },
                     onExpressionTap = { onExpressionTap(item) },
+                    onTogglePin = { onTogglePin(item.id) },
                     onDelete = { onDelete(item.id) },
                 )
             }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -167,6 +167,17 @@ class CartViewModel(
         mutate { cart -> cart.copy(items = cart.items.filter { it.id != id }) }
     }
 
+    fun togglePinned(id: String) {
+        mutate { cart ->
+            cart.copy(
+                items =
+                    cart.items.map {
+                        if (it.id == id) it.copy(pinned = !it.pinned) else it
+                    },
+            )
+        }
+    }
+
     fun setBaseCurrency(currency: Currency) {
         mutate { it.copy(currency = currency.iso4217Alpha()) }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,8 @@
     <string name="cart_item_expression_hint">Price (e.g. 2 × 3.50)</string>
     <string name="cart_row_value_format">= %1$s %2$s</string>
     <string name="cart_delete_item">Delete item</string>
+    <string name="cart_pin_item">Pin item to top</string>
+    <string name="cart_unpin_item">Unpin item</string>
     <string name="cart_subtotal_label">Subtotal</string>
     <string name="cart_total_label">Total</string>
     <string name="cart_fee_line">Fees: %s%%</string>


### PR DESCRIPTION
## Summary
- Add `CartItem.pinned: Boolean = false` and persist via a new `"pinned"` JSON key (only written when true so legacy carts round-trip untouched).
- Leading-edge heart toggle on each row using the same `Icons.Filled.Favorite` / `FavoriteBorder` pair the currency picker uses for favourites.
- Sort pinned-first in the composable at render time (stable sort, so underlying insertion / manual order is preserved within each partition).
- `CartViewModel.togglePinned(id)` mutates and persists via the same `mutate` path as existing edits.

## Test plan
- [ ] Toggle the heart on an item → it floats to the top; toggle again → returns to its original slot.
- [ ] Save-as → load → pins persist.
- [ ] Export to JSON → re-import → pins persist. `pinned` key only appears in JSON for pinned items.
- [ ] Legacy cart JSON (without `pinned`) still loads and renders all items as unpinned.
- [ ] Open keypad on a row, then pin it → keypad stays open and just tracks the row's new position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)