### PR TITLE
Fix cart outside-tap: close keyboards on blank items area (#107)

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -266,6 +266,7 @@ class CartActivity : BaseActivity() {
                     itemsView.hapticTap(hapticEnabled)
                     closeKeypad()
                 },
+                onBackgroundTap = ::dismissKeyboards,
             )
         }
 
@@ -1044,30 +1045,28 @@ class CartActivity : BaseActivity() {
         return super.dispatchTouchEvent(ev)
     }
 
-    // Extended-detector for outside taps: closes the app keypad when it's
-    // up, and symmetrically dismisses the system IME when a name field is
-    // focused. In both cases "outside" means "not on a row" (rows own their
-    // own click handlers — a row tap may swap the active field instead of
-    // closing) and, for the app-keypad case, "not on the keypad itself".
+    // Outside-tap detector for regions that live *outside* the items
+    // ComposeView (toolbar area, totals card / add-item button when the IME
+    // is up and the keypad is down). Taps *inside* the items view — including
+    // the blank space below the last row — are handled by the composable-side
+    // background-tap detector in [CartItemsList], which knows exactly which
+    // taps rows consumed. This handler keeps a short debounce on the keypad
+    // path so a tap that lands just outside the ComposeView on a row that's
+    // about to swap active state doesn't close prematurely.
     private fun handleOutsideTap(ev: MotionEvent) {
         val x = ev.rawX.toInt()
         val y = ev.rawY.toInt()
         val itemsRect = Rect().also(itemsView::getGlobalVisibleRect)
+        if (itemsRect.contains(x, y)) return
         if (keypadContainer.visibility == View.VISIBLE) {
             val keypadRect = Rect().also(keypadContainer::getGlobalVisibleRect)
-            if (!keypadRect.contains(x, y) && !itemsRect.contains(x, y)) {
-                val stillOn = activeItemId.value
-                keypadContainer.postDelayed({
-                    if (activeItemId.value == stillOn && stillOn != null) closeKeypad()
-                }, OUTSIDE_TAP_DEBOUNCE_MS)
-            }
-        } else if (systemImeVisible && !itemsRect.contains(x, y)) {
-            // A name field has focus (system IME is up). Match the app
-            // keypad's outside-tap behaviour so both keyboards dismiss the
-            // same way — tap the totals card / add button / blank area and
-            // the IME goes down and the field loses focus.
-            hideSystemIme()
-            currentFocus?.clearFocus()
+            if (keypadRect.contains(x, y)) return
+            val stillOn = activeItemId.value
+            keypadContainer.postDelayed({
+                if (activeItemId.value == stillOn && stillOn != null) closeKeypad()
+            }, OUTSIDE_TAP_DEBOUNCE_MS)
+        } else if (systemImeVisible) {
+            dismissKeyboards()
         }
     }
 
@@ -1139,6 +1138,18 @@ class CartActivity : BaseActivity() {
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager ?: return
         val token = currentFocus?.windowToken ?: window.decorView.windowToken ?: return
         imm.hideSoftInputFromWindow(token, 0)
+    }
+
+    // Single "get rid of whichever keyboard is up" entry point, shared by the
+    // outside-tap detector in [dispatchTouchEvent] and the composable-side
+    // background-tap detector inside [CartItemsList]. Both keyboards are
+    // handled together so callers don't need to know which one is visible.
+    private fun dismissKeyboards() {
+        if (keypadContainer.visibility == View.VISIBLE) closeKeypad()
+        if (systemImeVisible) {
+            hideSystemIme()
+            currentFocus?.clearFocus()
+        }
     }
 
     // Cancel every row's pending debounce and push its current buffer to the

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -1045,14 +1045,9 @@ class CartActivity : BaseActivity() {
         return super.dispatchTouchEvent(ev)
     }
 
-    // Outside-tap detector for regions that live *outside* the items
-    // ComposeView (toolbar area, totals card / add-item button when the IME
-    // is up and the keypad is down). Taps *inside* the items view — including
-    // the blank space below the last row — are handled by the composable-side
-    // background-tap detector in [CartItemsList], which knows exactly which
-    // taps rows consumed. This handler keeps a short debounce on the keypad
-    // path so a tap that lands just outside the ComposeView on a row that's
-    // about to swap active state doesn't close prematurely.
+    // Only owns taps outside the items ComposeView (toolbar, totals card,
+    // add-item button when the IME is up). Taps inside the items view are
+    // resolved by Compose in [CartItemsList] via onBackgroundTap.
     private fun handleOutsideTap(ev: MotionEvent) {
         val x = ev.rawX.toInt()
         val y = ev.rawY.toInt()
@@ -1140,10 +1135,6 @@ class CartActivity : BaseActivity() {
         imm.hideSoftInputFromWindow(token, 0)
     }
 
-    // Single "get rid of whichever keyboard is up" entry point, shared by the
-    // outside-tap detector in [dispatchTouchEvent] and the composable-side
-    // background-tap detector inside [CartItemsList]. Both keyboards are
-    // handled together so callers don't need to know which one is visible.
     private fun dismissKeyboards() {
         if (keypadContainer.visibility == View.VISIBLE) closeKeypad()
         if (systemImeVisible) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,7 +1,5 @@
 package com.eliormachlev.currencix.view.cart.compose
 
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -12,7 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -22,6 +19,7 @@ import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.compose.dragReorderGraphics
 import com.eliormachlev.currencix.view.compose.dragReorderHandle
+import com.eliormachlev.currencix.view.compose.onBackgroundTap
 import com.eliormachlev.currencix.view.compose.rememberDragReorderState
 
 // Nominal row height used to translate finger travel into "how many rows have
@@ -67,58 +65,47 @@ fun CartItemsList(
             if (src !in displayItems.indices) drag.reset()
         }
 
-        // Background tap detector: any tap that no row (or child of a row)
-        // consumes falls through to this pointerInput. Rows already consume
-        // taps on the expression, pin toggle, and name field — what remains
-        // are taps on the empty area below the last row or on a row's own
-        // blank card padding, both of which should dismiss the app keypad /
-        // system IME. Compose's gesture arbitration handles the "did any
-        // child consume?" question for us so the activity doesn't have to
-        // guess by coordinates.
-        Box(
+        // Rows consume taps on the expression, pin toggle, and name field;
+        // anything left over (blank space below the last row, blank card
+        // padding on a row) dismisses whatever keyboard is up.
+        LazyColumn(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .pointerInput(Unit) {
-                        detectTapGestures(onTap = { onBackgroundTap() })
-                    },
+                    .onBackgroundTap(onBackgroundTap),
+            contentPadding =
+                PaddingValues(
+                    horizontal = dimensionResource(id = R.dimen.margin1x),
+                    vertical = dimensionResource(id = R.dimen.margin1x),
+                ),
         ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding =
-                    PaddingValues(
-                        horizontal = dimensionResource(id = R.dimen.margin1x),
-                        vertical = dimensionResource(id = R.dimen.margin1x),
-                    ),
-            ) {
-                itemsIndexed(items = displayItems, key = { _, it -> it.id }) { index, item ->
-                    val isActive = item.id == activeId
-                    SwipeableCartItemRow(
-                        item = item,
-                        currency = currency,
-                        isActive = isActive,
-                        liveExpression = if (isActive) liveExpression else null,
-                        onNameCommit = { onNameCommit(item.id, it) },
-                        onNamePending = { onNamePending(item.id, it) },
-                        onExpressionTap = { onExpressionTap(item) },
-                        onTogglePin = { onTogglePin(item.id) },
-                        onDelete = { onDelete(item.id) },
-                        modifier =
-                            Modifier
-                                .animateItem()
-                                .dragReorderGraphics(drag, index, rowHeightPx),
-                        dragHandleModifier =
-                            Modifier.dragReorderHandle(
-                                state = drag,
-                                index = index,
-                                key = item.id,
-                                rowHeightPx = rowHeightPx,
-                                itemCount = { displayItems.size },
-                                onStart = onReorderStart,
-                                onCommit = { from, to -> onReorder(displayItems[from].id, displayItems[to].id) },
-                            ),
-                    )
-                }
+            itemsIndexed(items = displayItems, key = { _, it -> it.id }) { index, item ->
+                val isActive = item.id == activeId
+                SwipeableCartItemRow(
+                    item = item,
+                    currency = currency,
+                    isActive = isActive,
+                    liveExpression = if (isActive) liveExpression else null,
+                    onNameCommit = { onNameCommit(item.id, it) },
+                    onNamePending = { onNamePending(item.id, it) },
+                    onExpressionTap = { onExpressionTap(item) },
+                    onTogglePin = { onTogglePin(item.id) },
+                    onDelete = { onDelete(item.id) },
+                    modifier =
+                        Modifier
+                            .animateItem()
+                            .dragReorderGraphics(drag, index, rowHeightPx),
+                    dragHandleModifier =
+                        Modifier.dragReorderHandle(
+                            state = drag,
+                            index = index,
+                            key = item.id,
+                            rowHeightPx = rowHeightPx,
+                            itemCount = { displayItems.size },
+                            onStart = onReorderStart,
+                            onCommit = { from, to -> onReorder(displayItems[from].id, displayItems[to].id) },
+                        ),
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemsList.kt
@@ -1,5 +1,7 @@
 package com.eliormachlev.currencix.view.cart.compose
 
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -10,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -41,6 +44,7 @@ fun CartItemsList(
     onDelete: (id: String) -> Unit,
     onReorder: (fromId: String, toId: String) -> Unit,
     onReorderStart: () -> Unit,
+    onBackgroundTap: () -> Unit,
 ) {
     AppTheme {
         val items by itemsSource.observeAsState(initial = emptyList())
@@ -63,41 +67,58 @@ fun CartItemsList(
             if (src !in displayItems.indices) drag.reset()
         }
 
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding =
-                PaddingValues(
-                    horizontal = dimensionResource(id = R.dimen.margin1x),
-                    vertical = dimensionResource(id = R.dimen.margin1x),
-                ),
+        // Background tap detector: any tap that no row (or child of a row)
+        // consumes falls through to this pointerInput. Rows already consume
+        // taps on the expression, pin toggle, and name field — what remains
+        // are taps on the empty area below the last row or on a row's own
+        // blank card padding, both of which should dismiss the app keypad /
+        // system IME. Compose's gesture arbitration handles the "did any
+        // child consume?" question for us so the activity doesn't have to
+        // guess by coordinates.
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTapGestures(onTap = { onBackgroundTap() })
+                    },
         ) {
-            itemsIndexed(items = displayItems, key = { _, it -> it.id }) { index, item ->
-                val isActive = item.id == activeId
-                SwipeableCartItemRow(
-                    item = item,
-                    currency = currency,
-                    isActive = isActive,
-                    liveExpression = if (isActive) liveExpression else null,
-                    onNameCommit = { onNameCommit(item.id, it) },
-                    onNamePending = { onNamePending(item.id, it) },
-                    onExpressionTap = { onExpressionTap(item) },
-                    onTogglePin = { onTogglePin(item.id) },
-                    onDelete = { onDelete(item.id) },
-                    modifier =
-                        Modifier
-                            .animateItem()
-                            .dragReorderGraphics(drag, index, rowHeightPx),
-                    dragHandleModifier =
-                        Modifier.dragReorderHandle(
-                            state = drag,
-                            index = index,
-                            key = item.id,
-                            rowHeightPx = rowHeightPx,
-                            itemCount = { displayItems.size },
-                            onStart = onReorderStart,
-                            onCommit = { from, to -> onReorder(displayItems[from].id, displayItems[to].id) },
-                        ),
-                )
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding =
+                    PaddingValues(
+                        horizontal = dimensionResource(id = R.dimen.margin1x),
+                        vertical = dimensionResource(id = R.dimen.margin1x),
+                    ),
+            ) {
+                itemsIndexed(items = displayItems, key = { _, it -> it.id }) { index, item ->
+                    val isActive = item.id == activeId
+                    SwipeableCartItemRow(
+                        item = item,
+                        currency = currency,
+                        isActive = isActive,
+                        liveExpression = if (isActive) liveExpression else null,
+                        onNameCommit = { onNameCommit(item.id, it) },
+                        onNamePending = { onNamePending(item.id, it) },
+                        onExpressionTap = { onExpressionTap(item) },
+                        onTogglePin = { onTogglePin(item.id) },
+                        onDelete = { onDelete(item.id) },
+                        modifier =
+                            Modifier
+                                .animateItem()
+                                .dragReorderGraphics(drag, index, rowHeightPx),
+                        dragHandleModifier =
+                            Modifier.dragReorderHandle(
+                                state = drag,
+                                index = index,
+                                key = item.id,
+                                rowHeightPx = rowHeightPx,
+                                itemCount = { displayItems.size },
+                                onStart = onReorderStart,
+                                onCommit = { from, to -> onReorder(displayItems[from].id, displayItems[to].id) },
+                            ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
@@ -1,6 +1,7 @@
 package com.eliormachlev.currencix.view.compose
 
 import android.widget.ImageView
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -9,7 +10,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
@@ -48,6 +52,17 @@ fun Ltr(content: @Composable () -> Unit) {
 // Filled-vs-outlined heart IconButton used for the picker's star toggle and
 // the cart's pin toggle. Same drawable pair, same tint semantics, so both
 // sites read the same way to users.
+// Fires [onTap] for taps no child of the modified node consumed. `composed`
+// + `rememberUpdatedState` keeps the captured lambda in sync across
+// recompositions without relaunching the pointer-input coroutine.
+fun Modifier.onBackgroundTap(onTap: () -> Unit): Modifier =
+    composed {
+        val current by rememberUpdatedState(onTap)
+        pointerInput(Unit) {
+            detectTapGestures(onTap = { current() })
+        }
+    }
+
 @Composable
 fun FavoriteToggleIcon(
     active: Boolean,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed


### PR DESCRIPTION
## Summary

Re-opens #107's outside-tap requirement. The activity-side detector already existed but was too narrow — it gated on \`itemsRect.contains(x, y)\`, so any tap inside the items \`ComposeView\` (including empty space below the last row) was treated as "on a row" and left both keyboards open.

- Moved the "did any row consume this tap?" decision into \`CartItemsList\` as a Compose-native \`pointerInput\` on a \`Box\` wrapping the \`LazyColumn\`. Taps that no row (or child of a row) consumes forward to a new \`onBackgroundTap\` callback.
- Wired that callback in the activity to a shared \`dismissKeyboards()\` helper that closes the app keypad and the system IME together.
- The activity's own \`handleOutsideTap\` now only owns taps that land outside the items view (toolbar area, totals card / add-item button when only the IME is up) and delegates to the same shared helper.

## Test plan

- [ ] Open a cart row's keypad, tap on the blank space below the last row → keypad closes.
- [ ] Open a cart row's keypad, tap another row's expression → keypad transfers to the new row (no close/reopen flicker).
- [ ] Focus a row's name (system IME up), tap on the blank space below the last row → IME dismisses, focus clears.
- [ ] Focus a row's name (system IME up), tap on the totals card → IME dismisses.
- [ ] Tapping the pin toggle, delete swipe, drag handle long-press, and expression tap all still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)