### PR TITLE
refactor(compose): extract shared long-press drag-reorder helper

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,6 +1,5 @@
 package com.eliormachlev.currencix.view.cart.compose
 
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,12 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -22,33 +17,16 @@ import androidx.lifecycle.LiveData
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
+import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
+import com.eliormachlev.currencix.view.compose.dragReorderHandle
+import com.eliormachlev.currencix.view.compose.rememberDragReorderState
+import com.eliormachlev.currencix.view.compose.translationYFor
 
 // Nominal row height used to translate finger travel into "how many rows have
 // I dragged past". Cart rows aren't uniform (name + expression + preview), but
 // this gives a good-enough delta for a snap-to-slot reorder feel; the actual
 // list re-lays out via LazyColumn animateItem() once the drop commits.
 private val REORDER_ROW_HEIGHT = 96.dp
-private const val REORDER_DRAG_ALPHA = 0.85f
-
-// State bag for an in-progress drag. Kept as a single class (rather than four
-// loose `mutableStateOf`s) so per-frame `dragOffsetY` writes stay scoped to
-// the draw-phase `graphicsLayer` lambda instead of invalidating every row's
-// composition. Reads inside a `graphicsLayer { ... }` block subscribe at the
-// draw layer, not the composition layer — the classic Compose "read state
-// late" perf trick.
-private class DragState {
-    var draggingId by mutableStateOf<String?>(null)
-    var draggingIndex by mutableStateOf<Int?>(null)
-    var targetIndex by mutableStateOf<Int?>(null)
-    var offsetY by mutableStateOf(0f)
-
-    fun reset() {
-        draggingId = null
-        draggingIndex = null
-        targetIndex = null
-        offsetY = 0f
-    }
-}
 
 @Composable
 @Suppress("LongParameterList")
@@ -71,12 +49,14 @@ fun CartItemsList(
         val liveExpression by activeExpressionSource.observeAsState(initial = "")
 
         val rowHeightPx = with(LocalDensity.current) { REORDER_ROW_HEIGHT.toPx() }
-        val drag = remember { DragState() }
+        val drag = rememberDragReorderState()
 
-        // Drop the drag if the item disappears (delete, cart reload) mid-gesture.
+        // Drop the drag if the dragged row disappears mid-gesture (delete,
+        // cart reload) — the pointer input can't cancel itself when its item
+        // is removed from the LazyColumn.
         LaunchedEffect(items) {
-            val id = drag.draggingId ?: return@LaunchedEffect
-            if (items.none { it.id == id }) drag.reset()
+            val src = drag.draggingIndex ?: return@LaunchedEffect
+            if (src !in items.indices) drag.reset()
         }
 
         LazyColumn(
@@ -101,70 +81,22 @@ fun CartItemsList(
                     modifier =
                         Modifier
                             .animateItem()
-                            // Reading DragState fields inside this lambda keeps
-                            // per-frame drag updates in the draw phase — rows
-                            // don't recompose, they just re-draw at a new Y.
                             .graphicsLayer {
-                                val isDragging = drag.draggingId == item.id
-                                translationY = dragTranslationY(drag, index, rowHeightPx, isDragging)
-                                if (isDragging) alpha = REORDER_DRAG_ALPHA
+                                translationY = drag.translationYFor(index, rowHeightPx)
+                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
                             },
                     dragHandleModifier =
-                        Modifier.pointerInput(item.id) {
-                            detectDragGesturesAfterLongPress(
-                                onDragStart = {
-                                    onReorderStart()
-                                    drag.draggingId = item.id
-                                    drag.draggingIndex = index
-                                    drag.targetIndex = index
-                                    drag.offsetY = 0f
-                                },
-                                onDragEnd = {
-                                    val movedId = drag.draggingId
-                                    val src = drag.draggingIndex
-                                    val dst = drag.targetIndex
-                                    if (movedId != null &&
-                                        src != null &&
-                                        dst != null &&
-                                        src != dst &&
-                                        dst in items.indices
-                                    ) {
-                                        onReorder(movedId, items[dst].id)
-                                    }
-                                    drag.reset()
-                                },
-                                onDragCancel = { drag.reset() },
-                                onDrag = { change, dragAmount ->
-                                    change.consume()
-                                    drag.offsetY += dragAmount.y
-                                    val src = drag.draggingIndex ?: return@detectDragGesturesAfterLongPress
-                                    val delta = kotlin.math.round(drag.offsetY / rowHeightPx).toInt()
-                                    drag.targetIndex = (src + delta).coerceIn(0, items.lastIndex)
-                                },
-                            )
-                        },
+                        Modifier.dragReorderHandle(
+                            state = drag,
+                            index = index,
+                            key = item.id,
+                            rowHeightPx = rowHeightPx,
+                            itemCount = { items.size },
+                            onStart = onReorderStart,
+                            onCommit = { from, to -> onReorder(items[from].id, items[to].id) },
+                        ),
                 )
             }
         }
-    }
-}
-
-// How far a row at [index] should be shifted while another row is being
-// dragged. The dragged row itself follows the finger (dragOffsetY); every row
-// between old and new slots slides one row-height in the opposite direction
-// to open the gap.
-private fun dragTranslationY(
-    drag: DragState,
-    index: Int,
-    rowHeightPx: Float,
-    isDragging: Boolean,
-): Float {
-    if (isDragging) return drag.offsetY
-    val src = drag.draggingIndex ?: return 0f
-    val dst = drag.targetIndex ?: return 0f
-    return when {
-        src < dst && index in (src + 1)..dst -> -rowHeightPx
-        src > dst && index in dst until src -> rowHeightPx
-        else -> 0f
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
@@ -1,0 +1,108 @@
+package com.eliormachlev.currencix.view.compose
+
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+// Shared alpha for a row that's actively being dragged; keeps the "picked-up"
+// affordance consistent across the two long-press reorder sites (cart items,
+// starred currencies).
+const val DRAG_REORDER_ACTIVE_ALPHA = 0.85f
+
+/**
+ * State bag for a long-press-to-drag reorder gesture. Kept as a class (rather
+ * than four loose `mutableStateOf`s at call sites) so field reads inside a
+ * `graphicsLayer { ... }` lambda stay in the draw phase — rows don't
+ * recompose while the finger moves at 60 Hz, they just re-draw at a new Y.
+ */
+class DragReorderState {
+    var draggingIndex by mutableStateOf<Int?>(null)
+    var targetIndex by mutableStateOf<Int?>(null)
+    var offsetY by mutableStateOf(0f)
+
+    val isActive: Boolean get() = draggingIndex != null
+
+    fun reset() {
+        draggingIndex = null
+        targetIndex = null
+        offsetY = 0f
+    }
+}
+
+@Composable
+fun rememberDragReorderState(): DragReorderState = remember { DragReorderState() }
+
+/**
+ * Vertical translation for the row at [index], given the current drag state.
+ * The dragged row itself follows the finger (offsetY); every row between the
+ * source and target slots slides one row-height in the opposite direction to
+ * open the gap. Callers should invoke this from inside a `graphicsLayer` lambda
+ * so state reads land in the draw phase.
+ */
+fun DragReorderState.translationYFor(
+    index: Int,
+    rowHeightPx: Float,
+): Float {
+    if (draggingIndex == index) return offsetY
+    val src = draggingIndex ?: return 0f
+    val dst = targetIndex ?: return 0f
+    return when {
+        src < dst && index in (src + 1)..dst -> -rowHeightPx
+        src > dst && index in dst until src -> rowHeightPx
+        else -> 0f
+    }
+}
+
+/**
+ * Wire long-press drag-to-reorder onto a row (typically its drag-handle
+ * icon). [key] scopes the pointer input so re-composition doesn't re-install
+ * the gesture unnecessarily — pass the row's stable id. [itemCount] is read
+ * lazily so a list change mid-gesture (delete, reload) is reflected in the
+ * clamp without needing to re-key.
+ *
+ * [onCommit] fires only when the user releases on a slot different from the
+ * one they picked up from, and both indices are still valid.
+ */
+@Suppress("LongParameterList")
+fun Modifier.dragReorderHandle(
+    state: DragReorderState,
+    index: Int,
+    key: Any?,
+    rowHeightPx: Float,
+    itemCount: () -> Int,
+    onStart: () -> Unit = {},
+    onCommit: (fromIndex: Int, toIndex: Int) -> Unit,
+): Modifier =
+    pointerInput(key) {
+        detectDragGesturesAfterLongPress(
+            onDragStart = {
+                onStart()
+                state.draggingIndex = index
+                state.targetIndex = index
+                state.offsetY = 0f
+            },
+            onDragEnd = {
+                val src = state.draggingIndex
+                val dst = state.targetIndex
+                val count = itemCount()
+                if (src != null && dst != null && src != dst && src in 0 until count && dst in 0 until count) {
+                    onCommit(src, dst)
+                }
+                state.reset()
+            },
+            onDragCancel = { state.reset() },
+            onDrag = { change, dragAmount ->
+                change.consume()
+                state.offsetY += dragAmount.y
+                val src = state.draggingIndex ?: return@detectDragGesturesAfterLongPress
+                val max = itemCount() - 1
+                if (max < 0) return@detectDragGesturesAfterLongPress
+                val delta = kotlin.math.round(state.offsetY / rowHeightPx).toInt()
+                state.targetIndex = (src + delta).coerceIn(0, max)
+            },
+        )
+    }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -2,7 +2,6 @@ package com.eliormachlev.currencix.view.main.spinner
 
 import android.content.Context
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -46,7 +45,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -64,7 +62,11 @@ import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
+import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
 import com.eliormachlev.currencix.view.compose.Ltr
+import com.eliormachlev.currencix.view.compose.dragReorderHandle
+import com.eliormachlev.currencix.view.compose.rememberDragReorderState
+import com.eliormachlev.currencix.view.compose.translationYFor
 import java.math.BigDecimal
 import java.math.MathContext
 
@@ -72,7 +74,6 @@ private const val FLAG_WIDTH_DP = 24
 private const val FLAG_HEIGHT_DP = 17
 private const val FLAG_CORNER_RADIUS_DP = 2
 private const val ROW_MIN_HEIGHT_DP = 56
-private const val DRAG_ELEVATION_ALPHA = 0.85f
 private const val API_HINT_ALPHA = 0.7f
 
 // Alpha for a currency row that can't be picked in the current context
@@ -311,26 +312,12 @@ private fun FavoritesSection(
     onStarClicked: (Rate) -> Unit,
     onDragEnded: () -> Unit,
 ) {
-    var draggingIndex by remember { mutableStateOf<Int?>(null) }
-    var targetIndex by remember { mutableStateOf<Int?>(null) }
-    var dragOffsetY by remember { mutableStateOf(0f) }
-    val density = LocalDensity.current
-    val rowHeightPx = with(density) { ROW_MIN_HEIGHT_DP.dp.toPx() }
+    val drag = rememberDragReorderState()
+    val rowHeightPx = with(LocalDensity.current) { ROW_MIN_HEIGHT_DP.dp.toPx() }
 
     Column(modifier = Modifier.fillMaxWidth()) {
         items.forEachIndexed { index, rate ->
             key(rate.currency.name) {
-                val isDragging = draggingIndex == index
-                val currentIndex by rememberUpdatedState(index)
-                val src = draggingIndex
-                val tgt = targetIndex
-                val translation =
-                    when {
-                        isDragging -> dragOffsetY
-                        src != null && tgt != null && src < tgt && index in (src + 1)..tgt -> -rowHeightPx
-                        src != null && tgt != null && src > tgt && index in tgt until src -> rowHeightPx
-                        else -> 0f
-                    }
                 CurrencyRow(
                     rate = rate,
                     isStarred = true,
@@ -342,50 +329,24 @@ private fun FavoritesSection(
                         Modifier
                             .fillMaxWidth()
                             .graphicsLayer {
-                                translationY = translation
-                                if (isDragging) alpha = DRAG_ELEVATION_ALPHA
+                                translationY = drag.translationYFor(index, rowHeightPx)
+                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
                             }.then(
                                 if (allowReorder) {
-                                    Modifier.pointerInput(allowReorder) {
-                                        detectDragGesturesAfterLongPress(
-                                            onDragStart = {
-                                                draggingIndex = currentIndex
-                                                targetIndex = currentIndex
-                                                dragOffsetY = 0f
-                                            },
-                                            onDragEnd = {
-                                                val s = draggingIndex
-                                                val t = targetIndex
-                                                if (s != null &&
-                                                    t != null &&
-                                                    s != t &&
-                                                    s in items.indices &&
-                                                    t in items.indices
-                                                ) {
-                                                    Snapshot.withMutableSnapshot {
-                                                        val moved = items.removeAt(s)
-                                                        items.add(t, moved)
-                                                    }
-                                                }
-                                                draggingIndex = null
-                                                targetIndex = null
-                                                dragOffsetY = 0f
-                                                onDragEnded()
-                                            },
-                                            onDragCancel = {
-                                                draggingIndex = null
-                                                targetIndex = null
-                                                dragOffsetY = 0f
-                                            },
-                                            onDrag = { change, dragAmount ->
-                                                change.consume()
-                                                dragOffsetY += dragAmount.y
-                                                val s = draggingIndex ?: return@detectDragGesturesAfterLongPress
-                                                val delta = kotlin.math.round(dragOffsetY / rowHeightPx).toInt()
-                                                targetIndex = (s + delta).coerceIn(0, items.lastIndex)
-                                            },
-                                        )
-                                    }
+                                    Modifier.dragReorderHandle(
+                                        state = drag,
+                                        index = index,
+                                        key = rate.currency.name,
+                                        rowHeightPx = rowHeightPx,
+                                        itemCount = { items.size },
+                                        onCommit = { from, to ->
+                                            Snapshot.withMutableSnapshot {
+                                                val moved = items.removeAt(from)
+                                                items.add(to, moved)
+                                            }
+                                            onDragEnded()
+                                        },
+                                    )
                                 } else {
                                     Modifier
                                 },


### PR DESCRIPTION
## Summary
Extracts the near-identical drag-to-reorder gesture that landed in #152 (cart items) and was already present in `SearchableCurrencyPicker.FavoritesSection` (starred currencies) into a single helper at `view/compose/DragReorder.kt`.

## Why
Both sites had:
- The same four state fields (`draggingIndex`, `targetIndex`, `offsetY`, plus a source id).
- The same shift-neighbors math (\`when { src < dst && index in (src+1)..dst -> -rowHeightPx; … }\`).
- The same `detectDragGesturesAfterLongPress` block with identical `round(offset / rowHeightPx).coerceIn(...)` snap logic.
- The same `0.85f` "picked-up" alpha under two different constant names (`DRAG_ELEVATION_ALPHA` / `REORDER_DRAG_ALPHA`).

The reuse review during #152 flagged this — deliberately deferred so the cart PR stayed focused. This is the follow-up.

## Shape
- `class DragReorderState` + `rememberDragReorderState()`
- `Modifier.dragReorderHandle(state, index, key, rowHeightPx, itemCount, onStart, onCommit)`
- `DragReorderState.translationYFor(index, rowHeightPx)` — called from inside `graphicsLayer` so drag frames stay in the draw phase and don't recompose rows.
- `DRAG_REORDER_ACTIVE_ALPHA` constant

The two call sites now differ only in what they do on drop:
- **Cart** → `onCommit = { from, to -> onReorder(items[from].id, items[to].id) }` (forwards to VM).
- **Picker** → `onCommit = { from, to -> Snapshot.withMutableSnapshot { ... } }` (in-place SnapshotStateList mutation).

Row height and item count stay caller-supplied — they're inherently caller-specific.

## Base branch
Stacks on top of #152 (`feat/cart-drag-reorder`). Once #152 merges, this rebases onto master cleanly.

## Net
- CartItemsList.kt: −67 lines
- SearchableCurrencyPicker.kt: −40 lines
- +new DragReorder.kt: +110 lines
- Diff net: −107 lines across the two composables, with a single documented mechanism to update instead of two.

## Test plan
- [ ] Cart: long-press drag-handle, drop above/below → order changes and persists (unchanged behavior from #152).
- [ ] Currency picker: long-press a starred row, drop it → star order updates and persists (unchanged behavior from master).
- [ ] Verify picker drag is still gated by \`allowReorder\` (query empty AND not filtered).
- [ ] TalkBack unchanged in both sites (no changes to Icon content descriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)