### PR TITLE
feat(cart): drag-handle reorder for cart items (closes #110)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -235,6 +235,18 @@ class CartActivity : BaseActivity() {
                     pendingNames.remove(id)
                     viewModel.removeItem(id)
                 },
+                onReorder = { fromId, toId ->
+                    itemsView.hapticTap(hapticEnabled)
+                    viewModel.reorderItem(fromId, toId)
+                },
+                onReorderStart = {
+                    // A drag doesn't interact well with a floating keypad — the
+                    // row being edited would slide out from under the caret.
+                    // Commit the current edit and close before the gesture takes
+                    // over the visible list.
+                    itemsView.hapticTap(hapticEnabled)
+                    closeKeypad()
+                },
             )
         }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -57,11 +58,13 @@ fun CartItemRow(
     onNamePending: (String) -> Unit,
     onExpressionTap: () -> Unit,
     onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    dragHandleModifier: Modifier = Modifier,
 ) {
     val displayedExpression = if (isActive) liveExpression.orEmpty() else item.expression
     OutlinedCard(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .padding(dimensionResource(id = R.dimen.margin1x)),
         border = rowBorder(isActive),
@@ -74,6 +77,7 @@ fun CartItemRow(
                     .padding(dimensionResource(id = R.dimen.margin1x)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            DragHandle(modifier = dragHandleModifier)
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
                     initial = item.name,
@@ -97,6 +101,16 @@ fun CartItemRow(
             }
         }
     }
+}
+
+@Composable
+private fun DragHandle(modifier: Modifier = Modifier) {
+    Icon(
+        imageVector = Icons.Filled.DragHandle,
+        contentDescription = stringResource(id = R.string.cart_reorder_item),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.padding(end = dimensionResource(id = R.dimen.margin1x)),
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,18 +1,54 @@
 package com.eliormachlev.currencix.view.cart.compose
 
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LiveData
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
+
+// Nominal row height used to translate finger travel into "how many rows have
+// I dragged past". Cart rows aren't uniform (name + expression + preview), but
+// this gives a good-enough delta for a snap-to-slot reorder feel; the actual
+// list re-lays out via LazyColumn animateItem() once the drop commits.
+private val REORDER_ROW_HEIGHT = 96.dp
+private const val REORDER_DRAG_ALPHA = 0.85f
+
+// State bag for an in-progress drag. Kept as a single class (rather than four
+// loose `mutableStateOf`s) so per-frame `dragOffsetY` writes stay scoped to
+// the draw-phase `graphicsLayer` lambda instead of invalidating every row's
+// composition. Reads inside a `graphicsLayer { ... }` block subscribe at the
+// draw layer, not the composition layer — the classic Compose "read state
+// late" perf trick.
+private class DragState {
+    var draggingId by mutableStateOf<String?>(null)
+    var draggingIndex by mutableStateOf<Int?>(null)
+    var targetIndex by mutableStateOf<Int?>(null)
+    var offsetY by mutableStateOf(0f)
+
+    fun reset() {
+        draggingId = null
+        draggingIndex = null
+        targetIndex = null
+        offsetY = 0f
+    }
+}
 
 @Composable
 @Suppress("LongParameterList")
@@ -25,12 +61,23 @@ fun CartItemsList(
     onNamePending: (id: String, name: String) -> Unit,
     onExpressionTap: (item: CartItem) -> Unit,
     onDelete: (id: String) -> Unit,
+    onReorder: (fromId: String, toId: String) -> Unit,
+    onReorderStart: () -> Unit,
 ) {
     AppTheme {
         val items by itemsSource.observeAsState(initial = emptyList())
         val currency by currencySource.observeAsState(initial = "")
         val activeId by activeItemIdSource.observeAsState()
         val liveExpression by activeExpressionSource.observeAsState(initial = "")
+
+        val rowHeightPx = with(LocalDensity.current) { REORDER_ROW_HEIGHT.toPx() }
+        val drag = remember { DragState() }
+
+        // Drop the drag if the item disappears (delete, cart reload) mid-gesture.
+        LaunchedEffect(items) {
+            val id = drag.draggingId ?: return@LaunchedEffect
+            if (items.none { it.id == id }) drag.reset()
+        }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -40,7 +87,7 @@ fun CartItemsList(
                     vertical = dimensionResource(id = R.dimen.margin1x),
                 ),
         ) {
-            items(items = items, key = { it.id }) { item ->
+            itemsIndexed(items = items, key = { _, it -> it.id }) { index, item ->
                 val isActive = item.id == activeId
                 CartItemRow(
                     item = item,
@@ -51,8 +98,73 @@ fun CartItemsList(
                     onNamePending = { onNamePending(item.id, it) },
                     onExpressionTap = { onExpressionTap(item) },
                     onDelete = { onDelete(item.id) },
+                    modifier =
+                        Modifier
+                            .animateItem()
+                            // Reading DragState fields inside this lambda keeps
+                            // per-frame drag updates in the draw phase — rows
+                            // don't recompose, they just re-draw at a new Y.
+                            .graphicsLayer {
+                                val isDragging = drag.draggingId == item.id
+                                translationY = dragTranslationY(drag, index, rowHeightPx, isDragging)
+                                if (isDragging) alpha = REORDER_DRAG_ALPHA
+                            },
+                    dragHandleModifier =
+                        Modifier.pointerInput(item.id) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = {
+                                    onReorderStart()
+                                    drag.draggingId = item.id
+                                    drag.draggingIndex = index
+                                    drag.targetIndex = index
+                                    drag.offsetY = 0f
+                                },
+                                onDragEnd = {
+                                    val movedId = drag.draggingId
+                                    val src = drag.draggingIndex
+                                    val dst = drag.targetIndex
+                                    if (movedId != null &&
+                                        src != null &&
+                                        dst != null &&
+                                        src != dst &&
+                                        dst in items.indices
+                                    ) {
+                                        onReorder(movedId, items[dst].id)
+                                    }
+                                    drag.reset()
+                                },
+                                onDragCancel = { drag.reset() },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    drag.offsetY += dragAmount.y
+                                    val src = drag.draggingIndex ?: return@detectDragGesturesAfterLongPress
+                                    val delta = kotlin.math.round(drag.offsetY / rowHeightPx).toInt()
+                                    drag.targetIndex = (src + delta).coerceIn(0, items.lastIndex)
+                                },
+                            )
+                        },
                 )
             }
         }
+    }
+}
+
+// How far a row at [index] should be shifted while another row is being
+// dragged. The dragged row itself follows the finger (dragOffsetY); every row
+// between old and new slots slides one row-height in the opposite direction
+// to open the gap.
+private fun dragTranslationY(
+    drag: DragState,
+    index: Int,
+    rowHeightPx: Float,
+    isDragging: Boolean,
+): Float {
+    if (isDragging) return drag.offsetY
+    val src = drag.draggingIndex ?: return 0f
+    val dst = drag.targetIndex ?: return 0f
+    return when {
+        src < dst && index in (src + 1)..dst -> -rowHeightPx
+        src > dst && index in dst until src -> rowHeightPx
+        else -> 0f
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -167,6 +167,29 @@ class CartViewModel(
         mutate { cart -> cart.copy(items = cart.items.filter { it.id != id }) }
     }
 
+    /**
+     * Move the item identified by [fromId] to the current position of [toId].
+     * No-op if either id is missing or the ids are the same — the caller (a
+     * drag-reorder gesture) is expected to fire this even when the user
+     * releases without moving, and we don't want to churn the LiveData or
+     * disk write on a no-op.
+     */
+    fun reorderItem(
+        fromId: String,
+        toId: String,
+    ) {
+        if (fromId == toId) return
+        mutate { cart ->
+            val fromIdx = cart.items.indexOfFirst { it.id == fromId }
+            val toIdx = cart.items.indexOfFirst { it.id == toId }
+            if (fromIdx < 0 || toIdx < 0) return@mutate cart
+            val reordered = cart.items.toMutableList()
+            val moved = reordered.removeAt(fromIdx)
+            reordered.add(toIdx, moved)
+            cart.copy(items = reordered)
+        }
+    }
+
     fun setBaseCurrency(currency: Currency) {
         mutate { it.copy(currency = currency.iso4217Alpha()) }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="cart_item_expression_hint">Price (e.g. 2 × 3.50)</string>
     <string name="cart_row_value_format">= %1$s %2$s</string>
     <string name="cart_delete_item">Delete item</string>
+    <string name="cart_reorder_item">Reorder item</string>
     <string name="cart_subtotal_label">Subtotal</string>
     <string name="cart_total_label">Total</string>
     <string name="cart_fee_line">Fees: %s%%</string>


### PR DESCRIPTION
## Summary
- Adds a leading drag-handle icon to each cart row; long-press then drag vertically to reorder.
- New `CartViewModel.reorderItem(fromId, toId)` mutates the cart list and persists via the existing `mutate` → `setCurrentCart` path, so order survives process death and JSON export/import (no schema change — items are already ordered by position).
- Opening a drag also closes the app keypad first, so the row being edited can't slide out from under the caret.

## Design notes
- Drag state (`draggingId`, `draggingIndex`, `targetIndex`, `offsetY`) is bundled into a single `DragState` holder whose fields are read **inside** each row's `graphicsLayer { ... }` lambda. That defers state reads to the draw phase — rows don't recompose while the finger moves at 60 Hz, only their `translationY` updates.
- Row layout is animated via `LazyColumn.animateItem()`, so once the drop commits and the underlying list changes, the slide-in is free.
- The gesture is mounted on the drag-handle icon only (not the whole row) so tapping the expression / name field still routes to their own click handlers.

## Interactions
- **#107 (keypad):** `onReorderStart` calls `closeKeypad()` before the drag takes over the visible list.
- **#108 (swipe-to-delete):** vertical long-press drag doesn't compete with horizontal swipe — different axes.
- **#109 (pin):** left as a merge-time concern. When both land, dragging a pinned row will need to either constrain within the pinned partition or auto-unpin. Suggest tackling in the follow-up integration PR.

## Follow-up
- `SearchableCurrencyPicker.FavoritesSection` uses ~90 % identical drag-reorder logic. Extracting a shared `Modifier.dragReorderHandle` + `rememberDragState` helper would deduplicate both call sites — deliberately left out of scope here to keep the PR focused.

## Test plan
- [ ] Long-press a row's drag-handle and drop it above/below another row; verify the new order persists after backing out and re-entering the cart.
- [ ] Verify order survives export → import (via the Cart export menu).
- [ ] Start a drag while the keypad is open — keypad should close, edit should commit, drag should proceed.
- [ ] Delete a row mid-drag (unlikely path but covered by a `LaunchedEffect` that resets `DragState` when the dragged id disappears).
- [ ] TalkBack: the handle announces "Reorder item".

🤖 Generated with [Claude Code](https://claude.com/claude-code)