### PR TITLE
Update ben-manes.versions plugin id to io.github namespace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.android.application") version "9.3.1" apply false
     id("org.jetbrains.kotlin.jvm") version "2.4.10" apply false
     // dependency-update-checker
-    id("com.github.ben-manes.versions") version "0.60.0"
+    id("io.github.ben-manes.versions") version "0.60.0"
     // Spotless drives ktlint (chosen over the org.jlleitschuh.gradle.ktlint
     // plugin because that plugin's Android source-set hook does not fire under
     // AGP 9 — only its .kts checker runs, leaving app/src/main/kotlin unlinted).


### PR DESCRIPTION
## Summary

Silences the Gradle configuration warning:
> The com.github.ben-manes.versions plugin id is deprecated; apply io.github.ben-manes.versions instead.

Same plugin, new coordinates.

## Test plan

- [ ] \`./gradlew help\` no longer prints the deprecation warning.
- [ ] \`./gradlew dependencyUpdates\` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)