### PR TITLE
feat(settings): give every preference row a leading icon

### DIFF
--- a/app/src/main/res/drawable/ic_backup.xml
+++ b/app/src/main/res/drawable/ic_backup.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4L7,13l5,-5 5,5h-3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_event.xml
+++ b/app/src/main/res/drawable/ic_event.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,12h-5v5h5v-5zM16,1v2L8,3L8,1L6,1v2L5,3c-1.11,0 -1.99,0.9 -1.99,2L3,19c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2h-1L18,1h-2zM19,19L5,19L5,8h14v11z" />
+</vector>

--- a/app/src/main/res/drawable/ic_gavel.xml
+++ b/app/src/main/res/drawable/ic_gavel.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:autoMirrored="true"
     android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_gavel.xml
+++ b/app/src/main/res/drawable/ic_gavel.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h12v2L1,23zM5.245,8.07l2.83,-2.827 14.14,14.142 -2.828,2.828zM12.317,1l5.657,5.656 -2.83,2.83 -5.654,-5.66zM3.825,9.485l5.657,5.657 -2.828,2.828 -5.657,-5.657z" />
+</vector>

--- a/app/src/main/res/drawable/ic_info.xml
+++ b/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_key.xml
+++ b/app/src/main/res/drawable/ic_key.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.65,10C11.83,7.67 9.61,6 7,6c-3.31,0 -6,2.69 -6,6s2.69,6 6,6c2.61,0 4.83,-1.67 5.65,-4L17,14v4h4v-4h2v-4L12.65,10zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_numbers.xml
+++ b/app/src/main/res/drawable/ic_numbers.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20.5,10L21,8h-4l1,-4h-2l-1,4h-4l1,-4h-2L9,8H5l-0.5,2h4l-1,4h-4L3,16h4l-1,4h2l1,-4h4l-1,4h2l1,-4h4l0.5,-2h-4l1,-4h4zM13.5,14h-4l1,-4h4l-1,4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_schedule.xml
+++ b/app/src/main/res/drawable/ic_schedule.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM12.5,7L11,7v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z" />
+</vector>

--- a/app/src/main/res/drawable/ic_tag.xml
+++ b/app/src/main/res/drawable/ic_tag.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21.41,11.58l-9,-9C12.05,2.22 11.55,2 11,2L4,2c-1.1,0 -2,0.9 -2,2v7c0,0.55 0.22,1.05 0.59,1.42l9,9c0.36,0.36 0.86,0.58 1.41,0.58 0.55,0 1.05,-0.22 1.41,-0.59l7,-7c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-0.55 -0.23,-1.06 -0.59,-1.42zM5.5,7C4.67,7 4,6.33 4,5.5S4.67,4 5.5,4 7,4.67 7,5.5 6.33,7 5.5,7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_vibration.xml
+++ b/app/src/main/res/drawable/ic_vibration.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M0,15h2L2,9L0,9v6zM3,17h2L5,7L3,7v10zM22,9v6h2L24,9h-2zM19,17h2L21,7h-2v10zM16,6L8,6c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h8c0.55,0 1,-0.45 1,-1L17,7c0,-0.55 -0.45,-1 -1,-1z" />
+</vector>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -26,6 +26,7 @@
             android:defaultValue="2"
             android:entries="@array/decimal_places_values"
             android:entryValues="@array/decimal_places_values"
+            android:icon="@drawable/ic_numbers"
             android:key="@string/decimal_places_key"
             android:summary="@string/decimal_places_summary"
             android:title="@string/decimal_places_title"
@@ -33,6 +34,7 @@
 
         <SwitchPreferenceCompat
             android:defaultValue="true"
+            android:icon="@drawable/ic_vibration"
             android:key="@string/haptic_feedback_key"
             android:summary="@string/haptic_feedback_summary"
             android:title="@string/haptic_feedback_title" />
@@ -41,10 +43,12 @@
             android:defaultValue="dd/MM/yy HH:mm"
             android:entries="@array/date_format_names"
             android:entryValues="@array/date_format_values"
+            android:icon="@drawable/ic_event"
             android:key="@string/date_format_key"
             android:title="@string/date_format_title" />
 
         <Preference
+            android:icon="@drawable/ic_backup"
             android:key="@string/backup_key"
             android:summary="@string/backup_summary"
             android:title="@string/backup_title" />
@@ -76,15 +80,18 @@
         <EditTextPreference
             android:dialogMessage="@string/api_open_exchangerates_api_key_message"
             android:dialogTitle="@string/api_open_exchangerates_api_key_title"
+            android:icon="@drawable/ic_key"
             app:dialogLayout="@layout/preference_dialog_api_key"
             android:key="@string/api_open_exchangerates_id_key"
             android:title="@string/api_open_exchangerates_api_key_title"
             app:useSimpleSummaryProvider="true" />
         <com.eliormachlev.currencix.widget.LongSummaryPreference
+            android:icon="@drawable/ic_info"
             android:key="@string/key_apiProvider"
             android:selectable="false"
             android:title="@string/api_about_title" />
         <com.eliormachlev.currencix.widget.LongSummaryPreference
+            android:icon="@drawable/ic_schedule"
             android:key="@string/key_refreshPeriod"
             android:selectable="false"
             android:title="@string/api_refreshPeriod_title" />
@@ -102,6 +109,7 @@
 
     <PreferenceCategory android:title="@string/category_about">
         <com.eliormachlev.currencix.widget.LongSummaryPreference
+            android:icon="@drawable/ic_gavel"
             android:selectable="false"
             android:summary="@string/disclaimer_summary"
             android:title="@string/disclaimer_title" />
@@ -125,6 +133,7 @@
             android:key="@string/changelog_key"
             android:title="@string/title_changelog" />
         <Preference
+            android:icon="@drawable/ic_tag"
             android:key="@string/version_key"
             android:selectable="false"
             android:summary="@string/version_summary"


### PR DESCRIPTION
## Summary
- Adds nine new 24dp vector icons (numbers, vibration, event, backup, key, info, schedule, gavel, tag) that follow the existing `?attr/colorControlNormal` tint style used by `ic_edit.xml`.
- Wires an `android:icon` onto every preference row that was previously missing one: decimal accuracy, haptic feedback, date/time format, Backup & Restore, Open Exchangerates API Key, provider-about, refresh period, disclaimer, and version.
- Result: every row in General Settings, Appearance, Exchange rates, Graph options, About this app, and Version info now has a leading icon, so the list scans uniformly instead of alternating between iconed and blank gutters.

Closes #101

## Test plan
- [ ] Open Settings and confirm every row across all categories has a leading icon aligned with the existing ones.
- [ ] Toggle light/dark theme and verify all new icons tint consistently.
- [ ] Verify row heights and padding stay uniform now that no row is iconless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)