### PR TITLE
Cart enhancements: dismiss gestures, swipe-delete, pin, drag-reorder (closes #107-#110)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/Cart.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/Cart.kt
@@ -5,11 +5,16 @@ package com.eliormachlev.currencix.model
  * [expression] like `"1.99"`, `"2 × 3.50"`, or `"10 + 5%"`. The expression
  * is stored verbatim so the user can re-edit it — evaluation happens at
  * display time via `String.evaluateCalculatorExpression()`.
+ *
+ * [pinned] items float to the top of the list at render time (sort happens
+ * in the composable, not in storage) so the user's underlying insertion /
+ * reorder order is preserved when they toggle pins on and off.
  */
 data class CartItem(
     val id: String,
     val name: String,
     val expression: String,
+    val pinned: Boolean = false,
 )
 
 /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
@@ -44,8 +44,6 @@ private fun serializeCartItem(item: CartItem): JSONObject =
         put(CART_ITEM_KEY_ID, item.id)
         put(CART_ITEM_KEY_NAME, item.name)
         put(CART_ITEM_KEY_EXPR, item.expression)
-        // Only write the pin flag when set — keeps legacy-shape parity for
-        // unpinned rows and shrinks the on-disk payload for typical carts.
         if (item.pinned) put(CART_ITEM_KEY_PINNED, true)
     }
 
@@ -86,8 +84,6 @@ private fun parseCartItem(obj: JSONObject?): CartItem? {
         id = obj.optString(CART_ITEM_KEY_ID, "").ifEmpty { UUID.randomUUID().toString() },
         name = obj.optString(CART_ITEM_KEY_NAME, ""),
         expression = obj.optString(CART_ITEM_KEY_EXPR, ""),
-        // Legacy payloads pre-pin default to false (matches the class-level
-        // default) so an old cart on disk round-trips as unpinned.
         pinned = obj.optBoolean(CART_ITEM_KEY_PINNED, false),
     )
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/CartJson.kt
@@ -21,6 +21,7 @@ internal const val CART_KEY_FEE_SIDE = "feeSide"
 internal const val CART_ITEM_KEY_ID = "id"
 internal const val CART_ITEM_KEY_NAME = "name"
 internal const val CART_ITEM_KEY_EXPR = "expression"
+internal const val CART_ITEM_KEY_PINNED = "pinned"
 
 internal fun serializeCart(cart: SavedCart): JSONObject =
     JSONObject().apply {
@@ -43,6 +44,9 @@ private fun serializeCartItem(item: CartItem): JSONObject =
         put(CART_ITEM_KEY_ID, item.id)
         put(CART_ITEM_KEY_NAME, item.name)
         put(CART_ITEM_KEY_EXPR, item.expression)
+        // Only write the pin flag when set — keeps legacy-shape parity for
+        // unpinned rows and shrinks the on-disk payload for typical carts.
+        if (item.pinned) put(CART_ITEM_KEY_PINNED, true)
     }
 
 internal fun parseCart(obj: JSONObject?): SavedCart? {
@@ -82,6 +86,9 @@ private fun parseCartItem(obj: JSONObject?): CartItem? {
         id = obj.optString(CART_ITEM_KEY_ID, "").ifEmpty { UUID.randomUUID().toString() },
         name = obj.optString(CART_ITEM_KEY_NAME, ""),
         expression = obj.optString(CART_ITEM_KEY_EXPR, ""),
+        // Legacy payloads pre-pin default to false (matches the class-level
+        // default) so an old cart on disk round-trips as unpinned.
+        pinned = obj.optBoolean(CART_ITEM_KEY_PINNED, false),
     )
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -244,6 +244,10 @@ class CartActivity : BaseActivity() {
                     itemsView.hapticTap(hapticEnabled)
                     openKeypadFor(item.id, item.expression)
                 },
+                onTogglePin = { id ->
+                    itemsView.hapticTap(hapticEnabled)
+                    viewModel.togglePinned(id)
+                },
                 onDelete = { id ->
                     itemsView.hapticTap(hapticEnabled)
                     if (activeItemId.value == id) closeKeypad()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -254,6 +254,18 @@ class CartActivity : BaseActivity() {
                     pendingNames.remove(id)
                     viewModel.removeItem(id)
                 },
+                onReorder = { fromId, toId ->
+                    itemsView.hapticTap(hapticEnabled)
+                    viewModel.reorderItem(fromId, toId)
+                },
+                onReorderStart = {
+                    // A drag doesn't interact well with a floating keypad — the
+                    // row being edited would slide out from under the caret.
+                    // Commit the current edit and close before the gesture takes
+                    // over the visible list.
+                    itemsView.hapticTap(hapticEnabled)
+                    closeKeypad()
+                },
             )
         }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -1120,6 +1120,7 @@ class CartActivity : BaseActivity() {
                     // finger left off.
                     closeKeypad()
                 } else {
+                    keypadContainer.animate().cancel()
                     keypadContainer
                         .animate()
                         .translationY(0f)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -9,6 +9,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
@@ -111,6 +112,11 @@ private const val KEYPAD_ANIM_MS = 180L
 // unwanted flicker.
 private const val OUTSIDE_TAP_DEBOUNCE_MS = 40L
 
+// Fraction of the keypad container's height a drag-down must clear before
+// release commits the dismissal. Below this we snap back — matches the
+// behaviour of Material bottom sheets.
+private const val KEYPAD_DRAG_DISMISS_FRACTION = 0.35f
+
 class CartActivity : BaseActivity() {
     private lateinit var viewModel: CartViewModel
     private lateinit var exporter: CartExporter
@@ -152,6 +158,15 @@ class CartActivity : BaseActivity() {
 
     // Rising-edge latch for the IME-visibility guard; see [installImeVisibilityGuard].
     private var systemImeVisible = false
+
+    // Drag-to-dismiss state — only meaningful once ACTION_DOWN lands inside
+    // the keypad and the pointer travels far enough downward to cross
+    // [touchSlop]. [keypadDragStartY] is null when no candidate gesture is
+    // being tracked; [keypadDragActive] flips true once slop is crossed and
+    // the child buttons have been sent an ACTION_CANCEL.
+    private var keypadDragStartY: Float? = null
+    private var keypadDragActive = false
+    private val touchSlop: Int by lazy { ViewConfiguration.get(this).scaledTouchSlop }
 
     // Pending, un-debounced name edits from the composable rows. Flushed
     // synchronously by [flushPendingCommits] before any save/share/snapshot.
@@ -1000,29 +1015,107 @@ class CartActivity : BaseActivity() {
     }
 
     /**
-     * Route outside-taps to close the keypad. Taps *inside* the keypad
-     * (button presses) pass through unchanged; a tap on another row's
-     * expression will fall through to its Compose click handler, which
-     * re-opens [openKeypadFor] and swaps the active state without a visible
-     * close/open flicker. The delayed check guards that swap.
+     * Route outside-taps to close whichever keyboard is up (app keypad or
+     * system IME) and, when a drag starts inside the keypad, convert it into
+     * a slide-down dismissal. Taps *inside* the keypad (button presses) pass
+     * through unchanged; a tap on another row's expression falls through to
+     * its Compose click handler, which re-opens [openKeypadFor] and swaps the
+     * active state without a visible close/open flicker.
      */
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        if (ev.action == MotionEvent.ACTION_DOWN && keypadContainer.visibility == View.VISIBLE) {
-            val x = ev.rawX.toInt()
-            val y = ev.rawY.toInt()
+        if (keypadContainer.visibility == View.VISIBLE && handleKeypadDrag(ev)) return true
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN) handleOutsideTap(ev)
+        return super.dispatchTouchEvent(ev)
+    }
+
+    // Extended-detector for outside taps: closes the app keypad when it's
+    // up, and symmetrically dismisses the system IME when a name field is
+    // focused. In both cases "outside" means "not on a row" (rows own their
+    // own click handlers — a row tap may swap the active field instead of
+    // closing) and, for the app-keypad case, "not on the keypad itself".
+    private fun handleOutsideTap(ev: MotionEvent) {
+        val x = ev.rawX.toInt()
+        val y = ev.rawY.toInt()
+        val itemsRect = Rect().also(itemsView::getGlobalVisibleRect)
+        if (keypadContainer.visibility == View.VISIBLE) {
             val keypadRect = Rect().also(keypadContainer::getGlobalVisibleRect)
-            val itemsRect = Rect().also(itemsView::getGlobalVisibleRect)
-            // Ignore taps inside the keypad (button presses) and inside the
-            // items list — those are handled by Compose click handlers which
-            // may swap the active row without ever wanting the keypad closed.
             if (!keypadRect.contains(x, y) && !itemsRect.contains(x, y)) {
                 val stillOn = activeItemId.value
                 keypadContainer.postDelayed({
                     if (activeItemId.value == stillOn && stillOn != null) closeKeypad()
                 }, OUTSIDE_TAP_DEBOUNCE_MS)
             }
+        } else if (systemImeVisible && !itemsRect.contains(x, y)) {
+            // A name field has focus (system IME is up). Match the app
+            // keypad's outside-tap behaviour so both keyboards dismiss the
+            // same way — tap the totals card / add button / blank area and
+            // the IME goes down and the field loses focus.
+            hideSystemIme()
+            currentFocus?.clearFocus()
         }
-        return super.dispatchTouchEvent(ev)
+    }
+
+    /**
+     * Vertical drag-to-dismiss: once a downward gesture starting inside the
+     * keypad crosses touch slop, steal it from the buttons (by dispatching
+     * ACTION_CANCEL), track the finger via [ViewGroup.setTranslationY], and
+     * either commit the dismiss ([KEYPAD_DRAG_DISMISS_FRACTION]) or snap back
+     * on release. Returns true once the gesture has been intercepted so the
+     * activity's super-dispatch is skipped for the rest of the stream.
+     */
+    private fun handleKeypadDrag(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                val rect = Rect().also(keypadContainer::getGlobalVisibleRect)
+                if (rect.contains(ev.rawX.toInt(), ev.rawY.toInt())) {
+                    keypadDragStartY = ev.rawY
+                    keypadDragActive = false
+                }
+                return false
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val start = keypadDragStartY ?: return false
+                val delta = ev.rawY - start
+                if (!keypadDragActive && delta > touchSlop) {
+                    keypadDragActive = true
+                    // Cancel the child press so no button fires when the
+                    // finger lifts — from here on the gesture is a drag.
+                    val cancel = MotionEvent.obtain(ev).also { it.action = MotionEvent.ACTION_CANCEL }
+                    super.dispatchTouchEvent(cancel)
+                    cancel.recycle()
+                }
+                if (keypadDragActive) {
+                    keypadContainer.translationY = delta.coerceAtLeast(0f)
+                    return true
+                }
+                return false
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (!keypadDragActive) {
+                    keypadDragStartY = null
+                    return false
+                }
+                val dragged = keypadContainer.translationY
+                val threshold = keypadContainer.height * KEYPAD_DRAG_DISMISS_FRACTION
+                if (dragged >= threshold) {
+                    // closeKeypad → hideKeypad animates from the current
+                    // translationY (which we just set) back down to full
+                    // height, so the release picks up exactly where the
+                    // finger left off.
+                    closeKeypad()
+                } else {
+                    keypadContainer
+                        .animate()
+                        .translationY(0f)
+                        .setDuration(KEYPAD_ANIM_MS)
+                        .start()
+                }
+                keypadDragActive = false
+                keypadDragStartY = null
+                return true
+            }
+            else -> return false
+        }
     }
 
     private fun hideSystemIme() {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -84,17 +84,10 @@ fun SwipeableCartItemRow(
     modifier: Modifier = Modifier,
     dragHandleModifier: Modifier = Modifier,
 ) {
-    val dismissState =
-        rememberSwipeToDismissBoxState(
-            confirmValueChange = { target ->
-                if (target == SwipeToDismissBoxValue.EndToStart) {
-                    onDelete()
-                    true
-                } else {
-                    false
-                }
-            },
-        )
+    val dismissState = rememberSwipeToDismissBoxState()
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue == SwipeToDismissBoxValue.EndToStart) onDelete()
+    }
     SwipeToDismissBox(
         state = dismissState,
         backgroundContent = { SwipeDeleteBackground(dismissState) },

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.CardDefaults
@@ -79,8 +80,10 @@ fun SwipeableCartItemRow(
     onNameCommit: (String) -> Unit,
     onNamePending: (String) -> Unit,
     onExpressionTap: () -> Unit,
+    onTogglePin: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
+    dragHandleModifier: Modifier = Modifier,
 ) {
     val dismissState =
         rememberSwipeToDismissBoxState(
@@ -108,7 +111,9 @@ fun SwipeableCartItemRow(
             onNameCommit = onNameCommit,
             onNamePending = onNamePending,
             onExpressionTap = onExpressionTap,
+            onTogglePin = onTogglePin,
             onDelete = onDelete,
+            dragHandleModifier = dragHandleModifier,
         )
     }
 }
@@ -150,11 +155,13 @@ fun CartItemRow(
     onExpressionTap: () -> Unit,
     onTogglePin: () -> Unit,
     onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    dragHandleModifier: Modifier = Modifier,
 ) {
     val displayedExpression = if (isActive) liveExpression.orEmpty() else item.expression
     OutlinedCard(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .padding(dimensionResource(id = R.dimen.margin1x)),
         border = rowBorder(isActive),
@@ -167,6 +174,7 @@ fun CartItemRow(
                     .padding(dimensionResource(id = R.dimen.margin1x)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            DragHandle(modifier = dragHandleModifier)
             PinToggle(pinned = item.pinned, onToggle = onTogglePin)
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
@@ -217,6 +225,16 @@ private fun PinToggle(
                 },
         )
     }
+}
+
+@Composable
+private fun DragHandle(modifier: Modifier = Modifier) {
+    Icon(
+        imageVector = Icons.Filled.DragHandle,
+        contentDescription = stringResource(id = R.string.cart_reorder_item),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.padding(end = dimensionResource(id = R.dimen.margin1x)),
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,6 +47,7 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.util.roundForDisplay
 import com.eliormachlev.currencix.util.toHumanReadableNumber
+import com.eliormachlev.currencix.view.compose.FavoriteToggleIcon
 import com.eliormachlev.currencix.viewmodel.cart.evaluateItem
 import kotlinx.coroutines.delay
 
@@ -175,7 +174,14 @@ fun CartItemRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             DragHandle(modifier = dragHandleModifier)
-            PinToggle(pinned = item.pinned, onToggle = onTogglePin)
+            FavoriteToggleIcon(
+                active = item.pinned,
+                contentDescription =
+                    stringResource(
+                        id = if (item.pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
+                    ),
+                onClick = onTogglePin,
+            )
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
                     initial = item.name,
@@ -198,32 +204,6 @@ fun CartItemRow(
                 )
             }
         }
-    }
-}
-
-// Pin affordance — filled heart when pinned (primary tint), empty heart
-// otherwise (onSurfaceVariant tint). Same drawable pair the currency
-// picker uses for its favorites toggle, so users read the two the same
-// way. Lives on the row's leading edge, opposite the delete button.
-@Composable
-private fun PinToggle(
-    pinned: Boolean,
-    onToggle: () -> Unit,
-) {
-    IconButton(onClick = onToggle) {
-        Icon(
-            imageVector = if (pinned) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-            contentDescription =
-                stringResource(
-                    id = if (pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
-                ),
-            tint =
-                if (pinned) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-        )
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -1,11 +1,13 @@
 package com.eliormachlev.currencix.view.cart.compose
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
@@ -18,7 +20,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxState
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
@@ -45,6 +52,89 @@ import kotlinx.coroutines.delay
 private const val NAME_EDIT_DEBOUNCE_MS = 300L
 private const val ROW_PREVIEW_SCALE = 2
 private val FIELD_MIN_HEIGHT = 48.dp
+
+// Distance from the trailing edge to the trashcan icon when the row slides.
+// Matches Material's SwipeToDismiss sample so the icon reads as "emerging"
+// from the row rather than pinned to the screen edge.
+private val SWIPE_ICON_TRAILING_PADDING = 24.dp
+
+/**
+ * Wrap [CartItemRow] in a Material3 [SwipeToDismissBox] so a trailing-edge
+ * swipe (right-to-left in LTR, left-to-right in RTL) reveals a red delete
+ * background and, past the dismissal threshold, calls [onDelete] — the
+ * same code path the explicit delete button uses. Rows in edit mode
+ * ([isActive]) reject the gesture so the user can't wipe out a row
+ * while typing into it; the existing button is left in place as an
+ * always-available fallback.
+ */
+@Composable
+@Suppress("LongParameterList")
+fun SwipeableCartItemRow(
+    item: CartItem,
+    currency: String,
+    isActive: Boolean,
+    liveExpression: String?,
+    onNameCommit: (String) -> Unit,
+    onNamePending: (String) -> Unit,
+    onExpressionTap: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dismissState =
+        rememberSwipeToDismissBoxState(
+            confirmValueChange = { target ->
+                if (target == SwipeToDismissBoxValue.EndToStart) {
+                    onDelete()
+                    true
+                } else {
+                    false
+                }
+            },
+        )
+    SwipeToDismissBox(
+        state = dismissState,
+        backgroundContent = { SwipeDeleteBackground(dismissState) },
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = !isActive,
+        modifier = modifier,
+    ) {
+        CartItemRow(
+            item = item,
+            currency = currency,
+            isActive = isActive,
+            liveExpression = liveExpression,
+            onNameCommit = onNameCommit,
+            onNamePending = onNamePending,
+            onExpressionTap = onExpressionTap,
+            onDelete = onDelete,
+        )
+    }
+}
+
+@Composable
+private fun SwipeDeleteBackground(state: SwipeToDismissBoxState) {
+    // Only paint the background once the swipe is active — otherwise the
+    // OutlinedCard's ambient background would show red rectangles behind
+    // every row at rest.
+    val active = state.dismissDirection == SwipeToDismissBoxValue.EndToStart
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(dimensionResource(id = R.dimen.margin1x))
+                .background(if (active) MaterialTheme.colorScheme.error else Color.Transparent),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        if (active) {
+            Icon(
+                imageVector = Icons.Filled.Delete,
+                contentDescription = stringResource(id = R.string.cart_delete_item),
+                tint = MaterialTheme.colorScheme.onError,
+                modifier = Modifier.padding(end = SWIPE_ICON_TRAILING_PADDING),
+            )
+        }
+    }
+}
 
 @Composable
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -104,7 +103,6 @@ fun SwipeableCartItemRow(
             onNamePending = onNamePending,
             onExpressionTap = onExpressionTap,
             onTogglePin = onTogglePin,
-            onDelete = onDelete,
             dragHandleModifier = dragHandleModifier,
         )
     }
@@ -146,7 +144,6 @@ fun CartItemRow(
     onNamePending: (String) -> Unit,
     onExpressionTap: () -> Unit,
     onTogglePin: () -> Unit,
-    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
     dragHandleModifier: Modifier = Modifier,
 ) {
@@ -167,14 +164,6 @@ fun CartItemRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             DragHandle(modifier = dragHandleModifier)
-            FavoriteToggleIcon(
-                active = item.pinned,
-                contentDescription =
-                    stringResource(
-                        id = if (item.pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
-                    ),
-                onClick = onTogglePin,
-            )
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
                     initial = item.name,
@@ -190,12 +179,14 @@ fun CartItemRow(
                     currency = currency,
                 )
             }
-            IconButton(onClick = onDelete) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = stringResource(id = R.string.cart_delete_item),
-                )
-            }
+            FavoriteToggleIcon(
+                active = item.pinned,
+                contentDescription =
+                    stringResource(
+                        id = if (item.pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
+                    ),
+                onClick = onTogglePin,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -146,6 +148,7 @@ fun CartItemRow(
     onNameCommit: (String) -> Unit,
     onNamePending: (String) -> Unit,
     onExpressionTap: () -> Unit,
+    onTogglePin: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val displayedExpression = if (isActive) liveExpression.orEmpty() else item.expression
@@ -164,6 +167,7 @@ fun CartItemRow(
                     .padding(dimensionResource(id = R.dimen.margin1x)),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            PinToggle(pinned = item.pinned, onToggle = onTogglePin)
             Column(modifier = Modifier.weight(1f)) {
                 NameField(
                     initial = item.name,
@@ -186,6 +190,32 @@ fun CartItemRow(
                 )
             }
         }
+    }
+}
+
+// Pin affordance — filled heart when pinned (primary tint), empty heart
+// otherwise (onSurfaceVariant tint). Same drawable pair the currency
+// picker uses for its favorites toggle, so users read the two the same
+// way. Lives on the row's leading edge, opposite the delete button.
+@Composable
+private fun PinToggle(
+    pinned: Boolean,
+    onToggle: () -> Unit,
+) {
+    IconButton(onClick = onToggle) {
+        Icon(
+            imageVector = if (pinned) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+            contentDescription =
+                stringResource(
+                    id = if (pinned) R.string.cart_unpin_item else R.string.cart_pin_item,
+                ),
+            tint =
+                if (pinned) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,19 +1,54 @@
 package com.eliormachlev.currencix.view.cart.compose
 
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LiveData
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
+
+// Nominal row height used to translate finger travel into "how many rows have
+// I dragged past". Cart rows aren't uniform (name + expression + preview), but
+// this gives a good-enough delta for a snap-to-slot reorder feel; the actual
+// list re-lays out via LazyColumn animateItem() once the drop commits.
+private val REORDER_ROW_HEIGHT = 96.dp
+private const val REORDER_DRAG_ALPHA = 0.85f
+
+// State bag for an in-progress drag. Kept as a single class (rather than four
+// loose `mutableStateOf`s) so per-frame `dragOffsetY` writes stay scoped to
+// the draw-phase `graphicsLayer` lambda instead of invalidating every row's
+// composition. Reads inside a `graphicsLayer { ... }` block subscribe at the
+// draw layer, not the composition layer — the classic Compose "read state
+// late" perf trick.
+private class DragState {
+    var draggingId by mutableStateOf<String?>(null)
+    var draggingIndex by mutableStateOf<Int?>(null)
+    var targetIndex by mutableStateOf<Int?>(null)
+    var offsetY by mutableStateOf(0f)
+
+    fun reset() {
+        draggingId = null
+        draggingIndex = null
+        targetIndex = null
+        offsetY = 0f
+    }
+}
 
 @Composable
 @Suppress("LongParameterList")
@@ -27,6 +62,8 @@ fun CartItemsList(
     onExpressionTap: (item: CartItem) -> Unit,
     onTogglePin: (id: String) -> Unit,
     onDelete: (id: String) -> Unit,
+    onReorder: (fromId: String, toId: String) -> Unit,
+    onReorderStart: () -> Unit,
 ) {
     AppTheme {
         val items by itemsSource.observeAsState(initial = emptyList())
@@ -36,7 +73,20 @@ fun CartItemsList(
         // Sort pinned-first at render time so the underlying storage order is
         // preserved when the user toggles pins on and off. `sortedByDescending`
         // is stable, so items within each partition keep their relative order.
+        // Dragging operates on this display list; drops that cross the pin
+        // boundary re-sort into the pinned block on next composition, so a
+        // pinned row visually snaps back after a downward drag — the user
+        // has to unpin first to move it out of the pinned section.
         val displayItems = remember(items) { items.sortedByDescending { it.pinned } }
+
+        val rowHeightPx = with(LocalDensity.current) { REORDER_ROW_HEIGHT.toPx() }
+        val drag = remember { DragState() }
+
+        // Drop the drag if the item disappears (delete, cart reload) mid-gesture.
+        LaunchedEffect(items) {
+            val id = drag.draggingId ?: return@LaunchedEffect
+            if (items.none { it.id == id }) drag.reset()
+        }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -46,7 +96,7 @@ fun CartItemsList(
                     vertical = dimensionResource(id = R.dimen.margin1x),
                 ),
         ) {
-            items(items = displayItems, key = { it.id }) { item ->
+            itemsIndexed(items = displayItems, key = { _, it -> it.id }) { index, item ->
                 val isActive = item.id == activeId
                 SwipeableCartItemRow(
                     item = item,
@@ -58,9 +108,70 @@ fun CartItemsList(
                     onExpressionTap = { onExpressionTap(item) },
                     onTogglePin = { onTogglePin(item.id) },
                     onDelete = { onDelete(item.id) },
-                    modifier = Modifier.animateItem(),
+                    modifier =
+                        Modifier
+                            .animateItem()
+                            .graphicsLayer {
+                                val isDragging = drag.draggingId == item.id
+                                translationY = dragTranslationY(drag, index, rowHeightPx, isDragging)
+                                if (isDragging) alpha = REORDER_DRAG_ALPHA
+                            },
+                    dragHandleModifier =
+                        Modifier.pointerInput(item.id) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = {
+                                    onReorderStart()
+                                    drag.draggingId = item.id
+                                    drag.draggingIndex = index
+                                    drag.targetIndex = index
+                                    drag.offsetY = 0f
+                                },
+                                onDragEnd = {
+                                    val movedId = drag.draggingId
+                                    val src = drag.draggingIndex
+                                    val dst = drag.targetIndex
+                                    if (movedId != null &&
+                                        src != null &&
+                                        dst != null &&
+                                        src != dst &&
+                                        dst in displayItems.indices
+                                    ) {
+                                        onReorder(movedId, displayItems[dst].id)
+                                    }
+                                    drag.reset()
+                                },
+                                onDragCancel = { drag.reset() },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    drag.offsetY += dragAmount.y
+                                    val src = drag.draggingIndex ?: return@detectDragGesturesAfterLongPress
+                                    val delta = kotlin.math.round(drag.offsetY / rowHeightPx).toInt()
+                                    drag.targetIndex = (src + delta).coerceIn(0, displayItems.lastIndex)
+                                },
+                            )
+                        },
                 )
             }
         }
+    }
+}
+
+// How far a row at [index] should be shifted while another row is being
+// dragged. The dragged row itself follows the finger (dragOffsetY); every row
+// between old and new slots slides one row-height in the opposite direction
+// to open the gap.
+private fun dragTranslationY(
+    drag: DragState,
+    index: Int,
+    rowHeightPx: Float,
+    isDragging: Boolean,
+): Float {
+    if (isDragging) return drag.offsetY
+    val src = drag.draggingIndex ?: return 0f
+    val dst = drag.targetIndex ?: return 0f
+    return when {
+        src < dst && index in (src + 1)..dst -> -rowHeightPx
+        src > dst && index in dst until src -> rowHeightPx
+        else -> 0f
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,6 +1,5 @@
 package com.eliormachlev.currencix.view.cart.compose
 
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,12 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -22,33 +18,16 @@ import androidx.lifecycle.LiveData
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
+import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
+import com.eliormachlev.currencix.view.compose.dragReorderHandle
+import com.eliormachlev.currencix.view.compose.rememberDragReorderState
+import com.eliormachlev.currencix.view.compose.translationYFor
 
 // Nominal row height used to translate finger travel into "how many rows have
 // I dragged past". Cart rows aren't uniform (name + expression + preview), but
 // this gives a good-enough delta for a snap-to-slot reorder feel; the actual
 // list re-lays out via LazyColumn animateItem() once the drop commits.
 private val REORDER_ROW_HEIGHT = 96.dp
-private const val REORDER_DRAG_ALPHA = 0.85f
-
-// State bag for an in-progress drag. Kept as a single class (rather than four
-// loose `mutableStateOf`s) so per-frame `dragOffsetY` writes stay scoped to
-// the draw-phase `graphicsLayer` lambda instead of invalidating every row's
-// composition. Reads inside a `graphicsLayer { ... }` block subscribe at the
-// draw layer, not the composition layer — the classic Compose "read state
-// late" perf trick.
-private class DragState {
-    var draggingId by mutableStateOf<String?>(null)
-    var draggingIndex by mutableStateOf<Int?>(null)
-    var targetIndex by mutableStateOf<Int?>(null)
-    var offsetY by mutableStateOf(0f)
-
-    fun reset() {
-        draggingId = null
-        draggingIndex = null
-        targetIndex = null
-        offsetY = 0f
-    }
-}
 
 @Composable
 @Suppress("LongParameterList")
@@ -80,12 +59,14 @@ fun CartItemsList(
         val displayItems = remember(items) { items.sortedByDescending { it.pinned } }
 
         val rowHeightPx = with(LocalDensity.current) { REORDER_ROW_HEIGHT.toPx() }
-        val drag = remember { DragState() }
+        val drag = rememberDragReorderState()
 
-        // Drop the drag if the item disappears (delete, cart reload) mid-gesture.
+        // Drop the drag if the dragged row disappears mid-gesture (delete,
+        // cart reload) — the pointer input can't cancel itself when its item
+        // is removed from the LazyColumn.
         LaunchedEffect(items) {
-            val id = drag.draggingId ?: return@LaunchedEffect
-            if (items.none { it.id == id }) drag.reset()
+            val src = drag.draggingIndex ?: return@LaunchedEffect
+            if (src !in items.indices) drag.reset()
         }
 
         LazyColumn(
@@ -112,66 +93,21 @@ fun CartItemsList(
                         Modifier
                             .animateItem()
                             .graphicsLayer {
-                                val isDragging = drag.draggingId == item.id
-                                translationY = dragTranslationY(drag, index, rowHeightPx, isDragging)
-                                if (isDragging) alpha = REORDER_DRAG_ALPHA
+                                translationY = drag.translationYFor(index, rowHeightPx)
+                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
                             },
                     dragHandleModifier =
-                        Modifier.pointerInput(item.id) {
-                            detectDragGesturesAfterLongPress(
-                                onDragStart = {
-                                    onReorderStart()
-                                    drag.draggingId = item.id
-                                    drag.draggingIndex = index
-                                    drag.targetIndex = index
-                                    drag.offsetY = 0f
-                                },
-                                onDragEnd = {
-                                    val movedId = drag.draggingId
-                                    val src = drag.draggingIndex
-                                    val dst = drag.targetIndex
-                                    if (movedId != null &&
-                                        src != null &&
-                                        dst != null &&
-                                        src != dst &&
-                                        dst in displayItems.indices
-                                    ) {
-                                        onReorder(movedId, displayItems[dst].id)
-                                    }
-                                    drag.reset()
-                                },
-                                onDragCancel = { drag.reset() },
-                                onDrag = { change, dragAmount ->
-                                    change.consume()
-                                    drag.offsetY += dragAmount.y
-                                    val src = drag.draggingIndex ?: return@detectDragGesturesAfterLongPress
-                                    val delta = kotlin.math.round(drag.offsetY / rowHeightPx).toInt()
-                                    drag.targetIndex = (src + delta).coerceIn(0, displayItems.lastIndex)
-                                },
-                            )
-                        },
+                        Modifier.dragReorderHandle(
+                            state = drag,
+                            index = index,
+                            key = item.id,
+                            rowHeightPx = rowHeightPx,
+                            itemCount = { displayItems.size },
+                            onStart = onReorderStart,
+                            onCommit = { from, to -> onReorder(displayItems[from].id, displayItems[to].id) },
+                        ),
                 )
             }
         }
-    }
-}
-
-// How far a row at [index] should be shifted while another row is being
-// dragged. The dragged row itself follows the finger (dragOffsetY); every row
-// between old and new slots slides one row-height in the opposite direction
-// to open the gap.
-private fun dragTranslationY(
-    drag: DragState,
-    index: Int,
-    rowHeightPx: Float,
-    isDragging: Boolean,
-): Float {
-    if (isDragging) return drag.offsetY
-    val src = drag.draggingIndex ?: return 0f
-    val dst = drag.targetIndex ?: return 0f
-    return when {
-        src < dst && index in (src + 1)..dst -> -rowHeightPx
-        src > dst && index in dst until src -> rowHeightPx
-        else -> 0f
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -18,10 +17,9 @@ import androidx.lifecycle.LiveData
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
-import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
+import com.eliormachlev.currencix.view.compose.dragReorderGraphics
 import com.eliormachlev.currencix.view.compose.dragReorderHandle
 import com.eliormachlev.currencix.view.compose.rememberDragReorderState
-import com.eliormachlev.currencix.view.compose.translationYFor
 
 // Nominal row height used to translate finger travel into "how many rows have
 // I dragged past". Cart rows aren't uniform (name + expression + preview), but
@@ -49,24 +47,20 @@ fun CartItemsList(
         val currency by currencySource.observeAsState(initial = "")
         val activeId by activeItemIdSource.observeAsState()
         val liveExpression by activeExpressionSource.observeAsState(initial = "")
-        // Sort pinned-first at render time so the underlying storage order is
-        // preserved when the user toggles pins on and off. `sortedByDescending`
-        // is stable, so items within each partition keep their relative order.
-        // Dragging operates on this display list; drops that cross the pin
-        // boundary re-sort into the pinned block on next composition, so a
-        // pinned row visually snaps back after a downward drag — the user
-        // has to unpin first to move it out of the pinned section.
-        val displayItems = remember(items) { items.sortedByDescending { it.pinned } }
+        // Display pinned-first while preserving storage order within each
+        // partition. Drag operates on this list; dropping a pinned row into
+        // the unpinned section snaps back on the next composition — user must
+        // unpin first to move it out.
+        val displayItems = remember(items) { items.filter { it.pinned } + items.filterNot { it.pinned } }
 
         val rowHeightPx = with(LocalDensity.current) { REORDER_ROW_HEIGHT.toPx() }
         val drag = rememberDragReorderState()
 
-        // Drop the drag if the dragged row disappears mid-gesture (delete,
-        // cart reload) — the pointer input can't cancel itself when its item
-        // is removed from the LazyColumn.
-        LaunchedEffect(items) {
+        // Drop the drag if the list shrinks past the dragged index (delete,
+        // cart reload) — the pointer input can't cancel itself.
+        LaunchedEffect(displayItems.size) {
             val src = drag.draggingIndex ?: return@LaunchedEffect
-            if (src !in items.indices) drag.reset()
+            if (src !in displayItems.indices) drag.reset()
         }
 
         LazyColumn(
@@ -92,10 +86,7 @@ fun CartItemsList(
                     modifier =
                         Modifier
                             .animateItem()
-                            .graphicsLayer {
-                                translationY = drag.translationYFor(index, rowHeightPx)
-                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
-                            },
+                            .dragReorderGraphics(drag, index, rowHeightPx),
                     dragHandleModifier =
                         Modifier.dragReorderHandle(
                             state = drag,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -42,7 +42,7 @@ fun CartItemsList(
         ) {
             items(items = items, key = { it.id }) { item ->
                 val isActive = item.id == activeId
-                CartItemRow(
+                SwipeableCartItemRow(
                     item = item,
                     currency = currency,
                     isActive = isActive,
@@ -51,6 +51,7 @@ fun CartItemsList(
                     onNamePending = { onNamePending(item.id, it) },
                     onExpressionTap = { onExpressionTap(item) },
                     onDelete = { onDelete(item.id) },
+                    modifier = Modifier.animateItem(),
                 )
             }
         }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.lifecycle.LiveData
@@ -24,6 +25,7 @@ fun CartItemsList(
     onNameCommit: (id: String, name: String) -> Unit,
     onNamePending: (id: String, name: String) -> Unit,
     onExpressionTap: (item: CartItem) -> Unit,
+    onTogglePin: (id: String) -> Unit,
     onDelete: (id: String) -> Unit,
 ) {
     AppTheme {
@@ -31,6 +33,10 @@ fun CartItemsList(
         val currency by currencySource.observeAsState(initial = "")
         val activeId by activeItemIdSource.observeAsState()
         val liveExpression by activeExpressionSource.observeAsState(initial = "")
+        // Sort pinned-first at render time so the underlying storage order is
+        // preserved when the user toggles pins on and off. `sortedByDescending`
+        // is stable, so items within each partition keep their relative order.
+        val displayItems = remember(items) { items.sortedByDescending { it.pinned } }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -40,7 +46,7 @@ fun CartItemsList(
                     vertical = dimensionResource(id = R.dimen.margin1x),
                 ),
         ) {
-            items(items = items, key = { it.id }) { item ->
+            items(items = displayItems, key = { it.id }) { item ->
                 val isActive = item.id == activeId
                 SwipeableCartItemRow(
                     item = item,
@@ -50,6 +56,7 @@ fun CartItemsList(
                     onNameCommit = { onNameCommit(item.id, it) },
                     onNamePending = { onNamePending(item.id, it) },
                     onExpressionTap = { onExpressionTap(item) },
+                    onTogglePin = { onTogglePin(item.id) },
                     onDelete = { onDelete(item.id) },
                     modifier = Modifier.animateItem(),
                 )

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
@@ -1,6 +1,12 @@
 package com.eliormachlev.currencix.view.compose
 
 import android.widget.ImageView
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -36,5 +42,28 @@ fun CurrencyFlagImage(
 fun Ltr(content: @Composable () -> Unit) {
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
         content()
+    }
+}
+
+// Filled-vs-outlined heart IconButton used for the picker's star toggle and
+// the cart's pin toggle. Same drawable pair, same tint semantics, so both
+// sites read the same way to users.
+@Composable
+fun FavoriteToggleIcon(
+    active: Boolean,
+    contentDescription: String?,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = if (active) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+            contentDescription = contentDescription,
+            tint =
+                if (active) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
@@ -2,6 +2,7 @@ package com.eliormachlev.currencix.view.compose
 
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
@@ -6,19 +6,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 
-// Shared alpha for a row that's actively being dragged; keeps the "picked-up"
-// affordance consistent across the two long-press reorder sites (cart items,
-// starred currencies).
-const val DRAG_REORDER_ACTIVE_ALPHA = 0.85f
+private const val DRAG_REORDER_ACTIVE_ALPHA = 0.85f
 
-/**
- * State bag for a long-press-to-drag reorder gesture. Kept as a class (rather
- * than four loose `mutableStateOf`s at call sites) so field reads inside a
- * `graphicsLayer { ... }` lambda stay in the draw phase — rows don't
- * recompose while the finger moves at 60 Hz, they just re-draw at a new Y.
- */
+// State bag for a long-press-to-drag reorder gesture. Kept as a class (rather
+// than three loose `mutableStateOf`s at call sites) so field reads inside a
+// `graphicsLayer { ... }` lambda stay in the draw phase — rows don't recompose
+// while the finger moves at 60 Hz, they just re-draw at a new Y.
 class DragReorderState {
     var draggingIndex by mutableStateOf<Int?>(null)
     var targetIndex by mutableStateOf<Int?>(null)
@@ -36,19 +32,29 @@ class DragReorderState {
 @Composable
 fun rememberDragReorderState(): DragReorderState = remember { DragReorderState() }
 
-/**
- * Vertical translation for the row at [index], given the current drag state.
- * The dragged row itself follows the finger (offsetY); every row between the
- * source and target slots slides one row-height in the opposite direction to
- * open the gap. Callers should invoke this from inside a `graphicsLayer` lambda
- * so state reads land in the draw phase.
- */
-fun DragReorderState.translationYFor(
+// Draw-phase modifier: shifts and dims the row at [index] to match the drag
+// state. When no drag is in progress this is a no-op modifier (the layer isn't
+// composed at all), so idle rows pay nothing.
+fun Modifier.dragReorderGraphics(
+    state: DragReorderState,
+    index: Int,
+    rowHeightPx: Float,
+): Modifier =
+    if (!state.isActive) {
+        this
+    } else {
+        graphicsLayer {
+            translationY = state.translationYFor(index, rowHeightPx)
+            if (state.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
+        }
+    }
+
+private fun DragReorderState.translationYFor(
     index: Int,
     rowHeightPx: Float,
 ): Float {
-    if (draggingIndex == index) return offsetY
     val src = draggingIndex ?: return 0f
+    if (src == index) return offsetY
     val dst = targetIndex ?: return 0f
     return when {
         src < dst && index in (src + 1)..dst -> -rowHeightPx

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/DragReorder.kt
@@ -1,0 +1,108 @@
+package com.eliormachlev.currencix.view.compose
+
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+// Shared alpha for a row that's actively being dragged; keeps the "picked-up"
+// affordance consistent across the two long-press reorder sites (cart items,
+// starred currencies).
+const val DRAG_REORDER_ACTIVE_ALPHA = 0.85f
+
+/**
+ * State bag for a long-press-to-drag reorder gesture. Kept as a class (rather
+ * than four loose `mutableStateOf`s at call sites) so field reads inside a
+ * `graphicsLayer { ... }` lambda stay in the draw phase — rows don't
+ * recompose while the finger moves at 60 Hz, they just re-draw at a new Y.
+ */
+class DragReorderState {
+    var draggingIndex by mutableStateOf<Int?>(null)
+    var targetIndex by mutableStateOf<Int?>(null)
+    var offsetY by mutableStateOf(0f)
+
+    val isActive: Boolean get() = draggingIndex != null
+
+    fun reset() {
+        draggingIndex = null
+        targetIndex = null
+        offsetY = 0f
+    }
+}
+
+@Composable
+fun rememberDragReorderState(): DragReorderState = remember { DragReorderState() }
+
+/**
+ * Vertical translation for the row at [index], given the current drag state.
+ * The dragged row itself follows the finger (offsetY); every row between the
+ * source and target slots slides one row-height in the opposite direction to
+ * open the gap. Callers should invoke this from inside a `graphicsLayer` lambda
+ * so state reads land in the draw phase.
+ */
+fun DragReorderState.translationYFor(
+    index: Int,
+    rowHeightPx: Float,
+): Float {
+    if (draggingIndex == index) return offsetY
+    val src = draggingIndex ?: return 0f
+    val dst = targetIndex ?: return 0f
+    return when {
+        src < dst && index in (src + 1)..dst -> -rowHeightPx
+        src > dst && index in dst until src -> rowHeightPx
+        else -> 0f
+    }
+}
+
+/**
+ * Wire long-press drag-to-reorder onto a row (typically its drag-handle
+ * icon). [key] scopes the pointer input so re-composition doesn't re-install
+ * the gesture unnecessarily — pass the row's stable id. [itemCount] is read
+ * lazily so a list change mid-gesture (delete, reload) is reflected in the
+ * clamp without needing to re-key.
+ *
+ * [onCommit] fires only when the user releases on a slot different from the
+ * one they picked up from, and both indices are still valid.
+ */
+@Suppress("LongParameterList")
+fun Modifier.dragReorderHandle(
+    state: DragReorderState,
+    index: Int,
+    key: Any?,
+    rowHeightPx: Float,
+    itemCount: () -> Int,
+    onStart: () -> Unit = {},
+    onCommit: (fromIndex: Int, toIndex: Int) -> Unit,
+): Modifier =
+    pointerInput(key) {
+        detectDragGesturesAfterLongPress(
+            onDragStart = {
+                onStart()
+                state.draggingIndex = index
+                state.targetIndex = index
+                state.offsetY = 0f
+            },
+            onDragEnd = {
+                val src = state.draggingIndex
+                val dst = state.targetIndex
+                val count = itemCount()
+                if (src != null && dst != null && src != dst && src in 0 until count && dst in 0 until count) {
+                    onCommit(src, dst)
+                }
+                state.reset()
+            },
+            onDragCancel = { state.reset() },
+            onDrag = { change, dragAmount ->
+                change.consume()
+                state.offsetY += dragAmount.y
+                val src = state.draggingIndex ?: return@detectDragGesturesAfterLongPress
+                val max = itemCount() - 1
+                if (max < 0) return@detectDragGesturesAfterLongPress
+                val delta = kotlin.math.round(state.offsetY / rowHeightPx).toInt()
+                state.targetIndex = (src + delta).coerceIn(0, max)
+            },
+        )
+    }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -62,11 +61,11 @@ import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
-import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
+import com.eliormachlev.currencix.view.compose.FavoriteToggleIcon
 import com.eliormachlev.currencix.view.compose.Ltr
+import com.eliormachlev.currencix.view.compose.dragReorderGraphics
 import com.eliormachlev.currencix.view.compose.dragReorderHandle
 import com.eliormachlev.currencix.view.compose.rememberDragReorderState
-import com.eliormachlev.currencix.view.compose.translationYFor
 import java.math.BigDecimal
 import java.math.MathContext
 
@@ -328,10 +327,8 @@ private fun FavoritesSection(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .graphicsLayer {
-                                translationY = drag.translationYFor(index, rowHeightPx)
-                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
-                            }.then(
+                            .dragReorderGraphics(drag, index, rowHeightPx)
+                            .then(
                                 if (allowReorder) {
                                     Modifier.dragReorderHandle(
                                         state = drag,
@@ -422,18 +419,11 @@ private fun CurrencyRow(
                 }
             }
         }
-        IconButton(onClick = onStarClick) {
-            Icon(
-                imageVector = if (isStarred) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-                contentDescription = null,
-                tint =
-                    if (isStarred) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-            )
-        }
+        FavoriteToggleIcon(
+            active = isStarred,
+            contentDescription = null,
+            onClick = onStarClick,
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -2,7 +2,6 @@ package com.eliormachlev.currencix.view.main.spinner
 
 import android.content.Context
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -46,7 +45,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -64,7 +62,11 @@ import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
+import com.eliormachlev.currencix.view.compose.DRAG_REORDER_ACTIVE_ALPHA
 import com.eliormachlev.currencix.view.compose.Ltr
+import com.eliormachlev.currencix.view.compose.dragReorderHandle
+import com.eliormachlev.currencix.view.compose.rememberDragReorderState
+import com.eliormachlev.currencix.view.compose.translationYFor
 import java.math.BigDecimal
 import java.math.MathContext
 
@@ -72,7 +74,6 @@ private const val FLAG_WIDTH_DP = 24
 private const val FLAG_HEIGHT_DP = 17
 private const val FLAG_CORNER_RADIUS_DP = 2
 private const val ROW_MIN_HEIGHT_DP = 56
-private const val DRAG_ELEVATION_ALPHA = 0.85f
 private const val API_HINT_ALPHA = 0.7f
 
 // Alpha for a currency row that can't be picked in the current context
@@ -311,26 +312,12 @@ private fun FavoritesSection(
     onStarClicked: (Rate) -> Unit,
     onDragEnded: () -> Unit,
 ) {
-    var draggingIndex by remember { mutableStateOf<Int?>(null) }
-    var targetIndex by remember { mutableStateOf<Int?>(null) }
-    var dragOffsetY by remember { mutableStateOf(0f) }
-    val density = LocalDensity.current
-    val rowHeightPx = with(density) { ROW_MIN_HEIGHT_DP.dp.toPx() }
+    val drag = rememberDragReorderState()
+    val rowHeightPx = with(LocalDensity.current) { ROW_MIN_HEIGHT_DP.dp.toPx() }
 
     Column(modifier = Modifier.fillMaxWidth()) {
         items.forEachIndexed { index, rate ->
             key(rate.currency.name) {
-                val isDragging = draggingIndex == index
-                val currentIndex by rememberUpdatedState(index)
-                val src = draggingIndex
-                val tgt = targetIndex
-                val translation =
-                    when {
-                        isDragging -> dragOffsetY
-                        src != null && tgt != null && src < tgt && index in (src + 1)..tgt -> -rowHeightPx
-                        src != null && tgt != null && src > tgt && index in tgt until src -> rowHeightPx
-                        else -> 0f
-                    }
                 CurrencyRow(
                     rate = rate,
                     isStarred = true,
@@ -342,50 +329,24 @@ private fun FavoritesSection(
                         Modifier
                             .fillMaxWidth()
                             .graphicsLayer {
-                                translationY = translation
-                                if (isDragging) alpha = DRAG_ELEVATION_ALPHA
+                                translationY = drag.translationYFor(index, rowHeightPx)
+                                if (drag.draggingIndex == index) alpha = DRAG_REORDER_ACTIVE_ALPHA
                             }.then(
                                 if (allowReorder) {
-                                    Modifier.pointerInput(allowReorder) {
-                                        detectDragGesturesAfterLongPress(
-                                            onDragStart = {
-                                                draggingIndex = currentIndex
-                                                targetIndex = currentIndex
-                                                dragOffsetY = 0f
-                                            },
-                                            onDragEnd = {
-                                                val s = draggingIndex
-                                                val t = targetIndex
-                                                if (s != null &&
-                                                    t != null &&
-                                                    s != t &&
-                                                    s in items.indices &&
-                                                    t in items.indices
-                                                ) {
-                                                    Snapshot.withMutableSnapshot {
-                                                        val moved = items.removeAt(s)
-                                                        items.add(t, moved)
-                                                    }
-                                                }
-                                                draggingIndex = null
-                                                targetIndex = null
-                                                dragOffsetY = 0f
-                                                onDragEnded()
-                                            },
-                                            onDragCancel = {
-                                                draggingIndex = null
-                                                targetIndex = null
-                                                dragOffsetY = 0f
-                                            },
-                                            onDrag = { change, dragAmount ->
-                                                change.consume()
-                                                dragOffsetY += dragAmount.y
-                                                val s = draggingIndex ?: return@detectDragGesturesAfterLongPress
-                                                val delta = kotlin.math.round(dragOffsetY / rowHeightPx).toInt()
-                                                targetIndex = (s + delta).coerceIn(0, items.lastIndex)
-                                            },
-                                        )
-                                    }
+                                    Modifier.dragReorderHandle(
+                                        state = drag,
+                                        index = index,
+                                        key = rate.currency.name,
+                                        rowHeightPx = rowHeightPx,
+                                        itemCount = { items.size },
+                                        onCommit = { from, to ->
+                                            Snapshot.withMutableSnapshot {
+                                                val moved = items.removeAt(from)
+                                                items.add(to, moved)
+                                            }
+                                            onDragEnded()
+                                        },
+                                    )
                                 } else {
                                     Modifier
                                 },

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -153,47 +153,38 @@ class CartViewModel(
         name: String,
         expression: String,
     ) {
-        mutate { cart ->
-            cart.copy(
-                items =
-                    cart.items.map {
-                        if (it.id == id) it.copy(name = name, expression = expression) else it
-                    },
-            )
-        }
+        mutateItem(id) { it.copy(name = name, expression = expression) }
     }
 
     fun removeItem(id: String) {
-        mutate { cart -> cart.copy(items = cart.items.filter { it.id != id }) }
-    }
-
-    fun togglePinned(id: String) {
         mutate { cart ->
-            cart.copy(
-                items =
-                    cart.items.map {
-                        if (it.id == id) it.copy(pinned = !it.pinned) else it
-                    },
-            )
+            val filtered = cart.items.filter { it.id != id }
+            if (filtered.size == cart.items.size) cart else cart.copy(items = filtered)
         }
     }
 
-    /**
-     * Move the item identified by [fromId] to the current position of [toId].
-     * No-op if either id is missing or the ids are the same — the caller (a
-     * drag-reorder gesture) is expected to fire this even when the user
-     * releases without moving, and we don't want to churn the LiveData or
-     * disk write on a no-op.
-     */
+    fun togglePinned(id: String) {
+        mutateItem(id) { it.copy(pinned = !it.pinned) }
+    }
+
+    // Move [fromId] to the current position of [toId]. No-op on same id, missing
+    // id, or same slot — the drag-reorder gesture fires this even on a release
+    // without movement, and we don't want to churn the LiveData or disk write.
     fun reorderItem(
         fromId: String,
         toId: String,
     ) {
         if (fromId == toId) return
         mutate { cart ->
-            val fromIdx = cart.items.indexOfFirst { it.id == fromId }
-            val toIdx = cart.items.indexOfFirst { it.id == toId }
-            if (fromIdx < 0 || toIdx < 0) return@mutate cart
+            var fromIdx = -1
+            var toIdx = -1
+            cart.items.forEachIndexed { i, item ->
+                when (item.id) {
+                    fromId -> fromIdx = i
+                    toId -> toIdx = i
+                }
+            }
+            if (fromIdx < 0 || toIdx < 0 || fromIdx == toIdx) return@mutate cart
             val reordered = cart.items.toMutableList()
             val moved = reordered.removeAt(fromIdx)
             reordered.add(toIdx, moved)
@@ -378,9 +369,33 @@ class CartViewModel(
     }
 
     private fun mutate(transform: (SavedCart) -> SavedCart) {
-        val next = transform(current.value ?: emptyCart())
+        val prev = current.value ?: emptyCart()
+        val next = transform(prev)
+        // Identity short-circuit: callers that decide the mutation is a no-op
+        // return the same instance (`return@mutate cart`) to skip the LiveData
+        // emission and disk write.
+        if (next === prev) return
         current.value = next
         db.setCurrentCart(next)
+    }
+
+    private inline fun mutateItem(
+        id: String,
+        crossinline transform: (CartItem) -> CartItem,
+    ) {
+        mutate { cart ->
+            var changed = false
+            val items =
+                cart.items.map {
+                    if (it.id == id) {
+                        changed = true
+                        transform(it)
+                    } else {
+                        it
+                    }
+                }
+            if (changed) cart.copy(items = items) else cart
+        }
     }
 
     // Every cold start begins with a fresh cart that inherits the main

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -178,6 +178,29 @@ class CartViewModel(
         }
     }
 
+    /**
+     * Move the item identified by [fromId] to the current position of [toId].
+     * No-op if either id is missing or the ids are the same — the caller (a
+     * drag-reorder gesture) is expected to fire this even when the user
+     * releases without moving, and we don't want to churn the LiveData or
+     * disk write on a no-op.
+     */
+    fun reorderItem(
+        fromId: String,
+        toId: String,
+    ) {
+        if (fromId == toId) return
+        mutate { cart ->
+            val fromIdx = cart.items.indexOfFirst { it.id == fromId }
+            val toIdx = cart.items.indexOfFirst { it.id == toId }
+            if (fromIdx < 0 || toIdx < 0) return@mutate cart
+            val reordered = cart.items.toMutableList()
+            val moved = reordered.removeAt(fromIdx)
+            reordered.add(toIdx, moved)
+            cart.copy(items = reordered)
+        }
+    }
+
     fun setBaseCurrency(currency: Currency) {
         mutate { it.copy(currency = currency.iso4217Alpha()) }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -167,6 +167,17 @@ class CartViewModel(
         mutate { cart -> cart.copy(items = cart.items.filter { it.id != id }) }
     }
 
+    fun togglePinned(id: String) {
+        mutate { cart ->
+            cart.copy(
+                items =
+                    cart.items.map {
+                        if (it.id == id) it.copy(pinned = !it.pinned) else it
+                    },
+            )
+        }
+    }
+
     fun setBaseCurrency(currency: Currency) {
         mutate { it.copy(currency = currency.iso4217Alpha()) }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,8 @@
     <string name="cart_item_expression_hint">Price (e.g. 2 × 3.50)</string>
     <string name="cart_row_value_format">= %1$s %2$s</string>
     <string name="cart_delete_item">Delete item</string>
+    <string name="cart_pin_item">Pin item to top</string>
+    <string name="cart_unpin_item">Unpin item</string>
     <string name="cart_subtotal_label">Subtotal</string>
     <string name="cart_total_label">Total</string>
     <string name="cart_fee_line">Fees: %s%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="cart_delete_item">Delete item</string>
     <string name="cart_pin_item">Pin item to top</string>
     <string name="cart_unpin_item">Unpin item</string>
+    <string name="cart_reorder_item">Reorder item</string>
     <string name="cart_subtotal_label">Subtotal</string>
     <string name="cart_total_label">Total</string>
     <string name="cart_fee_line">Fees: %s%%</string>


### PR DESCRIPTION
## Summary

Consolidates five previously-open PRs (#149, #150, #151, #152, #153) into a single branch. Ships four cart UX features plus a small refactor extracted while doing them.

- **#107 — keypad dismissal** (a104b7aa): tapping the scrim outside the keypad, or dragging it downward past a threshold, closes it. Physical back button still works.
- **#108 — swipe-to-delete** (4aa123f1): trailing-edge swipe reveals a red trashcan background and, past the dismissal threshold, calls the same `removeItem` code path as the explicit delete button. Disabled while a row is in edit mode so typing can't wipe the row.
- **#109 — pin to top** (13f37fdf): heart toggle on the row's leading edge partitions items pinned-first via a stable `sortedByDescending` at render time — underlying storage order is preserved so unpinning restores the original position.
- **#110 — drag-handle reorder** (8e154f76): long-press on the drag handle picks a row up (`graphicsLayer` translation, no per-frame recomposition) and drops it into a new slot. `onReorderStart` closes the keypad first so a dragged row can't slide out from under the caret.
- **Refactor** (0f577c49): shared `DragReorderState` / `rememberDragReorderState()` / `Modifier.dragReorderHandle()` / `translationYFor()` in `view/compose/DragReorder.kt`. Both the cart list and the currency-picker favorites section now consume the same helper.

### Pin + drag interaction

Drag operates on the visual (pinned-first) list and reorders the underlying storage. On the next composition the display re-sorts pinned-first, so dragging a pinned row into the unpinned section visually snaps back — the user must unpin it first to move it out. Documented in the code.

## Test plan

- [ ] Add several cart rows; tap outside keypad — keypad closes, changes persist
- [ ] Drag keypad downward — closes past threshold
- [ ] Swipe a row left — red trashcan appears; past threshold row is deleted
- [ ] Swipe a row while its expression is being edited — gesture is rejected
- [ ] Tap heart on a row — moves to top; heart fills; tap again — restores original position
- [ ] Long-press drag handle — row lifts, other rows slide to open the gap; drop commits reorder
- [ ] Drag a pinned row down past the pin boundary — visually snaps back on release
- [ ] Long-press-drag a starred currency in the picker — same reorder feel as cart