### PR TITLE
feat(timeline): add MED row alongside MAX/AVG/MIN

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineScreen.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineScreen.kt
@@ -41,6 +41,7 @@ internal fun TimelineScreen(
             val diffPercent by model.getRatesDifferencePercent().observeAsState()
             val ratesMax by model.getRatesMax().observeAsState()
             val ratesAvg by model.getRatesAverage().observeAsState()
+            val ratesMed by model.getRatesMedian().observeAsState()
             val ratesMin by model.getRatesMin().observeAsState()
 
             val period =
@@ -66,6 +67,7 @@ internal fun TimelineScreen(
                     diffPercent = diffPercent,
                     ratesMax = ratesMax,
                     ratesAvg = ratesAvg,
+                    ratesMed = ratesMed,
                     ratesMin = ratesMin,
                     formatter = formatter,
                     selectedPeriod = period.value,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineSecondary.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineSecondary.kt
@@ -56,6 +56,7 @@ internal fun TimelineSecondary(
     diffPercent: BigDecimal?,
     ratesMax: Triple<Rate?, LocalDate?, Int>?,
     ratesAvg: Pair<Rate?, Int>?,
+    ratesMed: Pair<Rate?, Int>?,
     ratesMin: Triple<Rate?, LocalDate?, Int>?,
     formatter: DateTimeFormatter,
     selectedPeriod: TimelineViewModel.Period,
@@ -69,16 +70,18 @@ internal fun TimelineSecondary(
 
     val maxLabel = stringResource(R.string.rate_max)
     val avgLabel = stringResource(R.string.rate_average)
+    val medLabel = stringResource(R.string.rate_median)
     val minLabel = stringResource(R.string.rate_min)
 
     val rows =
         listOf(
             statRow(context, maxLabel, ratesMax?.first, ratesMax?.second, ratesMax?.third, formatter),
             statRow(context, avgLabel, ratesAvg?.first, null, ratesAvg?.second, formatter),
+            statRow(context, medLabel, ratesMed?.first, null, ratesMed?.second, formatter),
             statRow(context, minLabel, ratesMin?.first, ratesMin?.second, ratesMin?.third, formatter),
         )
 
-    val labelWidth = maxLabelWidth(listOf(maxLabel, avgLabel, minLabel))
+    val labelWidth = maxLabelWidth(listOf(maxLabel, avgLabel, medLabel, minLabel))
 
     Column(
         modifier =

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -44,8 +44,6 @@ private fun averageOf(values: List<BigDecimal>): BigDecimal =
         .fold(BigDecimal.ZERO, BigDecimal::add)
         .divide(BigDecimal(values.size), MathContext.DECIMAL128)
 
-// Standard definition: sort, take the middle value, or the mean of the two
-// middle values when the count is even.
 private fun medianOf(values: List<BigDecimal>): BigDecimal {
     val sorted = values.sorted()
     val mid = sorted.size / 2

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -37,6 +37,25 @@ private fun Set<Map.Entry<LocalDate, Rate?>>.fromScrub(scrubDate: LocalDate?): L
         this.filter { !it.key.isBefore(scrubDate) }
     }
 
+private val TWO = BigDecimal(2)
+
+private fun averageOf(values: List<BigDecimal>): BigDecimal =
+    values
+        .fold(BigDecimal.ZERO, BigDecimal::add)
+        .divide(BigDecimal(values.size), MathContext.DECIMAL128)
+
+// Standard definition: sort, take the middle value, or the mean of the two
+// middle values when the count is even.
+private fun medianOf(values: List<BigDecimal>): BigDecimal {
+    val sorted = values.sorted()
+    val mid = sorted.size / 2
+    return if (sorted.size % 2 == 1) {
+        sorted[mid]
+    } else {
+        sorted[mid - 1].add(sorted[mid]).divide(TWO, MathContext.DECIMAL128)
+    }
+}
+
 class TimelineViewModel(
     private val app: Application,
     private var base: Currency,
@@ -223,7 +242,14 @@ class TimelineViewModel(
             }
         }
 
-    fun getRatesAverage(): LiveData<Pair<Rate?, Int>> =
+    fun getRatesAverage(): LiveData<Pair<Rate?, Int>> = aggregateLiveData(::averageOf)
+
+    fun getRatesMedian(): LiveData<Pair<Rate?, Int>> = aggregateLiveData(::medianOf)
+
+    // Shared MediatorLiveData scaffolding for range-wide statistics that reduce
+    // the visible-range value set to a single [Rate]. The reducer receives a
+    // non-empty list; an empty range short-circuits to null before it runs.
+    private fun aggregateLiveData(reducer: (List<BigDecimal>) -> BigDecimal): LiveData<Pair<Rate?, Int>> =
         MediatorLiveData<Pair<Rate?, Int>>().apply {
             var scrubDate: LocalDate? = null
             var rates: Set<Map.Entry<LocalDate, Rate?>>? = null
@@ -233,16 +259,13 @@ class TimelineViewModel(
                     rates
                         ?.fromScrub(scrubDate)
                         ?.mapNotNull { entry -> entry.value?.value }
-                val avg: Rate? =
+                val aggregate: Rate? =
                     if (values.isNullOrEmpty()) {
                         null
                     } else {
-                        values
-                            .fold(BigDecimal.ZERO, BigDecimal::add)
-                            .divide(BigDecimal(values.size), MathContext.DECIMAL128)
-                            .let { Rate(target, it) }
+                        Rate(target, reducer(values))
                     }
-                this.value = Pair(avg, decimalPlaces)
+                this.value = Pair(aggregate, decimalPlaces)
             }
 
             addSource(dbLiveItems) {

--- a/app/src/main/res/values/strings_timeline.xml
+++ b/app/src/main/res/values/strings_timeline.xml
@@ -4,6 +4,7 @@
     <string name="data_provider">Data by &lt;b>%s&lt;/b></string>
 
     <string name="rate_average">avg</string>
+    <string name="rate_median">med</string>
     <string name="rate_min">min</string>
     <string name="rate_max">max</string>
 


### PR DESCRIPTION
Closes #100.

## Summary
- Adds a `MED` row directly below `AVG` in the timeline summary. Median matches AVG's semantics: same visible-range value set, honoring the current week/month/year selection and scrub position.
- Even-count ranges use the mean of the two middle values (standard convention). No date is shown next to MED — it's a statistic over the range, not a point in time.
- Extracts the shared `MediatorLiveData` scaffolding behind average/median into a private `aggregateLiveData(reducer)` helper, so both statistics only differ in the reducer (`averageOf` / `medianOf`).
- New string `rate_median` (default: `med`). Other locales fall back to English until a translation lands.

## Test plan
- [ ] Open the timeline; verify MED appears between AVG and MIN.
- [ ] Switch between WEEK / MONTH / YEAR — MED updates alongside AVG.
- [ ] Scrub the timeline — MED and AVG update together; MAX/MIN dates still shown, MED shows no date.
- [ ] Sanity-check MED value against a range with a known outlier (should differ from AVG in the expected direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)