### PR TITLE
Fee picker: row opens editor, radio selects; grey inactive rows

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/Fee.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/Fee.kt
@@ -20,6 +20,21 @@ sealed class Fee {
     abstract val feeSide: FeeSide
     abstract val type: FeeType
 
+    /**
+     * Return a copy with the fields the editor UI exposes overwritten,
+     * preserving each subclass's non-editable fields (e.g. SpecificPair's
+     * [SpecificPair.from]/[SpecificPair.to]/[SpecificPair.bothWays]). Dispatches
+     * to the concrete `copy` so the runtime type is preserved without the
+     * fragment having to `when` over the sealed hierarchy.
+     */
+    abstract fun withEditableFields(
+        name: String,
+        percent: BigDecimal,
+        isMarkup: Boolean,
+        isActive: Boolean,
+        feeSide: FeeSide,
+    ): Fee
+
     /** Applies to every conversion, no matter which currencies are involved. */
     data class GlobalExchange(
         override val id: String,
@@ -30,6 +45,21 @@ sealed class Fee {
         override val feeSide: FeeSide = FeeSide.ORIGINAL,
     ) : Fee() {
         override val type: FeeType get() = FeeType.GLOBAL_EXCHANGE
+
+        override fun withEditableFields(
+            name: String,
+            percent: BigDecimal,
+            isMarkup: Boolean,
+            isActive: Boolean,
+            feeSide: FeeSide,
+        ): GlobalExchange =
+            copy(
+                name = name,
+                percent = percent,
+                isMarkup = isMarkup,
+                isActive = isActive,
+                feeSide = feeSide,
+            )
     }
 
     /** Bank / card fee that also applies to every conversion. */
@@ -42,6 +72,21 @@ sealed class Fee {
         override val feeSide: FeeSide = FeeSide.ORIGINAL,
     ) : Fee() {
         override val type: FeeType get() = FeeType.GLOBAL_BANK
+
+        override fun withEditableFields(
+            name: String,
+            percent: BigDecimal,
+            isMarkup: Boolean,
+            isActive: Boolean,
+            feeSide: FeeSide,
+        ): GlobalBank =
+            copy(
+                name = name,
+                percent = percent,
+                isMarkup = isMarkup,
+                isActive = isActive,
+                feeSide = feeSide,
+            )
     }
 
     /**
@@ -60,6 +105,21 @@ sealed class Fee {
         override val feeSide: FeeSide = FeeSide.ORIGINAL,
     ) : Fee() {
         override val type: FeeType get() = FeeType.SPECIFIC_PAIR
+
+        override fun withEditableFields(
+            name: String,
+            percent: BigDecimal,
+            isMarkup: Boolean,
+            isActive: Boolean,
+            feeSide: FeeSide,
+        ): SpecificPair =
+            copy(
+                name = name,
+                percent = percent,
+                isMarkup = isMarkup,
+                isActive = isActive,
+                feeSide = feeSide,
+            )
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
-import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.ViewCompat
@@ -60,7 +59,6 @@ fun choiceExplainerRow(
     description: CharSequence,
     leadingView: View? = null,
     trailingView: View? = null,
-    @ColorInt textColor: Int? = null,
     clickActionLabel: CharSequence? = null,
     onClick: () -> Unit,
 ): LinearLayout {
@@ -90,17 +88,13 @@ fun choiceExplainerRow(
                 TextView(ctx).apply {
                     text = title
                     setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_TitleMedium)
-                    if (textColor != null) setTextColor(textColor)
                 },
             )
             addView(
                 TextView(ctx).apply {
                     text = description
                     setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodySmall)
-                    // Opaque muted colour is preferred over alpha for state cues
-                    // per the accessibility statement; only fall back to alpha
-                    // for the default (non-state) subordinate-line treatment.
-                    if (textColor != null) setTextColor(textColor) else alpha = CHOICE_DESC_ALPHA
+                    alpha = CHOICE_DESC_ALPHA
                 },
             )
         }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -7,8 +7,11 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
+import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import com.eliormachlev.currencix.R
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
@@ -57,6 +60,8 @@ fun choiceExplainerRow(
     description: CharSequence,
     leadingView: View? = null,
     trailingView: View? = null,
+    @ColorInt textColor: Int? = null,
+    clickActionLabel: CharSequence? = null,
     onClick: () -> Unit,
 ): LinearLayout {
     val padV = ctx.resources.getDimensionPixelSize(R.dimen.margin2x)
@@ -68,6 +73,14 @@ fun choiceExplainerRow(
             isClickable = true
             applySelectableRowBackground()
             setOnClickListener { onClick() }
+            if (clickActionLabel != null) {
+                ViewCompat.replaceAccessibilityAction(
+                    this,
+                    AccessibilityActionCompat.ACTION_CLICK,
+                    clickActionLabel,
+                    null,
+                )
+            }
         }
     if (leadingView != null) row.addView(leadingView)
     val textCol =
@@ -77,13 +90,17 @@ fun choiceExplainerRow(
                 TextView(ctx).apply {
                     text = title
                     setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_TitleMedium)
+                    if (textColor != null) setTextColor(textColor)
                 },
             )
             addView(
                 TextView(ctx).apply {
                     text = description
                     setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodySmall)
-                    alpha = CHOICE_DESC_ALPHA
+                    // Opaque muted colour is preferred over alpha for state cues
+                    // per the accessibility statement; only fall back to alpha
+                    // for the default (non-state) subordinate-line treatment.
+                    if (textColor != null) setTextColor(textColor) else alpha = CHOICE_DESC_ALPHA
                 },
             )
         }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/ParenButton.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/ParenButton.kt
@@ -1,12 +1,10 @@
 package com.eliormachlev.currencix.util
 
-import android.content.Context
 import android.graphics.Typeface
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
-import android.util.TypedValue
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.eliormachlev.currencix.R
@@ -32,10 +30,4 @@ fun TextView.paintParenCycle(next: Char) {
             setSpan(StyleSpan(Typeface.BOLD), activeIndex, activeIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             setSpan(ForegroundColorSpan(mutedColor), mutedIndex, mutedIndex + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-}
-
-private fun Context.resolveThemeColor(attr: Int): Int {
-    val tv = TypedValue()
-    theme.resolveAttribute(attr, tv, true)
-    return if (tv.resourceId != 0) ContextCompat.getColor(this, tv.resourceId) else tv.data
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/ThemeUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/ThemeUtils.kt
@@ -7,6 +7,14 @@ import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 
 /**
+ * Alpha for a row that is present in the list but cannot be selected in the
+ * current context — e.g. a currency already picked on the opposite side of a
+ * pair, or an inactive saved fee. Paired with a text marker so state is not
+ * conveyed by alpha alone (WCAG 1.4.1).
+ */
+const val DISABLED_ROW_ALPHA = 0.4f
+
+/**
  * Resolve a theme colour attribute (e.g. `?attr/colorOnSurfaceVariant`) to an
  * `@ColorInt`. Handles both direct colour values and colour-state-list refs.
  */

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/ThemeUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/ThemeUtils.kt
@@ -1,0 +1,20 @@
+package com.eliormachlev.currencix.util
+
+import android.content.Context
+import android.util.TypedValue
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+
+/**
+ * Resolve a theme colour attribute (e.g. `?attr/colorOnSurfaceVariant`) to an
+ * `@ColorInt`. Handles both direct colour values and colour-state-list refs.
+ */
+@ColorInt
+fun Context.resolveThemeColor(
+    @AttrRes attr: Int,
+): Int {
+    val tv = TypedValue()
+    theme.resolveAttribute(attr, tv, true)
+    return if (tv.resourceId != 0) ContextCompat.getColor(this, tv.resourceId) else tv.data
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -56,6 +56,7 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
+import com.eliormachlev.currencix.util.DISABLED_ROW_ALPHA
 import com.eliormachlev.currencix.util.hasAppendedCurrencySymbol
 import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.stripRtlMark
@@ -74,12 +75,6 @@ private const val FLAG_HEIGHT_DP = 17
 private const val FLAG_CORNER_RADIUS_DP = 2
 private const val ROW_MIN_HEIGHT_DP = 56
 private const val API_HINT_ALPHA = 0.7f
-
-// Alpha for a currency row that can't be picked in the current context
-// (e.g. it's already selected on the opposite side of the same pair, so
-// picking it here would produce a same-currency conversion). Same weight as
-// [API_HINT_ALPHA] so disabled rows read as ambient, not error.
-private const val DISABLED_ROW_ALPHA = 0.4f
 
 internal data class CurrencyPickerConversion(
     val baseRate: Rate,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -121,15 +121,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val ctx = preferenceManager.context
         val screen: PreferenceScreen = preferenceManager.createPreferenceScreen(ctx)
 
-        globalExchangePref =
-            buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_EXCHANGE, R.string.fee_section_global_exchange)
-        globalBankPref =
-            buildGlobalSelectorPreference(ctx, PREF_KEY_GLOBAL_BANK, R.string.fee_section_global_bank)
         // Wrap each selector in its own category so the section header is
         // visible on the top-level screen; without it users can't tell the
         // exchange row from the bank/card row without opening the dialog.
-        addCategory(screen, ctx, R.string.fee_section_global_exchange).addPreference(globalExchangePref)
-        addCategory(screen, ctx, R.string.fee_section_global_bank).addPreference(globalBankPref)
+        globalExchangePref =
+            addGlobalSelectorSection(screen, ctx, PREF_KEY_GLOBAL_EXCHANGE, R.string.fee_section_global_exchange)
+        globalBankPref =
+            addGlobalSelectorSection(screen, ctx, PREF_KEY_GLOBAL_BANK, R.string.fee_section_global_bank)
 
         categoryPair = addCategory(screen, ctx, R.string.fee_section_specific_pair)
 
@@ -171,16 +169,21 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         activity?.title = getString(R.string.fee_manager_title)
     }
 
-    private fun buildGlobalSelectorPreference(
+    private fun addGlobalSelectorSection(
+        screen: PreferenceScreen,
         ctx: Context,
         key: String,
         titleRes: Int,
-    ): Preference =
-        Preference(ctx).apply {
-            this.key = key
-            title = getString(titleRes)
-            isIconSpaceReserved = false
-        }
+    ): Preference {
+        val pref =
+            Preference(ctx).apply {
+                this.key = key
+                title = getString(titleRes)
+                isIconSpaceReserved = false
+            }
+        addCategory(screen, ctx, titleRes).addPreference(pref)
+        return pref
+    }
 
     private fun renderFees(fees: List<Fee>) {
         renderGlobalCategory(
@@ -189,7 +192,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = R.string.fee_section_global_exchange,
             getActiveId = db::getActiveExchangeIdBlocking,
             setActiveId = db::setActiveExchangeId,
-            create = { d -> Fee.GlobalExchange(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
+            create = { it.toGlobalExchange() },
             update = feeUpdater(),
         )
         renderGlobalCategory(
@@ -198,7 +201,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = R.string.fee_section_global_bank,
             getActiveId = db::getActiveBankIdBlocking,
             setActiveId = db::setActiveBankId,
-            create = { d -> Fee.GlobalBank(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
+            create = { it.toGlobalBank() },
             update = feeUpdater(),
         )
         populate(
@@ -621,22 +624,26 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             ).apply { topMargin = resources.getDimensionPixelSize(topGapRes) }
 
     /**
-     * Build the [MaterialAlertDialogBuilder] shared by the two fee-editor
-     * dialogs — title, body view, cancel, and optional delete. Callers append
-     * their own positive button (each dialog handles OK differently) and call
-     * `show()`.
+     * Show the fee-editor dialog shared by both editors — title, body view,
+     * cancel, optional delete, and OK. [onOk] is invoked when the user
+     * confirms; use `return@showFeeEditorDialog` to bail without dismissing
+     * data flow (e.g. when required inputs aren't filled in yet).
      */
-    private fun feeEditorDialog(
+    private fun showFeeEditorDialog(
         ctx: Context,
         @StringRes titleRes: Int,
         container: View,
         onDelete: (() -> Unit)?,
-    ): MaterialAlertDialogBuilder =
+        onOk: () -> Unit,
+    ) {
         MaterialAlertDialogBuilder(ctx)
             .setTitle(titleRes)
             .setView(container)
             .setNegativeButton(android.R.string.cancel, null)
             .withDeleteButton(onDelete)
+            .setPositiveButton(android.R.string.ok) { _, _ -> onOk() }
+            .show()
+    }
 
     /**
      * Snapshot of the fields shared between the global-fee and specific-pair
@@ -727,9 +734,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val inputs = buildSharedFeeInputs(ctx, existing)
         container.addFeeEditorLayout(inputs)
 
-        feeEditorDialog(ctx, titleRes, container, onDelete)
-            .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
-            .show()
+        showFeeEditorDialog(ctx, titleRes, container, onDelete) {
+            onConfirm(inputs.toDraft())
+        }
     }
 
     private fun showSpecificPairDialog(
@@ -770,20 +777,39 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             addView(bothWays, topGapLayoutParams(FEE_EDITOR_SECTION_GAP))
         }
 
-        feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                val from = pickedFrom ?: return@setPositiveButton
-                val to = pickedTo ?: return@setPositiveButton
-                onConfirm(
-                    inputs.toDraft().toSpecificPair(
-                        id = existing?.id ?: UUID.randomUUID().toString(),
-                        from = from,
-                        to = to,
-                        bothWays = bothWays.isChecked,
-                    ),
-                )
-            }.show()
+        showFeeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete) {
+            val from = pickedFrom ?: return@showFeeEditorDialog
+            val to = pickedTo ?: return@showFeeEditorDialog
+            onConfirm(
+                inputs.toDraft().toSpecificPair(
+                    id = existing?.id ?: UUID.randomUUID().toString(),
+                    from = from,
+                    to = to,
+                    bothWays = bothWays.isChecked,
+                ),
+            )
+        }
     }
+
+    private fun FeeDraft.toGlobalExchange(): Fee.GlobalExchange =
+        Fee.GlobalExchange(
+            id = UUID.randomUUID().toString(),
+            name = name,
+            percent = percent,
+            isMarkup = isMarkup,
+            isActive = isActive,
+            feeSide = feeSide,
+        )
+
+    private fun FeeDraft.toGlobalBank(): Fee.GlobalBank =
+        Fee.GlobalBank(
+            id = UUID.randomUUID().toString(),
+            name = name,
+            percent = percent,
+            isMarkup = isMarkup,
+            isActive = isActive,
+            feeSide = feeSide,
+        )
 
     private fun FeeDraft.toSpecificPair(
         id: String,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -505,8 +505,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
      * Numeric percent field. Signed integer input in [-100, 100]; a leading
      * "−" flips the fee from markup to discount, unsigned defaults to markup.
      * [initialSigned] is the value carrying its own sign — callers compose it
-     * from the model's separate abs-percent / isMarkup fields. setText runs
-     * before filters are attached so a legacy decimal value still displays.
+     * from the model's separate abs-percent / isMarkup fields.
      */
     private fun buildPercentInput(
         ctx: Context,
@@ -514,8 +513,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ): EditText =
         EditText(ctx).apply {
             keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_ALLOWED_CHARS)
-            if (initialSigned != null) setText(initialSigned.toPlainString())
             filters = arrayOf(feePercentRangeFilter)
+            if (initialSigned != null) setText(initialSigned.toPlainString())
         }
 
     private fun buildActiveSwitch(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -383,20 +383,33 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
     }
 
-    private fun formatFeeDescription(fee: Fee): CharSequence {
-        val percent = formatPercent(fee.percent, fee.isMarkup)
-        if (fee.isActive) return percent
-        return SpannableStringBuilder(percent)
-            .append(SUMMARY_SEPARATOR)
-            .append(getString(R.string.fee_inactive_marker))
-    }
+    private fun formatFeeDescription(fee: Fee): CharSequence = withInactiveMarker(formatPercent(fee.percent, fee.isMarkup), fee.isActive)
+
+    /**
+     * Append the "Inactive" text marker after [base] when [isActive] is false.
+     * Shared by the fee-selector row summary and the specific-pair category
+     * summary so both surfaces spell out inactive state identically — the
+     * marker is what keeps the reduced-alpha row WCAG 1.4.1 compliant (state
+     * not conveyed by colour alone).
+     */
+    private fun withInactiveMarker(
+        base: CharSequence,
+        isActive: Boolean,
+    ): CharSequence =
+        if (isActive) {
+            base
+        } else {
+            SpannableStringBuilder(base)
+                .append(SUMMARY_SEPARATOR)
+                .append(getString(R.string.fee_inactive_marker))
+        }
 
     private fun displayNameOf(fee: Fee): String = fee.name.ifBlank { getString(R.string.fee_untitled) }
 
     private fun <T : Fee> populate(
         category: PreferenceCategory,
         entries: List<T>,
-        summaryFor: (T) -> CharSequence?,
+        summaryFor: (T) -> CharSequence,
         onAdd: () -> Unit,
         onEdit: (T) -> Unit,
     ) {
@@ -415,7 +428,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 category.addPreference(
                     Preference(ctx).apply {
                         title = formatFeeTitle(fee)
-                        summary = buildFeeSummary(summaryFor(fee), fee.isActive)
+                        summary = withInactiveMarker(summaryFor(fee), fee.isActive)
                         isIconSpaceReserved = false
                         setOnPreferenceClickListener {
                             onEdit(fee)
@@ -439,20 +452,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
     private fun formatFeeTitle(fee: Fee): CharSequence {
         val percent = formatPercent(fee.percent, fee.isMarkup)
-        return if (fee.name.isBlank()) percent else "${fee.name}  ·  $percent"
-    }
-
-    private fun buildFeeSummary(
-        base: CharSequence?,
-        isActive: Boolean,
-    ): CharSequence? {
-        val inactive = if (!isActive) getString(R.string.fee_inactive_marker) else null
-        return when {
-            base == null && inactive == null -> null
-            base == null -> inactive
-            inactive == null -> base
-            else -> SpannableStringBuilder(base).append(SUMMARY_SEPARATOR).append(inactive)
-        }
+        return if (fee.name.isBlank()) percent else "${fee.name}$SUMMARY_SEPARATOR$percent"
     }
 
     private fun formatPercent(
@@ -611,6 +611,24 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     private fun buildEditorContainer(ctx: Context): LinearLayout =
         paddedDialogContainer(ctx, topPadding = resources.getDimensionPixelSize(R.dimen.margin2x))
 
+    /**
+     * Stack the shared prefix (active switch + name), any dialog-specific
+     * [middle] rows, then the shared suffix (percent + fee-side block with a
+     * top gap) into a fee-editor container. Both editor dialogs use this so
+     * the field order — and the gap before the fee-side header — stays in
+     * sync automatically.
+     */
+    private fun LinearLayout.addFeeEditorLayout(
+        inputs: SharedFeeInputs,
+        middle: LinearLayout.() -> Unit = {},
+    ) {
+        addView(inputs.activeSwitch)
+        addLabeled(R.string.fee_edit_name, inputs.nameInput)
+        middle()
+        addLabeled(R.string.fee_edit_percent, inputs.percentInput)
+        addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
+    }
+
     private fun showGlobalFeeDialog(
         @StringRes titleRes: Int,
         existing: Fee?,
@@ -620,11 +638,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val ctx = requireContext()
         val container = buildEditorContainer(ctx)
         val inputs = buildSharedFeeInputs(ctx, existing)
-
-        container.addView(inputs.activeSwitch)
-        container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
-        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
-        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
+        container.addFeeEditorLayout(inputs)
 
         feeEditorDialog(ctx, titleRes, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
@@ -667,34 +681,44 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 isChecked = existing?.bothWays == true
             }
 
-        container.addView(inputs.activeSwitch)
-        container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
-        container.addLabeled(R.string.fee_pair_from, fromButton)
-        container.addLabeled(R.string.fee_pair_to, toButton)
-        container.addView(bothWays)
-        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
-        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
+        container.addFeeEditorLayout(inputs) {
+            addLabeled(R.string.fee_pair_from, fromButton)
+            addLabeled(R.string.fee_pair_to, toButton)
+            addView(bothWays)
+        }
 
         feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 val from = pickedFrom ?: return@setPositiveButton
                 val to = pickedTo ?: return@setPositiveButton
-                val draft = inputs.toDraft()
                 onConfirm(
-                    Fee.SpecificPair(
+                    inputs.toDraft().toSpecificPair(
                         id = existing?.id ?: UUID.randomUUID().toString(),
-                        name = draft.name,
-                        percent = draft.percent,
-                        isMarkup = draft.isMarkup,
                         from = from,
                         to = to,
                         bothWays = bothWays.isChecked,
-                        isActive = draft.isActive,
-                        feeSide = draft.feeSide,
                     ),
                 )
             }.show()
     }
+
+    private fun FeeDraft.toSpecificPair(
+        id: String,
+        from: String,
+        to: String,
+        bothWays: Boolean,
+    ): Fee.SpecificPair =
+        Fee.SpecificPair(
+            id = id,
+            name = name,
+            percent = percent,
+            isMarkup = isMarkup,
+            from = from,
+            to = to,
+            bothWays = bothWays,
+            isActive = isActive,
+            feeSide = feeSide,
+        )
 
     private fun MaterialAlertDialogBuilder.withDeleteButton(onDelete: (() -> Unit)?): MaterialAlertDialogBuilder {
         if (onDelete != null) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -32,6 +32,7 @@ import com.eliormachlev.currencix.util.applySelectableRowBackground
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.dpToPx
 import com.eliormachlev.currencix.util.paddedDialogContainer
+import com.eliormachlev.currencix.util.resolveThemeColor
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
@@ -59,6 +60,11 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 // used by the saved-carts list so all in-app row-affordance icons look alike.
 private const val ROW_ICON_BUTTON_SIZE_DP = 48f
 private const val ROW_ICON_PADDING_DP = 12f
+
+// Minimum tap-target for the leading radio in the fee picker. Matches the
+// Material accessibility guidance (WCAG 2.5.5) so the radio can be tapped
+// independently of the row's edit affordance without missing.
+private const val RADIO_MIN_TOUCH_DP = 48f
 
 // Arrows used in the "specific pair" summary.
 private const val ARROW_ONE_WAY = "\u2192"
@@ -318,30 +324,32 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val container = paddedDialogContainer(ctx)
         val dialogHolder = arrayOfNulls<AlertDialog>(1)
         val radios = mutableListOf<RadioButton>()
+        // Opaque muted colour for the inactive-state cue. Paired with the
+        // existing "Inactive" text marker so state is not conveyed by colour
+        // alone (WCAG 1.4.1); using a theme-resolved colour keeps the AA
+        // contrast target on light/dark/OLED.
+        val mutedColor = ctx.resolveThemeColor(com.google.android.material.R.attr.colorOnSurfaceVariant)
+        val editActionLabel = getString(R.string.fee_edit_percent)
 
         entries.forEachIndexed { index, fee ->
             val radio =
-                RadioButton(ctx).apply {
-                    isChecked = fee.id == effectiveId
-                    isClickable = false
+                buildPickerRadio(ctx, checked = fee.id == effectiveId) {
+                    radios.forEachIndexed { i, r -> r.isChecked = i == index }
+                    onPicked(fee.id)
+                    dialogHolder[0]?.dismiss()
                 }
             radios += radio
-            val editButton =
-                buildEditIconButton(ctx) {
-                    dialogHolder[0]?.dismiss()
-                    onEdit(fee)
-                }
             container.addView(
                 choiceExplainerRow(
                     ctx = ctx,
                     title = displayNameOf(fee),
                     description = formatFeeDescription(fee),
                     leadingView = radio,
-                    trailingView = editButton,
+                    textColor = if (fee.isActive) null else mutedColor,
+                    clickActionLabel = editActionLabel,
                 ) {
-                    radios.forEachIndexed { i, r -> r.isChecked = i == index }
-                    onPicked(fee.id)
                     dialogHolder[0]?.dismiss()
+                    onEdit(fee)
                 },
             )
         }
@@ -361,10 +369,21 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .show()
     }
 
-    private fun buildEditIconButton(
+    private fun buildPickerRadio(
         ctx: Context,
+        checked: Boolean,
         onClick: () -> Unit,
-    ): View = buildRowIcon(ctx, R.drawable.ic_edit, getString(R.string.fee_edit_percent), onClick)
+    ): RadioButton {
+        val minTouchPx = RADIO_MIN_TOUCH_DP.dpToPx().toInt()
+        return RadioButton(ctx).apply {
+            isChecked = checked
+            isClickable = true
+            isFocusable = true
+            minWidth = minTouchPx
+            minHeight = minTouchPx
+            setOnClickListener { onClick() }
+        }
+    }
 
     private fun buildAddRow(
         ctx: Context,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -81,16 +81,46 @@ private fun feePercentFormat(sep: Char): Regex =
             "(?:\\Q$sep\\E\\d{0,$FEE_PERCENT_MAX_FRACTION_DIGITS})?$",
     )
 
-private fun String.normalizeSeparatorsTo(sep: Char): String =
-    if (none { it == '.' || it == ',' }) {
-        this
-    } else {
-        buildString(length) {
-            for (c in this@normalizeSeparatorsTo) {
-                append(if (c == '.' || c == ',') sep else c)
+// String.replace(char, char) returns the receiver unchanged when no
+// replacement happened, so the two-step version allocates only when a
+// non-locale separator was actually present.
+private fun String.normalizeSeparatorsTo(sep: Char): String = replace('.', sep).replace(',', sep)
+
+// Parses text as typed in the field back to BigDecimal by first pulling
+// the locale separator back to ASCII "." (which is all BigDecimal
+// understands). Shared by the filter's range check and the confirm-time
+// draft build.
+private fun String.toFeePercentOrNull(sep: Char): BigDecimal? = replace(sep, '.').toBigDecimalOrNull()
+
+/**
+ * Longest prefix of [normalized] that, when placed between [before] and
+ * [after], yields a valid fee-percent field. Returns `null` when even the
+ * empty prefix is invalid (never happens from a valid starting state, but
+ * keeps the caller total). Drives the graceful paste-truncation: e.g.
+ * "1234.5678" collapses to "123.567" instead of being rejected outright.
+ */
+private fun firstAcceptableTrim(
+    normalized: String,
+    before: String,
+    after: String,
+    sep: Char,
+): String? {
+    val format = feePercentFormat(sep)
+    val intermediateChars = "+-$sep"
+    var candidate = normalized
+    while (true) {
+        val result = before + candidate + after
+        val ok =
+            when {
+                !format.matches(result) -> false
+                result.isEmpty() || result.last() in intermediateChars -> true
+                else -> result.toFeePercentOrNull(sep)?.let { it in FEE_PERCENT_RANGE } == true
             }
-        }
+        if (ok) return candidate
+        if (candidate.isEmpty()) return null
+        candidate = candidate.dropLast(1)
     }
+}
 
 /**
  * Rejects edits that would push the field outside FEE_PERCENT_RANGE or
@@ -106,31 +136,15 @@ private fun String.normalizeSeparatorsTo(sep: Char): String =
 private val feePercentInputFilter =
     InputFilter { source, start, end, dest, dstart, dend ->
         val sep = feePercentSeparator
-        val format = feePercentFormat(sep)
-        val intermediateChars = "+-$sep"
         val before = dest.subSequence(0, dstart).toString()
         val after = dest.subSequence(dend, dest.length).toString()
         val original = source.subSequence(start, end).toString()
-        var trimmed = original.normalizeSeparatorsTo(sep)
-
-        while (true) {
-            val result = before + trimmed + after
-            val ok =
-                when {
-                    !format.matches(result) -> false
-                    result.isEmpty() || result.last() in intermediateChars -> true
-                    else ->
-                        result
-                            .replace(sep, '.')
-                            .toBigDecimalOrNull()
-                            ?.let { it in FEE_PERCENT_RANGE } == true
-                }
-            if (ok) return@InputFilter if (trimmed == original) null else trimmed
-            if (trimmed.isEmpty()) return@InputFilter ""
-            trimmed = trimmed.dropLast(1)
+        val normalized = original.normalizeSeparatorsTo(sep)
+        when (val accepted = firstAcceptableTrim(normalized, before, after, sep)) {
+            null -> ""
+            original -> null
+            else -> accepted
         }
-        @Suppress("UNREACHABLE_CODE")
-        null
     }
 
 // Trailing/leading icon buttons in picker rows. 48dp total with 12dp padding
@@ -721,8 +735,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             val parsed =
                 percentInput.editText.text
                     .toString()
-                    .replace(feePercentSeparator, '.')
-                    .toBigDecimalOrNull() ?: BigDecimal.ZERO
+                    .toFeePercentOrNull(feePercentSeparator) ?: BigDecimal.ZERO
             return FeeDraft(
                 name = nameInput.text.toString().trim(),
                 percent = parsed.abs(),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -621,12 +621,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
      */
     private fun LinearLayout.addFeeEditorLayout(
         inputs: SharedFeeInputs,
+        @DimenRes percentTopGapRes: Int? = null,
         middle: LinearLayout.() -> Unit = {},
     ) {
         addView(inputs.activeSwitch)
         addLabeled(R.string.fee_edit_name, inputs.nameInput)
         middle()
-        addLabeled(R.string.fee_edit_percent, inputs.percentInput)
+        addLabeled(R.string.fee_edit_percent, inputs.percentInput, topGapRes = percentTopGapRes)
         addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
     }
 
@@ -682,7 +683,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 isChecked = existing?.bothWays == true
             }
 
-        container.addFeeEditorLayout(inputs) {
+        container.addFeeEditorLayout(inputs, percentTopGapRes = R.dimen.margin4x) {
             addLabeled(R.string.fee_pair_from, fromButton)
             addLabeled(R.string.fee_pair_to, toButton)
             addView(bothWays, topGapLayoutParams(R.dimen.margin4x))

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -2,9 +2,11 @@ package com.eliormachlev.currencix.view.preference
 
 import android.content.Context
 import android.os.Bundle
+import android.text.InputFilter
 import android.text.InputType
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.method.DigitsKeyListener
 import android.text.style.ImageSpan
 import android.util.TypedValue
 import android.view.Gravity
@@ -50,6 +52,28 @@ private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
+
+// Fee percent field: whole-number percents in [-100, 100]. Sign toggles
+// markup vs discount downstream; abs value is stored on the model.
+private val FEE_PERCENT_RANGE = -100..100
+private const val FEE_PERCENT_ALLOWED_CHARS = "+-0123456789"
+private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d+$")
+
+// Rejects edits that would leave the field outside FEE_PERCENT_RANGE.
+// Empty and a lone sign are allowed as intermediate typing states.
+private val feePercentRangeFilter =
+    InputFilter { source, start, end, dest, dstart, dend ->
+        val result =
+            dest.substring(0, dstart) +
+                source.subSequence(start, end) +
+                dest.substring(dend)
+        when {
+            result.isEmpty() || result == "+" || result == "-" -> null
+            !FEE_PERCENT_FORMAT.matches(result) -> ""
+            result.toIntOrNull() in FEE_PERCENT_RANGE -> null
+            else -> ""
+        }
+    }
 
 // Trailing/leading icon buttons in picker rows. 48dp total with 12dp padding
 // yields a 24dp visible glyph — matches the Material3 IconButton dimensions
@@ -478,21 +502,20 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
 
     /**
-     * Numeric percent field. Signed input is allowed so a leading "−" flips
-     * the fee from markup to discount; unsigned input defaults to markup.
+     * Numeric percent field. Signed integer input in [-100, 100]; a leading
+     * "−" flips the fee from markup to discount, unsigned defaults to markup.
      * [initialSigned] is the value carrying its own sign — callers compose it
-     * from the model's separate abs-percent / isMarkup fields.
+     * from the model's separate abs-percent / isMarkup fields. setText runs
+     * before filters are attached so a legacy decimal value still displays.
      */
     private fun buildPercentInput(
         ctx: Context,
         initialSigned: BigDecimal?,
     ): EditText =
         EditText(ctx).apply {
-            inputType =
-                InputType.TYPE_CLASS_NUMBER or
-                InputType.TYPE_NUMBER_FLAG_DECIMAL or
-                InputType.TYPE_NUMBER_FLAG_SIGNED
+            keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_ALLOWED_CHARS)
             if (initialSigned != null) setText(initialSigned.toPlainString())
+            filters = arrayOf(feePercentRangeFilter)
         }
 
     private fun buildActiveSwitch(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -16,6 +16,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
+import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
@@ -117,24 +118,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 title = getString(titleRes)
                 isIconSpaceReserved = false
             }.also(screen::addPreference)
-
-    // Extra clearance below the EditText so its text-selection handle doesn't
-    // drop onto the sign toggle.
-    private fun addSignToggleWithTopMargin(
-        container: LinearLayout,
-        signToggle: View,
-    ) {
-        container.addView(
-            signToggle,
-            LinearLayout
-                .LayoutParams(
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                ).apply {
-                    topMargin = resources.getDimensionPixelSize(R.dimen.margin4x)
-                },
-        )
-    }
 
     private fun feeSideOption(side: FeeSide): ChoiceOption =
         when (side) {
@@ -527,13 +510,61 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     /**
      * Append a section label followed by its associated view. Used by both
      * fee-editor dialogs, which are entirely a stack of labelled-input pairs.
+     * [topGapRes] adds a top margin to the label — pass when the caller wants
+     * to break the visual flow before a new section (e.g. the fee-side block
+     * after the numeric row).
      */
     private fun LinearLayout.addLabeled(
         @StringRes labelRes: Int,
         view: View,
+        @DimenRes topGapRes: Int? = null,
     ) {
-        addView(sectionLabel(context, labelRes))
+        val label = sectionLabel(context, labelRes)
+        if (topGapRes != null) {
+            addView(
+                label,
+                LinearLayout
+                    .LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ).apply { topMargin = resources.getDimensionPixelSize(topGapRes) },
+            )
+        } else {
+            addView(label)
+        }
         addView(view)
+    }
+
+    /**
+     * Combine the sign toggle and percent input into a single horizontal row
+     * so the +/− sits inline with the numeric field. The row's layout
+     * direction is pinned to LTR in both LTR and RTL locales — the sign is a
+     * mathematical prefix to the number, not a directional element, so it
+     * always belongs at the physical left of the value.
+     */
+    private fun buildPercentRow(
+        ctx: Context,
+        inputs: SharedFeeInputs,
+    ): LinearLayout {
+        val gap = resources.getDimensionPixelSize(R.dimen.margin2x)
+        return LinearLayout(ctx).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            layoutDirection = View.LAYOUT_DIRECTION_LTR
+            addView(
+                inputs.signToggle.view,
+                LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+            addView(
+                inputs.percentInput,
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                    marginStart = gap
+                },
+            )
+        }
     }
 
     /**
@@ -606,19 +637,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             activeSwitch = buildActiveSwitch(ctx, existing?.isActive != false),
         )
 
-    /**
-     * Append the sign toggle + fee-side header + fee-side chooser to a
-     * dialog's container. Shared so both fee-editor dialogs render this
-     * trailing block identically.
-     */
-    private fun addSignAndFeeSideViews(
-        container: LinearLayout,
-        inputs: SharedFeeInputs,
-    ) {
-        addSignToggleWithTopMargin(container, inputs.signToggle.view)
-        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view)
-    }
-
     private fun buildEditorContainer(ctx: Context): LinearLayout =
         paddedDialogContainer(ctx, topPadding = resources.getDimensionPixelSize(R.dimen.margin2x))
 
@@ -634,8 +652,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
         container.addView(inputs.activeSwitch)
         container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
-        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
-        addSignAndFeeSideViews(container, inputs)
+        container.addLabeled(R.string.fee_edit_percent, buildPercentRow(ctx, inputs))
+        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
 
         feeEditorDialog(ctx, titleRes, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
@@ -683,8 +701,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         container.addLabeled(R.string.fee_pair_from, fromButton)
         container.addLabeled(R.string.fee_pair_to, toButton)
         container.addView(bothWays)
-        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
-        addSignAndFeeSideViews(container, inputs)
+        container.addLabeled(R.string.fee_edit_percent, buildPercentRow(ctx, inputs))
+        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
 
         feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ ->

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -39,7 +39,6 @@ import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
 import com.google.android.material.button.MaterialButton
-import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
 import java.math.BigDecimal
@@ -49,13 +48,6 @@ import java.util.UUID
 // the settings back-up/restore pipeline.
 private const val PREF_KEY_GLOBAL_EXCHANGE = "__global_exchange"
 private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
-
-// Sign-toggle button geometry (dp) and text size (sp). Sized to sit inline
-// with the percent EditText — height matches the 48dp WCAG touch-target
-// minimum, width is just enough for the glyph.
-private const val SIGN_TOGGLE_BUTTON_HEIGHT_DP = 48f
-private const val SIGN_TOGGLE_BUTTON_WIDTH_DP = 48f
-private const val SIGN_TOGGLE_TEXT_SIZE_SP = 16f
 
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
@@ -486,13 +478,22 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             if (initial != null) setText(initial)
         }
 
+    /**
+     * Numeric percent field. Signed input is allowed so a leading "−" flips
+     * the fee from markup to discount; unsigned input defaults to markup.
+     * [initialSigned] is the value carrying its own sign — callers compose it
+     * from the model's separate abs-percent / isMarkup fields.
+     */
     private fun buildPercentInput(
         ctx: Context,
-        initial: BigDecimal?,
+        initialSigned: BigDecimal?,
     ): EditText =
         EditText(ctx).apply {
-            inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-            if (initial != null) setText(initial.toPlainString())
+            inputType =
+                InputType.TYPE_CLASS_NUMBER or
+                InputType.TYPE_NUMBER_FLAG_DECIMAL or
+                InputType.TYPE_NUMBER_FLAG_SIGNED
+            if (initialSigned != null) setText(initialSigned.toPlainString())
         }
 
     private fun buildActiveSwitch(
@@ -538,38 +539,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     }
 
     /**
-     * Combine the sign toggle and percent input into a single horizontal row
-     * so the +/− sits inline with the numeric field. The row's layout
-     * direction is pinned to LTR in both LTR and RTL locales — the sign is a
-     * mathematical prefix to the number, not a directional element, so it
-     * always belongs at the physical left of the value.
-     */
-    private fun buildPercentRow(
-        ctx: Context,
-        inputs: SharedFeeInputs,
-    ): LinearLayout {
-        val gap = resources.getDimensionPixelSize(R.dimen.margin2x)
-        return LinearLayout(ctx).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            addView(
-                inputs.signToggle.view,
-                LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                ),
-            )
-            addView(
-                inputs.percentInput,
-                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
-                    marginStart = gap
-                },
-            )
-        }
-    }
-
-    /**
      * Build the [MaterialAlertDialogBuilder] shared by the two fee-editor
      * dialogs — title, body view, cancel, and optional delete. Callers append
      * their own positive button (each dialog handles OK differently) and call
@@ -609,22 +578,21 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     private data class SharedFeeInputs(
         val nameInput: EditText,
         val percentInput: EditText,
-        val signToggle: SignToggle,
         val feeSideChooser: FeeSideChooser,
         val activeSwitch: MaterialSwitch,
     ) {
-        fun toDraft(): FeeDraft =
-            FeeDraft(
+        fun toDraft(): FeeDraft {
+            val parsed = percentInput.text.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
+            return FeeDraft(
                 name = nameInput.text.toString().trim(),
-                percent =
-                    percentInput.text
-                        .toString()
-                        .toBigDecimalOrNull()
-                        ?.abs() ?: BigDecimal.ZERO,
-                isMarkup = signToggle.isMarkup(),
+                percent = parsed.abs(),
+                // Zero has no sign meaning — treat as markup so the default
+                // for a blank/zero field matches the previous +/-toggle default.
+                isMarkup = parsed.signum() >= 0,
                 isActive = activeSwitch.isChecked,
                 feeSide = feeSideChooser.current(),
             )
+        }
     }
 
     private fun buildSharedFeeInputs(
@@ -633,11 +601,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ): SharedFeeInputs =
         SharedFeeInputs(
             nameInput = buildNameInput(ctx, existing?.name),
-            percentInput = buildPercentInput(ctx, existing?.percent),
-            signToggle = buildSignToggle(ctx, existing?.isMarkup),
+            percentInput = buildPercentInput(ctx, existing?.signedPercent()),
             feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL),
             activeSwitch = buildActiveSwitch(ctx, existing?.isActive != false),
         )
+
+    private fun Fee.signedPercent(): BigDecimal = if (isMarkup) percent else percent.negate()
 
     private fun buildEditorContainer(ctx: Context): LinearLayout =
         paddedDialogContainer(ctx, topPadding = resources.getDimensionPixelSize(R.dimen.margin2x))
@@ -654,7 +623,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
         container.addView(inputs.activeSwitch)
         container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
-        container.addLabeled(R.string.fee_edit_percent, buildPercentRow(ctx, inputs))
+        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
         container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
 
         feeEditorDialog(ctx, titleRes, container, onDelete)
@@ -703,7 +672,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         container.addLabeled(R.string.fee_pair_from, fromButton)
         container.addLabeled(R.string.fee_pair_to, toButton)
         container.addView(bothWays)
-        container.addLabeled(R.string.fee_edit_percent, buildPercentRow(ctx, inputs))
+        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
         container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
 
         feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)
@@ -790,44 +759,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 }
             }
         return FeeSideChooser(row, { picked })
-    }
-
-    /**
-     * Two-button +/− toggle group. The wrapper hides the "is minus selected?"
-     * predicate behind [SignToggle.isMarkup] so callers don't reach into the
-     * button ids directly. Selection defaults to + unless [initialMarkup] is
-     * explicitly false.
-     */
-    private data class SignToggle(
-        val view: MaterialButtonToggleGroup,
-        val plusId: Int,
-        val minusId: Int,
-    ) {
-        fun isMarkup(): Boolean = view.checkedButtonId != minusId
-    }
-
-    private fun buildSignToggle(
-        ctx: Context,
-        initialMarkup: Boolean?,
-    ): SignToggle {
-        val group = MaterialButtonToggleGroup(ctx).apply { isSingleSelection = true }
-        val btnHeight = SIGN_TOGGLE_BUTTON_HEIGHT_DP.dpToPx().toInt()
-        val btnWidth = SIGN_TOGGLE_BUTTON_WIDTH_DP.dpToPx().toInt()
-
-        fun makeButton(labelRes: Int): MaterialButton =
-            outlinedMaterialButton(ctx).apply {
-                id = View.generateViewId()
-                text = getString(labelRes)
-                textSize = SIGN_TOGGLE_TEXT_SIZE_SP
-                insetTop = 0
-                insetBottom = 0
-            }
-        val btnPlus = makeButton(R.string.fee_edit_sign_positive)
-        val btnMinus = makeButton(R.string.fee_edit_sign_negative)
-        group.addView(btnPlus, LinearLayout.LayoutParams(btnWidth, btnHeight))
-        group.addView(btnMinus, LinearLayout.LayoutParams(btnWidth, btnHeight))
-        group.check(if (initialMarkup == false) btnMinus.id else btnPlus.id)
-        return SignToggle(group, btnPlus.id, btnMinus.id)
     }
 
     private fun outlinedMaterialButton(ctx: Context): MaterialButton =

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -639,7 +639,10 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val activeSwitch: MaterialSwitch,
     ) {
         fun toDraft(): FeeDraft {
-            val parsed = percentInput.editText.text.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
+            val parsed =
+                percentInput.editText.text
+                    .toString()
+                    .toBigDecimalOrNull() ?: BigDecimal.ZERO
             return FeeDraft(
                 name = nameInput.text.toString().trim(),
                 percent = parsed.abs(),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -40,6 +40,7 @@ import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.materialswitch.MaterialSwitch
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -232,7 +233,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = sectionTitleRes,
             onPicked = setActiveId,
             onAdd = {
-                showGlobalFeeDialog(existing = null) { draft ->
+                showGlobalFeeDialog(titleRes = sectionTitleRes, existing = null) { draft ->
                     val fee = create(draft)
                     db.addFee(fee)
                     if (getActiveId() == null) setActiveId(fee.id)
@@ -240,6 +241,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             },
             onEdit = { fee ->
                 showGlobalFeeDialog(
+                    titleRes = sectionTitleRes,
                     existing = fee,
                     onDelete = { db.deleteFee(fee.id) },
                 ) { draft -> db.updateFee(update(fee, draft)) }
@@ -508,11 +510,11 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             if (initial != null) setText(initial.toPlainString())
         }
 
-    private fun buildActiveCheckbox(
+    private fun buildActiveSwitch(
         ctx: Context,
         initial: Boolean,
-    ): CheckBox =
-        CheckBox(ctx).apply {
+    ): MaterialSwitch =
+        MaterialSwitch(ctx).apply {
             text = getString(R.string.fee_edit_active)
             isChecked = initial
         }
@@ -546,7 +548,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val percentInput: EditText,
         val signToggle: SignToggle,
         val feeSideChooser: FeeSideChooser,
-        val activeCheckbox: CheckBox,
+        val activeSwitch: MaterialSwitch,
     ) {
         fun toDraft(): FeeDraft =
             FeeDraft(
@@ -557,7 +559,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                         .toBigDecimalOrNull()
                         ?.abs() ?: BigDecimal.ZERO,
                 isMarkup = signToggle.isMarkup(),
-                isActive = activeCheckbox.isChecked,
+                isActive = activeSwitch.isChecked,
                 feeSide = feeSideChooser.current(),
             )
     }
@@ -571,27 +573,29 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             percentInput = buildPercentInput(ctx, existing?.percent),
             signToggle = buildSignToggle(ctx, existing?.isMarkup),
             feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL),
-            activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false),
+            activeSwitch = buildActiveSwitch(ctx, existing?.isActive != false),
         )
 
     /**
-     * Append the meta section — sign toggle, fee-side chooser, active switch —
-     * to a dialog's container. Shared so both fee-editor dialogs render the
+     * Append the sign toggle + fee-side header + fee-side chooser to a
+     * dialog's container. Shared so both fee-editor dialogs render this
      * trailing block identically.
      */
-    private fun addFeeMetaViews(
+    private fun addSignAndFeeSideViews(
         container: LinearLayout,
+        ctx: Context,
         inputs: SharedFeeInputs,
     ) {
         addSignToggleWithTopMargin(container, inputs.signToggle.view)
+        container.addView(sectionLabel(ctx, R.string.fee_side_label))
         container.addView(inputs.feeSideChooser.view)
-        container.addView(inputs.activeCheckbox)
     }
 
     private fun buildEditorContainer(ctx: Context): LinearLayout =
         paddedDialogContainer(ctx, topPadding = resources.getDimensionPixelSize(R.dimen.margin2x))
 
     private fun showGlobalFeeDialog(
+        @StringRes titleRes: Int,
         existing: Fee?,
         onDelete: (() -> Unit)? = null,
         onConfirm: (FeeDraft) -> Unit,
@@ -600,14 +604,15 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val container = buildEditorContainer(ctx)
         val inputs = buildSharedFeeInputs(ctx, existing)
 
+        container.addView(inputs.activeSwitch)
         container.addView(sectionLabel(ctx, R.string.fee_edit_name))
         container.addView(inputs.nameInput)
         container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
         container.addView(inputs.percentInput)
-        addFeeMetaViews(container, inputs)
+        addSignAndFeeSideViews(container, ctx, inputs)
 
         MaterialAlertDialogBuilder(ctx)
-            .setTitle(R.string.fee_edit_percent)
+            .setTitle(titleRes)
             .setView(container)
             .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
             .setNegativeButton(android.R.string.cancel, null)
@@ -651,6 +656,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 isChecked = existing?.bothWays == true
             }
 
+        container.addView(inputs.activeSwitch)
         container.addView(sectionLabel(ctx, R.string.fee_edit_name))
         container.addView(inputs.nameInput)
         container.addView(sectionLabel(ctx, R.string.fee_pair_from))
@@ -660,7 +666,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         container.addView(bothWays)
         container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
         container.addView(inputs.percentInput)
-        addFeeMetaViews(container, inputs)
+        addSignAndFeeSideViews(container, ctx, inputs)
 
         MaterialAlertDialogBuilder(ctx)
             .setTitle(R.string.fee_section_specific_pair)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -59,13 +59,17 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 // renames.
 private val FEE_EDITOR_SECTION_GAP = R.dimen.margin4x
 
-// Fee percent field: signed decimal percents in [-100, 100]. Sign toggles
-// markup vs discount downstream; abs value is stored on the model. Both
-// ASCII "." and the current locale's decimal separator are accepted so
-// numeric keypads in comma-decimal locales (de, fr, ru, …) still work.
+// Fee percent field: signed decimal percents in [-100, 100] with up to
+// FEE_PERCENT_MAX_FRACTION_DIGITS digits after the separator. Sign
+// toggles markup vs discount downstream; abs value is stored on the
+// model. Both ASCII "." and the current locale's decimal separator are
+// accepted so numeric keypads in comma-decimal locales (de, fr, ru, …)
+// still work.
 private val FEE_PERCENT_RANGE = BigDecimal("-100")..BigDecimal("100")
+private const val FEE_PERCENT_MAX_FRACTION_DIGITS = 3
 private const val FEE_PERCENT_DIGITS = "+-.,0123456789"
-private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d*[.,]?\\d*$")
+private val FEE_PERCENT_FORMAT =
+    Regex("^[+-]?\\d*(?:[.,]\\d{0,$FEE_PERCENT_MAX_FRACTION_DIGITS})?$")
 
 private fun String.normalizeDecimalSeparator(): String = replace(',', '.')
 
@@ -532,7 +536,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
 
     /**
-     * Numeric percent field with a "%" glyph pinned to the physical left of
+     * Numeric percent field with a "%" glyph pinned to the physical right of
      * the input (LTR *or* RTL locale). Signed decimal input in [-100, 100];
      * a leading "−" flips the fee from markup to discount, unsigned defaults
      * to markup. [initialSigned] is the value carrying its own sign —
@@ -550,24 +554,25 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 filters = arrayOf(feePercentRangeFilter)
                 if (initialSigned != null) setText(initialSigned.toPlainString())
             }
-        val prefix =
+        val suffix =
             TextView(ctx).apply { text = "%" }
         val row =
             LinearLayout(ctx).apply {
                 orientation = LinearLayout.HORIZONTAL
-                // Pin "%" to the physical left even in RTL locales.
+                // Pin "%" to the physical right even in RTL locales.
                 layoutDirection = View.LAYOUT_DIRECTION_LTR
                 addView(
-                    prefix,
+                    editText,
                     LinearLayout
-                        .LayoutParams(
-                            ViewGroup.LayoutParams.WRAP_CONTENT,
-                            ViewGroup.LayoutParams.WRAP_CONTENT,
-                        ).apply { marginEnd = resources.getDimensionPixelSize(R.dimen.margin1x) },
+                        .LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+                        .apply { marginEnd = resources.getDimensionPixelSize(R.dimen.margin1x) },
                 )
                 addView(
-                    editText,
-                    LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+                    suffix,
+                    LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ),
                 )
             }
         return PercentInput(row, editText)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -186,9 +186,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             getActiveId = db::getActiveExchangeIdBlocking,
             setActiveId = db::setActiveExchangeId,
             create = { d -> Fee.GlobalExchange(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
-            update = { existing, d ->
-                existing.copy(name = d.name, percent = d.percent, isMarkup = d.isMarkup, isActive = d.isActive, feeSide = d.feeSide)
-            },
+            update = feeUpdater(),
         )
         renderGlobalCategory(
             pref = globalBankPref,
@@ -197,9 +195,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             getActiveId = db::getActiveBankIdBlocking,
             setActiveId = db::setActiveBankId,
             create = { d -> Fee.GlobalBank(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
-            update = { existing, d ->
-                existing.copy(name = d.name, percent = d.percent, isMarkup = d.isMarkup, isActive = d.isActive, feeSide = d.feeSide)
-            },
+            update = feeUpdater(),
         )
         populate(
             category = categoryPair,
@@ -220,6 +216,24 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             },
         )
     }
+
+    /**
+     * Update lambda shared by every category. [Fee.withEditableFields] is
+     * defined per-subclass to `copy` and return its own concrete type, so
+     * the cast back to [T] is safe (unchecked warning is the price of Kotlin
+     * not having a "Self" type on sealed hierarchies).
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Fee> feeUpdater(): (T, FeeDraft) -> T =
+        { existing, d ->
+            existing.withEditableFields(
+                name = d.name,
+                percent = d.percent,
+                isMarkup = d.isMarkup,
+                isActive = d.isActive,
+                feeSide = d.feeSide,
+            ) as T
+        }
 
     /**
      * Wire one global-fee category (exchange or bank/card) into its selector
@@ -557,21 +571,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val editText: EditText,
     )
 
-    private fun buildActiveSwitch(
+    private fun buildSwitch(
         ctx: Context,
+        @StringRes labelRes: Int,
         initial: Boolean,
     ): MaterialSwitch =
         MaterialSwitch(ctx).apply {
-            text = getString(R.string.fee_edit_active)
-            isChecked = initial
-        }
-
-    private fun buildBothWaysSwitch(
-        ctx: Context,
-        initial: Boolean,
-    ): MaterialSwitch =
-        MaterialSwitch(ctx).apply {
-            text = getString(R.string.fee_pair_both_ways)
+            text = getString(labelRes)
             isChecked = initial
         }
 
@@ -678,7 +684,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             nameInput = buildNameInput(ctx, existing?.name),
             percentInput = buildPercentInput(ctx, existing?.signedPercent()),
             feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL),
-            activeSwitch = buildActiveSwitch(ctx, existing?.isActive != false),
+            activeSwitch = buildSwitch(ctx, R.string.fee_edit_active, existing?.isActive != false),
         )
 
     private fun Fee.signedPercent(): BigDecimal = if (isMarkup) percent else percent.negate()
@@ -751,7 +757,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 placeholder,
                 disabled = { pickedFrom },
             ) { pickedTo = it }
-        val bothWays = buildBothWaysSwitch(ctx, existing?.bothWays == true)
+        val bothWays = buildSwitch(ctx, R.string.fee_pair_both_ways, existing?.bothWays == true)
 
         container.addFeeEditorLayout(inputs, percentTopGapRes = FEE_EDITOR_SECTION_GAP) {
             addLabeled(R.string.fee_pair_from, fromButton)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -525,6 +525,36 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ): TextView = TextView(ctx).apply { text = getString(res) }
 
     /**
+     * Append a section label followed by its associated view. Used by both
+     * fee-editor dialogs, which are entirely a stack of labelled-input pairs.
+     */
+    private fun LinearLayout.addLabeled(
+        @StringRes labelRes: Int,
+        view: View,
+    ) {
+        addView(sectionLabel(context, labelRes))
+        addView(view)
+    }
+
+    /**
+     * Build the [MaterialAlertDialogBuilder] shared by the two fee-editor
+     * dialogs — title, body view, cancel, and optional delete. Callers append
+     * their own positive button (each dialog handles OK differently) and call
+     * `show()`.
+     */
+    private fun feeEditorDialog(
+        ctx: Context,
+        @StringRes titleRes: Int,
+        container: View,
+        onDelete: (() -> Unit)?,
+    ): MaterialAlertDialogBuilder =
+        MaterialAlertDialogBuilder(ctx)
+            .setTitle(titleRes)
+            .setView(container)
+            .setNegativeButton(android.R.string.cancel, null)
+            .withDeleteButton(onDelete)
+
+    /**
      * Snapshot of the fields shared between the global-fee and specific-pair
      * edit dialogs. Threading a struct instead of five positional args keeps
      * the create/update lambdas in [renderGlobalCategory] readable and avoids
@@ -583,12 +613,10 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
      */
     private fun addSignAndFeeSideViews(
         container: LinearLayout,
-        ctx: Context,
         inputs: SharedFeeInputs,
     ) {
         addSignToggleWithTopMargin(container, inputs.signToggle.view)
-        container.addView(sectionLabel(ctx, R.string.fee_side_label))
-        container.addView(inputs.feeSideChooser.view)
+        container.addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view)
     }
 
     private fun buildEditorContainer(ctx: Context): LinearLayout =
@@ -605,18 +633,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val inputs = buildSharedFeeInputs(ctx, existing)
 
         container.addView(inputs.activeSwitch)
-        container.addView(sectionLabel(ctx, R.string.fee_edit_name))
-        container.addView(inputs.nameInput)
-        container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
-        container.addView(inputs.percentInput)
-        addSignAndFeeSideViews(container, ctx, inputs)
+        container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
+        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
+        addSignAndFeeSideViews(container, inputs)
 
-        MaterialAlertDialogBuilder(ctx)
-            .setTitle(titleRes)
-            .setView(container)
+        feeEditorDialog(ctx, titleRes, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
-            .setNegativeButton(android.R.string.cancel, null)
-            .withDeleteButton(onDelete)
             .show()
     }
 
@@ -657,20 +679,14 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             }
 
         container.addView(inputs.activeSwitch)
-        container.addView(sectionLabel(ctx, R.string.fee_edit_name))
-        container.addView(inputs.nameInput)
-        container.addView(sectionLabel(ctx, R.string.fee_pair_from))
-        container.addView(fromButton)
-        container.addView(sectionLabel(ctx, R.string.fee_pair_to))
-        container.addView(toButton)
+        container.addLabeled(R.string.fee_edit_name, inputs.nameInput)
+        container.addLabeled(R.string.fee_pair_from, fromButton)
+        container.addLabeled(R.string.fee_pair_to, toButton)
         container.addView(bothWays)
-        container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
-        container.addView(inputs.percentInput)
-        addSignAndFeeSideViews(container, ctx, inputs)
+        container.addLabeled(R.string.fee_edit_percent, inputs.percentInput)
+        addSignAndFeeSideViews(container, inputs)
 
-        MaterialAlertDialogBuilder(ctx)
-            .setTitle(R.string.fee_section_specific_pair)
-            .setView(container)
+        feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 val from = pickedFrom ?: return@setPositiveButton
                 val to = pickedTo ?: return@setPositiveButton
@@ -688,9 +704,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                         feeSide = draft.feeSide,
                     ),
                 )
-            }.setNegativeButton(android.R.string.cancel, null)
-            .withDeleteButton(onDelete)
-            .show()
+            }.show()
     }
 
     private fun MaterialAlertDialogBuilder.withDeleteButton(onDelete: (() -> Unit)?): MaterialAlertDialogBuilder {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -29,11 +29,11 @@ import com.eliormachlev.currencix.model.FeeSide
 import com.eliormachlev.currencix.repository.Database
 import com.eliormachlev.currencix.util.CHOICE_DESC_ALPHA
 import com.eliormachlev.currencix.util.ChoiceOption
+import com.eliormachlev.currencix.util.DISABLED_ROW_ALPHA
 import com.eliormachlev.currencix.util.applySelectableRowBackground
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.dpToPx
 import com.eliormachlev.currencix.util.paddedDialogContainer
-import com.eliormachlev.currencix.util.resolveThemeColor
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
@@ -300,11 +300,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         val container = paddedDialogContainer(ctx)
         val dialogHolder = arrayOfNulls<AlertDialog>(1)
         val radios = mutableListOf<RadioButton>()
-        // Opaque muted colour for the inactive-state cue. Paired with the
-        // existing "Inactive" text marker so state is not conveyed by colour
-        // alone (WCAG 1.4.1); using a theme-resolved colour keeps the AA
-        // contrast target on light/dark/OLED.
-        val mutedColor = ctx.resolveThemeColor(com.google.android.material.R.attr.colorOnSurfaceVariant)
         val editActionLabel = getString(R.string.fee_edit_percent)
 
         entries.forEachIndexed { index, fee ->
@@ -315,19 +310,22 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                     dialogHolder[0]?.dismiss()
                 }
             radios += radio
-            container.addView(
+            val row =
                 choiceExplainerRow(
                     ctx = ctx,
                     title = displayNameOf(fee),
                     description = formatFeeDescription(fee),
                     leadingView = radio,
-                    textColor = if (fee.isActive) null else mutedColor,
                     clickActionLabel = editActionLabel,
                 ) {
                     dialogHolder[0]?.dismiss()
                     onEdit(fee)
-                },
-            )
+                }
+            // Dim inactive rows to match the disabled-currency treatment in
+            // the currency picker. The "Inactive" text marker in the summary
+            // keeps state non-colour-only for WCAG 1.4.1.
+            if (!fee.isActive) row.alpha = DISABLED_ROW_ALPHA
+            container.addView(row)
         }
 
         container.addView(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -50,10 +50,12 @@ import java.util.UUID
 private const val PREF_KEY_GLOBAL_EXCHANGE = "__global_exchange"
 private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 
-// Sign-toggle button geometry (dp) and text size (sp).
-private const val SIGN_TOGGLE_BUTTON_HEIGHT_DP = 56f
-private const val SIGN_TOGGLE_BUTTON_WIDTH_DP = 80f
-private const val SIGN_TOGGLE_TEXT_SIZE_SP = 20f
+// Sign-toggle button geometry (dp) and text size (sp). Sized to sit inline
+// with the percent EditText — height matches the 48dp WCAG touch-target
+// minimum, width is just enough for the glyph.
+private const val SIGN_TOGGLE_BUTTON_HEIGHT_DP = 48f
+private const val SIGN_TOGGLE_BUTTON_WIDTH_DP = 48f
+private const val SIGN_TOGGLE_TEXT_SIZE_SP = 16f
 
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -10,7 +10,6 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
-import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -524,19 +523,21 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ) {
         val label = sectionLabel(context, labelRes)
         if (topGapRes != null) {
-            addView(
-                label,
-                LinearLayout
-                    .LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ).apply { topMargin = resources.getDimensionPixelSize(topGapRes) },
-            )
+            addView(label, topGapLayoutParams(topGapRes))
         } else {
             addView(label)
         }
         addView(view)
     }
+
+    private fun LinearLayout.topGapLayoutParams(
+        @DimenRes topGapRes: Int,
+    ): LinearLayout.LayoutParams =
+        LinearLayout
+            .LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            ).apply { topMargin = resources.getDimensionPixelSize(topGapRes) }
 
     /**
      * Build the [MaterialAlertDialogBuilder] shared by the two fee-editor
@@ -676,7 +677,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 disabled = { pickedFrom },
             ) { pickedTo = it }
         val bothWays =
-            CheckBox(ctx).apply {
+            MaterialSwitch(ctx).apply {
                 text = getString(R.string.fee_pair_both_ways)
                 isChecked = existing?.bothWays == true
             }
@@ -684,7 +685,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         container.addFeeEditorLayout(inputs) {
             addLabeled(R.string.fee_pair_from, fromButton)
             addLabeled(R.string.fee_pair_to, toButton)
-            addView(bothWays)
+            addView(bothWays, topGapLayoutParams(R.dimen.margin4x))
         }
 
         feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -16,6 +16,7 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
@@ -58,6 +59,12 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 // dialog (Active switch, Name, per-dialog middle rows, Percent, Fee side).
 // Named so intent survives future dimen renames.
 private val FEE_EDITOR_SECTION_GAP = R.dimen.margin2x
+
+// Fraction of screen width the fee-editor dialog stretches to. Default
+// AlertDialog width is ~10dp-margin narrower on most devices, which pushes
+// the Fee-side radio row into wrapping; 0.95 keeps a hairline margin but
+// buys enough room to fit the row on typical phones.
+private const val FEE_EDITOR_DIALOG_WIDTH_FRACTION = 0.95f
 
 // Fee percent field: signed decimals in [-100, 100] with at most
 // FEE_PERCENT_MAX_INT_DIGITS before and FEE_PERCENT_MAX_FRACTION_DIGITS
@@ -688,6 +695,11 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
      * cancel, optional delete, and OK. [onOk] is invoked when the user
      * confirms; use `return@showFeeEditorDialog` to bail without dismissing
      * data flow (e.g. when required inputs aren't filled in yet).
+     *
+     * The body is wrapped in a [ScrollView] so overflowing rows (e.g. the
+     * fee-side explainer on short screens) stay reachable, and the dialog
+     * window is widened to [FEE_EDITOR_DIALOG_WIDTH_FRACTION] of screen
+     * width so we get more horizontal room before rows have to wrap.
      */
     private fun showFeeEditorDialog(
         ctx: Context,
@@ -696,13 +708,17 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         onDelete: (() -> Unit)?,
         onOk: () -> Unit,
     ) {
-        MaterialAlertDialogBuilder(ctx)
-            .setTitle(titleRes)
-            .setView(container)
-            .setNegativeButton(android.R.string.cancel, null)
-            .withDeleteButton(onDelete)
-            .setPositiveButton(android.R.string.ok) { _, _ -> onOk() }
-            .show()
+        val scroll = ScrollView(ctx).apply { addView(container) }
+        val dialog =
+            MaterialAlertDialogBuilder(ctx)
+                .setTitle(titleRes)
+                .setView(scroll)
+                .setNegativeButton(android.R.string.cancel, null)
+                .withDeleteButton(onDelete)
+                .setPositiveButton(android.R.string.ok) { _, _ -> onOk() }
+                .show()
+        val width = (ctx.resources.displayMetrics.widthPixels * FEE_EDITOR_DIALOG_WIDTH_FRACTION).toInt()
+        dialog.window?.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
     /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -505,20 +505,51 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
 
     /**
-     * Numeric percent field. Signed decimal input in [-100, 100]; a leading
-     * "−" flips the fee from markup to discount, unsigned defaults to markup.
-     * [initialSigned] is the value carrying its own sign — callers compose it
-     * from the model's separate abs-percent / isMarkup fields.
+     * Numeric percent field with a "%" glyph pinned to the physical left of
+     * the input (LTR *or* RTL locale). Signed decimal input in [-100, 100];
+     * a leading "−" flips the fee from markup to discount, unsigned defaults
+     * to markup. [initialSigned] is the value carrying its own sign —
+     * callers compose it from the model's separate abs-percent / isMarkup
+     * fields. Returned bundle exposes both the row [view] to add to the
+     * layout and the raw [editText] for reading text back at confirm time.
      */
     private fun buildPercentInput(
         ctx: Context,
         initialSigned: BigDecimal?,
-    ): EditText =
-        EditText(ctx).apply {
-            keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_ALLOWED_CHARS)
-            filters = arrayOf(feePercentRangeFilter)
-            if (initialSigned != null) setText(initialSigned.toPlainString())
-        }
+    ): PercentInput {
+        val editText =
+            EditText(ctx).apply {
+                keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_ALLOWED_CHARS)
+                filters = arrayOf(feePercentRangeFilter)
+                if (initialSigned != null) setText(initialSigned.toPlainString())
+            }
+        val prefix =
+            TextView(ctx).apply { text = "%" }
+        val row =
+            LinearLayout(ctx).apply {
+                orientation = LinearLayout.HORIZONTAL
+                // Pin "%" to the physical left even in RTL locales.
+                layoutDirection = View.LAYOUT_DIRECTION_LTR
+                addView(
+                    prefix,
+                    LinearLayout
+                        .LayoutParams(
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ).apply { marginEnd = resources.getDimensionPixelSize(R.dimen.margin1x) },
+                )
+                addView(
+                    editText,
+                    LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+                )
+            }
+        return PercentInput(row, editText)
+    }
+
+    private data class PercentInput(
+        val view: View,
+        val editText: EditText,
+    )
 
     private fun buildActiveSwitch(
         ctx: Context,
@@ -603,12 +634,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
      */
     private data class SharedFeeInputs(
         val nameInput: EditText,
-        val percentInput: EditText,
+        val percentInput: PercentInput,
         val feeSideChooser: FeeSideChooser,
         val activeSwitch: MaterialSwitch,
     ) {
         fun toDraft(): FeeDraft {
-            val parsed = percentInput.text.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
+            val parsed = percentInput.editText.text.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
             return FeeDraft(
                 name = nameInput.text.toString().trim(),
                 percent = parsed.abs(),
@@ -652,7 +683,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         addView(inputs.activeSwitch)
         addLabeled(R.string.fee_edit_name, inputs.nameInput)
         middle()
-        addLabeled(R.string.fee_edit_percent, inputs.percentInput, topGapRes = percentTopGapRes)
+        addLabeled(R.string.fee_edit_percent, inputs.percentInput.view, topGapRes = percentTopGapRes)
         addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -53,6 +53,12 @@ private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
 
+// Vertical break between logical sections of the fee-editor dialog
+// (percent → fee-side, and in the specific-pair dialog also before
+// Both directions / Percent). Named so intent survives future dimen
+// renames.
+private val FEE_EDITOR_SECTION_GAP = R.dimen.margin4x
+
 // Fee percent field: signed decimal percents in [-100, 100]. Sign toggles
 // markup vs discount downstream; abs value is stored on the model.
 private val FEE_PERCENT_RANGE = BigDecimal("-100")..BigDecimal("100")
@@ -560,6 +566,15 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             isChecked = initial
         }
 
+    private fun buildBothWaysSwitch(
+        ctx: Context,
+        initial: Boolean,
+    ): MaterialSwitch =
+        MaterialSwitch(ctx).apply {
+            text = getString(R.string.fee_pair_both_ways)
+            isChecked = initial
+        }
+
     private fun sectionLabel(
         ctx: Context,
         @StringRes res: Int,
@@ -687,7 +702,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         addLabeled(R.string.fee_edit_name, inputs.nameInput)
         middle()
         addLabeled(R.string.fee_edit_percent, inputs.percentInput.view, topGapRes = percentTopGapRes)
-        addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = R.dimen.margin4x)
+        addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = FEE_EDITOR_SECTION_GAP)
     }
 
     private fun showGlobalFeeDialog(
@@ -736,16 +751,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 placeholder,
                 disabled = { pickedFrom },
             ) { pickedTo = it }
-        val bothWays =
-            MaterialSwitch(ctx).apply {
-                text = getString(R.string.fee_pair_both_ways)
-                isChecked = existing?.bothWays == true
-            }
+        val bothWays = buildBothWaysSwitch(ctx, existing?.bothWays == true)
 
-        container.addFeeEditorLayout(inputs, percentTopGapRes = R.dimen.margin4x) {
+        container.addFeeEditorLayout(inputs, percentTopGapRes = FEE_EDITOR_SECTION_GAP) {
             addLabeled(R.string.fee_pair_from, fromButton)
             addLabeled(R.string.fee_pair_to, toButton)
-            addView(bothWays, topGapLayoutParams(R.dimen.margin4x))
+            addView(bothWays, topGapLayoutParams(FEE_EDITOR_SECTION_GAP))
         }
 
         feeEditorDialog(ctx, R.string.fee_section_specific_pair, container, onDelete)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -53,14 +53,15 @@ private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
 
-// Fee percent field: whole-number percents in [-100, 100]. Sign toggles
+// Fee percent field: signed decimal percents in [-100, 100]. Sign toggles
 // markup vs discount downstream; abs value is stored on the model.
-private val FEE_PERCENT_RANGE = -100..100
-private const val FEE_PERCENT_ALLOWED_CHARS = "+-0123456789"
-private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d+$")
+private val FEE_PERCENT_RANGE = BigDecimal("-100")..BigDecimal("100")
+private const val FEE_PERCENT_ALLOWED_CHARS = "+-.0123456789"
+private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d*\\.?\\d*$")
 
 // Rejects edits that would leave the field outside FEE_PERCENT_RANGE.
-// Empty and a lone sign are allowed as intermediate typing states.
+// Empty / trailing sign / trailing dot pass as intermediate typing states
+// (e.g. "-", "1.") since they aren't yet parseable as a decimal.
 private val feePercentRangeFilter =
     InputFilter { source, start, end, dest, dstart, dend ->
         val result =
@@ -68,10 +69,12 @@ private val feePercentRangeFilter =
                 source.subSequence(start, end) +
                 dest.substring(dend)
         when {
-            result.isEmpty() || result == "+" || result == "-" -> null
             !FEE_PERCENT_FORMAT.matches(result) -> ""
-            result.toIntOrNull() in FEE_PERCENT_RANGE -> null
-            else -> ""
+            result.isEmpty() || result.last() in "+-." -> null
+            else -> {
+                val value = result.toBigDecimalOrNull()
+                if (value != null && value in FEE_PERCENT_RANGE) null else ""
+            }
         }
     }
 
@@ -502,7 +505,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         }
 
     /**
-     * Numeric percent field. Signed integer input in [-100, 100]; a leading
+     * Numeric percent field. Signed decimal input in [-100, 100]; a leading
      * "−" flips the fee from markup to discount, unsigned defaults to markup.
      * [initialSigned] is the value carrying its own sign — callers compose it
      * from the model's separate abs-percent / isMarkup fields.

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -54,11 +54,10 @@ private const val PREF_KEY_GLOBAL_BANK = "__global_bank"
 // Flag glyph height for inline flag spans (sp so it scales with body text).
 private const val FLAG_INLINE_HEIGHT_SP = 14f
 
-// Vertical break between logical sections of the fee-editor dialog
-// (percent → fee-side, and in the specific-pair dialog also before
-// Both directions / Percent). Named so intent survives future dimen
-// renames.
-private val FEE_EDITOR_SECTION_GAP = R.dimen.margin4x
+// Vertical break applied uniformly between every section of the fee-editor
+// dialog (Active switch, Name, per-dialog middle rows, Percent, Fee side).
+// Named so intent survives future dimen renames.
+private val FEE_EDITOR_SECTION_GAP = R.dimen.margin2x
 
 // Fee percent field: signed decimals in [-100, 100] with at most
 // FEE_PERCENT_MAX_INT_DIGITS before and FEE_PERCENT_MAX_FRACTION_DIGITS
@@ -766,20 +765,20 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
 
     /**
      * Stack the shared prefix (active switch + name), any dialog-specific
-     * [middle] rows, then the shared suffix (percent + fee-side block with a
-     * top gap) into a fee-editor container. Both editor dialogs use this so
-     * the field order — and the gap before the fee-side header — stays in
-     * sync automatically.
+     * [middle] rows, then the shared suffix (percent + fee-side) into a
+     * fee-editor container. Every section transition gets the same
+     * [FEE_EDITOR_SECTION_GAP] so the rhythm reads evenly top-to-bottom;
+     * callers only need to apply the same gap to any rows they add in
+     * [middle].
      */
     private fun LinearLayout.addFeeEditorLayout(
         inputs: SharedFeeInputs,
-        @DimenRes percentTopGapRes: Int? = null,
         middle: LinearLayout.() -> Unit = {},
     ) {
         addView(inputs.activeSwitch)
-        addLabeled(R.string.fee_edit_name, inputs.nameInput)
+        addLabeled(R.string.fee_edit_name, inputs.nameInput, topGapRes = FEE_EDITOR_SECTION_GAP)
         middle()
-        addLabeled(R.string.fee_edit_percent, inputs.percentInput.view, topGapRes = percentTopGapRes)
+        addLabeled(R.string.fee_edit_percent, inputs.percentInput.view, topGapRes = FEE_EDITOR_SECTION_GAP)
         addLabeled(R.string.fee_side_label, inputs.feeSideChooser.view, topGapRes = FEE_EDITOR_SECTION_GAP)
     }
 
@@ -831,9 +830,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             ) { pickedTo = it }
         val bothWays = buildSwitch(ctx, R.string.fee_pair_both_ways, existing?.bothWays == true)
 
-        container.addFeeEditorLayout(inputs, percentTopGapRes = FEE_EDITOR_SECTION_GAP) {
-            addLabeled(R.string.fee_pair_from, fromButton)
-            addLabeled(R.string.fee_pair_to, toButton)
+        container.addFeeEditorLayout(inputs) {
+            addLabeled(R.string.fee_pair_from, fromButton, topGapRes = FEE_EDITOR_SECTION_GAP)
+            addLabeled(R.string.fee_pair_to, toButton, topGapRes = FEE_EDITOR_SECTION_GAP)
             addView(bothWays, topGapLayoutParams(FEE_EDITOR_SECTION_GAP))
         }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -60,14 +60,18 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 private val FEE_EDITOR_SECTION_GAP = R.dimen.margin4x
 
 // Fee percent field: signed decimal percents in [-100, 100]. Sign toggles
-// markup vs discount downstream; abs value is stored on the model.
+// markup vs discount downstream; abs value is stored on the model. Both
+// ASCII "." and the current locale's decimal separator are accepted so
+// numeric keypads in comma-decimal locales (de, fr, ru, …) still work.
 private val FEE_PERCENT_RANGE = BigDecimal("-100")..BigDecimal("100")
-private const val FEE_PERCENT_ALLOWED_CHARS = "+-.0123456789"
-private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d*\\.?\\d*$")
+private const val FEE_PERCENT_DIGITS = "+-.,0123456789"
+private val FEE_PERCENT_FORMAT = Regex("^[+-]?\\d*[.,]?\\d*$")
+
+private fun String.normalizeDecimalSeparator(): String = replace(',', '.')
 
 // Rejects edits that would leave the field outside FEE_PERCENT_RANGE.
-// Empty / trailing sign / trailing dot pass as intermediate typing states
-// (e.g. "-", "1.") since they aren't yet parseable as a decimal.
+// Empty / trailing sign / trailing separator pass as intermediate typing
+// states (e.g. "-", "1.", "1,") since they aren't yet parseable.
 private val feePercentRangeFilter =
     InputFilter { source, start, end, dest, dstart, dend ->
         val result =
@@ -76,9 +80,9 @@ private val feePercentRangeFilter =
                 dest.substring(dend)
         when {
             !FEE_PERCENT_FORMAT.matches(result) -> ""
-            result.isEmpty() || result.last() in "+-." -> null
+            result.isEmpty() || result.last() in "+-.," -> null
             else -> {
-                val value = result.toBigDecimalOrNull()
+                val value = result.normalizeDecimalSeparator().toBigDecimalOrNull()
                 if (value != null && value in FEE_PERCENT_RANGE) null else ""
             }
         }
@@ -539,7 +543,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ): PercentInput {
         val editText =
             EditText(ctx).apply {
-                keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_ALLOWED_CHARS)
+                keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_DIGITS)
                 filters = arrayOf(feePercentRangeFilter)
                 if (initialSigned != null) setText(initialSigned.toPlainString())
             }
@@ -663,6 +667,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             val parsed =
                 percentInput.editText.text
                     .toString()
+                    .normalizeDecimalSeparator()
                     .toBigDecimalOrNull() ?: BigDecimal.ZERO
             return FeeDraft(
                 name = nameInput.text.toString().trim(),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -16,6 +16,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.TextView
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -174,17 +175,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = R.string.fee_section_global_exchange,
             getActiveId = db::getActiveExchangeIdBlocking,
             setActiveId = db::setActiveExchangeId,
-            create = { name, percent, isMarkup, isActive, feeSide ->
-                Fee.GlobalExchange(UUID.randomUUID().toString(), name, percent, isMarkup, isActive, feeSide)
-            },
-            update = { existing, name, percent, isMarkup, isActive, feeSide ->
-                existing.copy(
-                    name = name,
-                    percent = percent,
-                    isMarkup = isMarkup,
-                    isActive = isActive,
-                    feeSide = feeSide,
-                )
+            create = { d -> Fee.GlobalExchange(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
+            update = { existing, d ->
+                existing.copy(name = d.name, percent = d.percent, isMarkup = d.isMarkup, isActive = d.isActive, feeSide = d.feeSide)
             },
         )
         renderGlobalCategory(
@@ -193,17 +186,9 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = R.string.fee_section_global_bank,
             getActiveId = db::getActiveBankIdBlocking,
             setActiveId = db::setActiveBankId,
-            create = { name, percent, isMarkup, isActive, feeSide ->
-                Fee.GlobalBank(UUID.randomUUID().toString(), name, percent, isMarkup, isActive, feeSide)
-            },
-            update = { existing, name, percent, isMarkup, isActive, feeSide ->
-                existing.copy(
-                    name = name,
-                    percent = percent,
-                    isMarkup = isMarkup,
-                    isActive = isActive,
-                    feeSide = feeSide,
-                )
+            create = { d -> Fee.GlobalBank(UUID.randomUUID().toString(), d.name, d.percent, d.isMarkup, d.isActive, d.feeSide) },
+            update = { existing, d ->
+                existing.copy(name = d.name, percent = d.percent, isMarkup = d.isMarkup, isActive = d.isActive, feeSide = d.feeSide)
             },
         )
         populate(
@@ -237,15 +222,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         sectionTitleRes: Int,
         getActiveId: () -> String?,
         setActiveId: (String) -> Unit,
-        create: (name: String, percent: BigDecimal, isMarkup: Boolean, isActive: Boolean, feeSide: FeeSide) -> T,
-        update: (
-            existing: T,
-            name: String,
-            percent: BigDecimal,
-            isMarkup: Boolean,
-            isActive: Boolean,
-            feeSide: FeeSide,
-        ) -> T,
+        create: (FeeDraft) -> T,
+        update: (existing: T, FeeDraft) -> T,
     ) {
         renderGlobalSelector(
             pref = pref,
@@ -254,8 +232,8 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             sectionTitleRes = sectionTitleRes,
             onPicked = setActiveId,
             onAdd = {
-                showGlobalFeeDialog(existing = null) { name, percent, isMarkup, isActive, feeSide ->
-                    val fee = create(name, percent, isMarkup, isActive, feeSide)
+                showGlobalFeeDialog(existing = null) { draft ->
+                    val fee = create(draft)
                     db.addFee(fee)
                     if (getActiveId() == null) setActiveId(fee.id)
                 }
@@ -264,9 +242,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 showGlobalFeeDialog(
                     existing = fee,
                     onDelete = { db.deleteFee(fee.id) },
-                ) { name, percent, isMarkup, isActive, feeSide ->
-                    db.updateFee(update(fee, name, percent, isMarkup, isActive, feeSide))
-                }
+                ) { draft -> db.updateFee(update(fee, draft)) }
             },
         )
     }
@@ -525,6 +501,15 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             if (initial != null) setText(initial)
         }
 
+    private fun buildPercentInput(
+        ctx: Context,
+        initial: BigDecimal?,
+    ): EditText =
+        EditText(ctx).apply {
+            inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+            if (initial != null) setText(initial.toPlainString())
+        }
+
     private fun buildActiveCheckbox(
         ctx: Context,
         initial: Boolean,
@@ -534,50 +519,100 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             isChecked = initial
         }
 
+    private fun sectionLabel(
+        ctx: Context,
+        @StringRes res: Int,
+    ): TextView = TextView(ctx).apply { text = getString(res) }
+
+    /**
+     * Snapshot of the fields shared between the global-fee and specific-pair
+     * edit dialogs. Threading a struct instead of five positional args keeps
+     * the create/update lambdas in [renderGlobalCategory] readable and avoids
+     * accidentally swapping arg order at call sites.
+     */
+    private data class FeeDraft(
+        val name: String,
+        val percent: BigDecimal,
+        val isMarkup: Boolean,
+        val isActive: Boolean,
+        val feeSide: FeeSide,
+    )
+
+    /**
+     * Bundle of the inputs that appear in both fee-editor dialogs. Each dialog
+     * builds one via [buildSharedFeeInputs], places the views in whatever
+     * order it wants, and asks [toDraft] for the confirm payload.
+     */
+    private data class SharedFeeInputs(
+        val nameInput: EditText,
+        val percentInput: EditText,
+        val signToggle: SignToggle,
+        val feeSideChooser: FeeSideChooser,
+        val activeCheckbox: CheckBox,
+    ) {
+        fun toDraft(): FeeDraft =
+            FeeDraft(
+                name = nameInput.text.toString().trim(),
+                percent =
+                    percentInput.text
+                        .toString()
+                        .toBigDecimalOrNull()
+                        ?.abs() ?: BigDecimal.ZERO,
+                isMarkup = signToggle.isMarkup(),
+                isActive = activeCheckbox.isChecked,
+                feeSide = feeSideChooser.current(),
+            )
+    }
+
+    private fun buildSharedFeeInputs(
+        ctx: Context,
+        existing: Fee?,
+    ): SharedFeeInputs =
+        SharedFeeInputs(
+            nameInput = buildNameInput(ctx, existing?.name),
+            percentInput = buildPercentInput(ctx, existing?.percent),
+            signToggle = buildSignToggle(ctx, existing?.isMarkup),
+            feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL),
+            activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false),
+        )
+
+    /**
+     * Append the meta section — sign toggle, fee-side chooser, active switch —
+     * to a dialog's container. Shared so both fee-editor dialogs render the
+     * trailing block identically.
+     */
+    private fun addFeeMetaViews(
+        container: LinearLayout,
+        inputs: SharedFeeInputs,
+    ) {
+        addSignToggleWithTopMargin(container, inputs.signToggle.view)
+        container.addView(inputs.feeSideChooser.view)
+        container.addView(inputs.activeCheckbox)
+    }
+
+    private fun buildEditorContainer(ctx: Context): LinearLayout =
+        paddedDialogContainer(ctx, topPadding = resources.getDimensionPixelSize(R.dimen.margin2x))
+
     private fun showGlobalFeeDialog(
         existing: Fee?,
         onDelete: (() -> Unit)? = null,
-        onConfirm: (name: String, percent: BigDecimal, isMarkup: Boolean, isActive: Boolean, feeSide: FeeSide) -> Unit,
+        onConfirm: (FeeDraft) -> Unit,
     ) {
         val ctx = requireContext()
-        val padV = resources.getDimensionPixelSize(R.dimen.margin2x)
-        val container = paddedDialogContainer(ctx, topPadding = padV)
+        val container = buildEditorContainer(ctx)
+        val inputs = buildSharedFeeInputs(ctx, existing)
 
-        val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
-        val nameInput = buildNameInput(ctx, existing?.name)
-        val percentLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_percent) }
-        val percentInput =
-            EditText(ctx).apply {
-                inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-                if (existing != null) setText(existing.percent.toPlainString())
-            }
-        val signGroup = buildSignToggle(ctx, existing?.isMarkup)
-        val feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL)
-        val activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false)
-
-        container.addView(nameLabel)
-        container.addView(nameInput)
-        container.addView(percentLabel)
-        container.addView(percentInput)
-        addSignToggleWithTopMargin(container, signGroup.view)
-        container.addView(feeSideChooser.view)
-        container.addView(activeCheckbox)
+        container.addView(sectionLabel(ctx, R.string.fee_edit_name))
+        container.addView(inputs.nameInput)
+        container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
+        container.addView(inputs.percentInput)
+        addFeeMetaViews(container, inputs)
 
         MaterialAlertDialogBuilder(ctx)
             .setTitle(R.string.fee_edit_percent)
             .setView(container)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                val percent =
-                    percentInput.text.toString().toBigDecimalOrNull()
-                        ?: BigDecimal.ZERO
-                onConfirm(
-                    nameInput.text.toString().trim(),
-                    percent.abs(),
-                    signGroup.isMarkup(),
-                    activeCheckbox.isChecked,
-                    feeSideChooser.current(),
-                )
-            }.setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm(inputs.toDraft()) }
+            .setNegativeButton(android.R.string.cancel, null)
             .withDeleteButton(onDelete)
             .show()
     }
@@ -588,16 +623,13 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         onConfirm: (Fee.SpecificPair) -> Unit,
     ) {
         val ctx = requireContext()
-        val padV = resources.getDimensionPixelSize(R.dimen.margin2x)
-        val container = paddedDialogContainer(ctx, topPadding = padV)
+        val container = buildEditorContainer(ctx)
+        val inputs = buildSharedFeeInputs(ctx, existing)
 
         var pickedFrom: String? = existing?.from
         var pickedTo: String? = existing?.to
         val placeholder = getString(R.string.fee_pair_pick_currency)
 
-        val nameLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_name) }
-        val nameInput = buildNameInput(ctx, existing?.name)
-        val fromLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_from) }
         val fromButton =
             buildCurrencyPickerButton(
                 ctx,
@@ -608,7 +640,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 // AUD → AUD is meaningless).
                 disabled = { pickedTo },
             ) { pickedFrom = it }
-        val toLabel = TextView(ctx).apply { text = getString(R.string.fee_pair_to) }
         val toButton =
             buildCurrencyPickerButton(
                 ctx,
@@ -621,52 +652,36 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 text = getString(R.string.fee_pair_both_ways)
                 isChecked = existing?.bothWays == true
             }
-        val percentLabel = TextView(ctx).apply { text = getString(R.string.fee_edit_percent) }
-        val percentInput =
-            EditText(ctx).apply {
-                inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-                if (existing != null) setText(existing.percent.toPlainString())
-            }
-        val signToggle = buildSignToggle(ctx, existing?.isMarkup)
-        val feeSideChooser = buildFeeSideChooser(ctx, existing?.feeSide ?: FeeSide.ORIGINAL)
-        val activeCheckbox = buildActiveCheckbox(ctx, existing?.isActive != false)
 
-        listOf(
-            nameLabel,
-            nameInput,
-            fromLabel,
-            fromButton,
-            toLabel,
-            toButton,
-            bothWays,
-            percentLabel,
-            percentInput,
-        ).forEach { container.addView(it) }
-        addSignToggleWithTopMargin(container, signToggle.view)
-        container.addView(feeSideChooser.view)
-        container.addView(activeCheckbox)
+        container.addView(sectionLabel(ctx, R.string.fee_edit_name))
+        container.addView(inputs.nameInput)
+        container.addView(sectionLabel(ctx, R.string.fee_pair_from))
+        container.addView(fromButton)
+        container.addView(sectionLabel(ctx, R.string.fee_pair_to))
+        container.addView(toButton)
+        container.addView(bothWays)
+        container.addView(sectionLabel(ctx, R.string.fee_edit_percent))
+        container.addView(inputs.percentInput)
+        addFeeMetaViews(container, inputs)
 
         MaterialAlertDialogBuilder(ctx)
             .setTitle(R.string.fee_section_specific_pair)
             .setView(container)
             .setPositiveButton(android.R.string.ok) { _, _ ->
-                val from = pickedFrom
-                val to = pickedTo
-                if (from == null || to == null) return@setPositiveButton
-                val percent =
-                    percentInput.text.toString().toBigDecimalOrNull()
-                        ?: BigDecimal.ZERO
+                val from = pickedFrom ?: return@setPositiveButton
+                val to = pickedTo ?: return@setPositiveButton
+                val draft = inputs.toDraft()
                 onConfirm(
                     Fee.SpecificPair(
                         id = existing?.id ?: UUID.randomUUID().toString(),
-                        name = nameInput.text.toString().trim(),
-                        percent = percent.abs(),
-                        isMarkup = signToggle.isMarkup(),
+                        name = draft.name,
+                        percent = draft.percent,
+                        isMarkup = draft.isMarkup,
                         from = from,
                         to = to,
                         bothWays = bothWays.isChecked,
-                        isActive = activeCheckbox.isChecked,
-                        feeSide = feeSideChooser.current(),
+                        isActive = draft.isActive,
+                        feeSide = draft.feeSide,
                     ),
                 )
             }.setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -43,6 +43,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
 import java.math.BigDecimal
+import java.text.DecimalFormatSymbols
 import java.util.UUID
 
 // Preference keys for UI-only rows. The leading __ marks them as ignored by
@@ -59,37 +60,77 @@ private const val FLAG_INLINE_HEIGHT_SP = 14f
 // renames.
 private val FEE_EDITOR_SECTION_GAP = R.dimen.margin4x
 
-// Fee percent field: signed decimal percents in [-100, 100] with up to
-// FEE_PERCENT_MAX_FRACTION_DIGITS digits after the separator. Sign
-// toggles markup vs discount downstream; abs value is stored on the
-// model. Both ASCII "." and the current locale's decimal separator are
-// accepted so numeric keypads in comma-decimal locales (de, fr, ru, …)
-// still work.
+// Fee percent field: signed decimals in [-100, 100] with at most
+// FEE_PERCENT_MAX_INT_DIGITS before and FEE_PERCENT_MAX_FRACTION_DIGITS
+// after the decimal separator. Sign toggles markup vs discount downstream;
+// abs value is stored on the model. The current locale's decimal separator
+// is what actually appears in the field, but both "." and "," in typed or
+// pasted input are auto-normalized to it so keyboards / spreadsheet paste
+// from other locales still work.
 private val FEE_PERCENT_RANGE = BigDecimal("-100")..BigDecimal("100")
+private const val FEE_PERCENT_MAX_INT_DIGITS = 3
 private const val FEE_PERCENT_MAX_FRACTION_DIGITS = 3
 private const val FEE_PERCENT_DIGITS = "+-.,0123456789"
-private val FEE_PERCENT_FORMAT =
-    Regex("^[+-]?\\d*(?:[.,]\\d{0,$FEE_PERCENT_MAX_FRACTION_DIGITS})?$")
 
-private fun String.normalizeDecimalSeparator(): String = replace(',', '.')
+private val feePercentSeparator: Char
+    get() = DecimalFormatSymbols.getInstance().decimalSeparator
 
-// Rejects edits that would leave the field outside FEE_PERCENT_RANGE.
-// Empty / trailing sign / trailing separator pass as intermediate typing
-// states (e.g. "-", "1.", "1,") since they aren't yet parseable.
-private val feePercentRangeFilter =
-    InputFilter { source, start, end, dest, dstart, dend ->
-        val result =
-            dest.substring(0, dstart) +
-                source.subSequence(start, end) +
-                dest.substring(dend)
-        when {
-            !FEE_PERCENT_FORMAT.matches(result) -> ""
-            result.isEmpty() || result.last() in "+-.," -> null
-            else -> {
-                val value = result.normalizeDecimalSeparator().toBigDecimalOrNull()
-                if (value != null && value in FEE_PERCENT_RANGE) null else ""
+private fun feePercentFormat(sep: Char): Regex =
+    Regex(
+        "^[+-]?\\d{0,$FEE_PERCENT_MAX_INT_DIGITS}" +
+            "(?:\\Q$sep\\E\\d{0,$FEE_PERCENT_MAX_FRACTION_DIGITS})?$",
+    )
+
+private fun String.normalizeSeparatorsTo(sep: Char): String =
+    if (none { it == '.' || it == ',' }) {
+        this
+    } else {
+        buildString(length) {
+            for (c in this@normalizeSeparatorsTo) {
+                append(if (c == '.' || c == ',') sep else c)
             }
         }
+    }
+
+/**
+ * Rejects edits that would push the field outside FEE_PERCENT_RANGE or
+ * over the digit budget. "." and "," in the incoming source are first
+ * normalized to the current locale's separator so users can type either.
+ * If the resulting text would exceed the digit budget (typical on paste
+ * of e.g. "1234.5678"), we trim characters off the end of the pasted
+ * source until it fits — so paste is graceful instead of silently
+ * rejected. Empty / trailing sign / trailing separator pass as
+ * intermediate typing states (e.g. "-", "1,") since they aren't yet
+ * parseable as a number.
+ */
+private val feePercentInputFilter =
+    InputFilter { source, start, end, dest, dstart, dend ->
+        val sep = feePercentSeparator
+        val format = feePercentFormat(sep)
+        val intermediateChars = "+-$sep"
+        val before = dest.subSequence(0, dstart).toString()
+        val after = dest.subSequence(dend, dest.length).toString()
+        val original = source.subSequence(start, end).toString()
+        var trimmed = original.normalizeSeparatorsTo(sep)
+
+        while (true) {
+            val result = before + trimmed + after
+            val ok =
+                when {
+                    !format.matches(result) -> false
+                    result.isEmpty() || result.last() in intermediateChars -> true
+                    else ->
+                        result
+                            .replace(sep, '.')
+                            .toBigDecimalOrNull()
+                            ?.let { it in FEE_PERCENT_RANGE } == true
+                }
+            if (ok) return@InputFilter if (trimmed == original) null else trimmed
+            if (trimmed.isEmpty()) return@InputFilter ""
+            trimmed = trimmed.dropLast(1)
+        }
+        @Suppress("UNREACHABLE_CODE")
+        null
     }
 
 // Trailing/leading icon buttons in picker rows. 48dp total with 12dp padding
@@ -548,11 +589,12 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         ctx: Context,
         initialSigned: BigDecimal?,
     ): PercentInput {
+        val sep = feePercentSeparator
         val editText =
             EditText(ctx).apply {
                 keyListener = DigitsKeyListener.getInstance(FEE_PERCENT_DIGITS)
-                filters = arrayOf(feePercentRangeFilter)
-                if (initialSigned != null) setText(initialSigned.toPlainString())
+                filters = arrayOf(feePercentInputFilter)
+                if (initialSigned != null) setText(initialSigned.toPlainString().replace('.', sep))
             }
         val suffix =
             TextView(ctx).apply { text = "%" }
@@ -679,7 +721,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             val parsed =
                 percentInput.editText.text
                     .toString()
-                    .normalizeDecimalSeparator()
+                    .replace(feePercentSeparator, '.')
                     .toBigDecimalOrNull() ?: BigDecimal.ZERO
             return FeeDraft(
                 name = nameInput.text.toString().trim(),

--- a/app/src/main/res/values-ar/strings_preference.xml
+++ b/app/src/main/res/values-ar/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">رسوم المعاملات الخارجية</string>
     <string name="fee_summary">إدارة رسوم الصرف والبنك/البطاقة والرسوم الخاصة بأزواج العملات</string>
     <string name="fee_manager_title">الرسوم</string>
-    <string name="fee_side_label">جانب الرسوم</string>
-    <string name="fee_side_original">الأصلي</string>
-    <string name="fee_side_converted">المحوَّل</string>
+    <string name="fee_side_label">نوع الرسوم</string>
+    <string name="fee_side_original">رسوم التحويل</string>
+    <string name="fee_side_converted">رسوم محوَّلة</string>
     <string name="fee_section_global_exchange">رسوم الصرف العامة</string>
     <string name="fee_section_global_bank">رسوم البنك/البطاقة العامة</string>
     <string name="fee_section_specific_pair">رسوم صرف زوج عملات محدد</string>

--- a/app/src/main/res/values-bg/strings_preference.xml
+++ b/app/src/main/res/values-bg/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Такса за чуждестранна транзакция</string>
     <string name="fee_summary">Управление на обменни, банкови/картови такси и такси за конкретни валутни двойки</string>
     <string name="fee_manager_title">Такси</string>
-    <string name="fee_side_label">Страна на таксата</string>
-    <string name="fee_side_original">Оригинална</string>
-    <string name="fee_side_converted">Конвертирана</string>
+    <string name="fee_side_label">Тип на таксата</string>
+    <string name="fee_side_original">Такса за конвертиране</string>
+    <string name="fee_side_converted">Конвертирана такса</string>
     <string name="fee_section_global_exchange">Глобална обменна такса</string>
     <string name="fee_section_global_bank">Глобална банкова/картова такса</string>
     <string name="fee_section_specific_pair">Такса за конкретна валутна двойка</string>

--- a/app/src/main/res/values-bn/strings_preference.xml
+++ b/app/src/main/res/values-bn/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">বিদেশি লেনদেন ফি</string>
     <string name="fee_summary">বিনিময়, ব্যাংক/কার্ড এবং নির্দিষ্ট জোড়ার ফি পরিচালনা করো</string>
     <string name="fee_manager_title">ফি</string>
-    <string name="fee_side_label">ফি এর দিক</string>
-    <string name="fee_side_original">মূল</string>
-    <string name="fee_side_converted">রূপান্তরিত</string>
+    <string name="fee_side_label">ফি এর ধরন</string>
+    <string name="fee_side_original">রূপান্তর ফি</string>
+    <string name="fee_side_converted">রূপান্তরিত ফি</string>
     <string name="fee_section_global_exchange">বিশ্বব্যাপী বিনিময় ফি</string>
     <string name="fee_section_global_bank">বিশ্বব্যাপী ব্যাংক/কার্ড ফি</string>
     <string name="fee_section_specific_pair">নির্দিষ্ট মুদ্রা জোড়ার বিনিময় ফি</string>

--- a/app/src/main/res/values-ca/strings_preference.xml
+++ b/app/src/main/res/values-ca/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Comissió per transacció amb l’estranger</string>
     <string name="fee_summary">Gestiona comissions de canvi, banc/targeta i específiques per parell</string>
     <string name="fee_manager_title">Comissions</string>
-    <string name="fee_side_label">Costat de la comissió</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Convertit</string>
+    <string name="fee_side_label">Tipus de comissió</string>
+    <string name="fee_side_original">Comissió de conversió</string>
+    <string name="fee_side_converted">Comissió convertida</string>
     <string name="fee_section_global_exchange">Comissió global de canvi</string>
     <string name="fee_section_global_bank">Comissió global de banc/targeta</string>
     <string name="fee_section_specific_pair">Comissió per parell de monedes específic</string>

--- a/app/src/main/res/values-cs/strings_preference.xml
+++ b/app/src/main/res/values-cs/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Poplatek za zahraniční transakci</string>
     <string name="fee_summary">Spravujte směnné, bankovní/kartové a specifické poplatky pro měnové páry</string>
     <string name="fee_manager_title">Poplatky</string>
-    <string name="fee_side_label">Strana poplatku</string>
-    <string name="fee_side_original">Původní</string>
-    <string name="fee_side_converted">Převedená</string>
+    <string name="fee_side_label">Typ poplatku</string>
+    <string name="fee_side_original">Poplatek za konverzi</string>
+    <string name="fee_side_converted">Převedený poplatek</string>
     <string name="fee_section_global_exchange">Globální směnný poplatek</string>
     <string name="fee_section_global_bank">Globální bankovní/kartový poplatek</string>
     <string name="fee_section_specific_pair">Poplatek pro konkrétní měnový pár</string>

--- a/app/src/main/res/values-da/strings_preference.xml
+++ b/app/src/main/res/values-da/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Gebyr for udenlandske transaktioner</string>
     <string name="fee_summary">Administrer veksel-, bank-/kortgebyrer og gebyrer for specifikke valutapar</string>
     <string name="fee_manager_title">Gebyrer</string>
-    <string name="fee_side_label">Gebyrside</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Konverteret</string>
+    <string name="fee_side_label">Gebyrtype</string>
+    <string name="fee_side_original">Konverteringsgebyr</string>
+    <string name="fee_side_converted">Konverteret gebyr</string>
     <string name="fee_section_global_exchange">Globalt vekselgebyr</string>
     <string name="fee_section_global_bank">Globalt bank-/kortgebyr</string>
     <string name="fee_section_specific_pair">Vekselgebyr for specifikt valutapar</string>

--- a/app/src/main/res/values-de/strings_preference.xml
+++ b/app/src/main/res/values-de/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Fremdwährungsgebühr</string>
     <string name="fee_summary">Wechsel-, Bank-/Karten- und paarspezifische Gebühren verwalten</string>
     <string name="fee_manager_title">Gebühren</string>
-    <string name="fee_side_label">Gebührenseite</string>
-    <string name="fee_side_original">Ursprünglich</string>
-    <string name="fee_side_converted">Umgerechnet</string>
+    <string name="fee_side_label">Gebührentyp</string>
+    <string name="fee_side_original">Umrechnungsgebühr</string>
+    <string name="fee_side_converted">Umgerechnete Gebühr</string>
     <string name="fee_section_global_exchange">Globale Wechselgebühr</string>
     <string name="fee_section_global_bank">Globale Bank-/Kartengebühr</string>
     <string name="fee_section_specific_pair">Gebühr für spezifisches Währungspaar</string>

--- a/app/src/main/res/values-el/strings_preference.xml
+++ b/app/src/main/res/values-el/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Προμήθεια συναλλαγής εξωτερικού</string>
     <string name="fee_summary">Διαχείριση προμηθειών συναλλάγματος, τράπεζας/κάρτας και ανά ζεύγος νομισμάτων</string>
     <string name="fee_manager_title">Προμήθειες</string>
-    <string name="fee_side_label">Πλευρά προμήθειας</string>
-    <string name="fee_side_original">Αρχικό</string>
-    <string name="fee_side_converted">Μετατραπέν</string>
+    <string name="fee_side_label">Τύπος προμήθειας</string>
+    <string name="fee_side_original">Προμήθεια μετατροπής</string>
+    <string name="fee_side_converted">Μετατραπείσα προμήθεια</string>
     <string name="fee_section_global_exchange">Καθολική προμήθεια συναλλάγματος</string>
     <string name="fee_section_global_bank">Καθολική προμήθεια τράπεζας/κάρτας</string>
     <string name="fee_section_specific_pair">Προμήθεια συγκεκριμένου ζεύγους νομισμάτων</string>

--- a/app/src/main/res/values-eo/strings_preference.xml
+++ b/app/src/main/res/values-eo/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Eksterlanda transakcia kotizo</string>
     <string name="fee_summary">Administri interŝanĝajn, bankajn/kartajn kaj para-specifajn kotizojn</string>
     <string name="fee_manager_title">Kotizoj</string>
-    <string name="fee_side_label">Flanko de la kotizo</string>
-    <string name="fee_side_original">Originala</string>
-    <string name="fee_side_converted">Konvertita</string>
+    <string name="fee_side_label">Speco de kotizo</string>
+    <string name="fee_side_original">Konverta kotizo</string>
+    <string name="fee_side_converted">Konvertita kotizo</string>
     <string name="fee_section_global_exchange">Ĝenerala interŝanĝa kotizo</string>
     <string name="fee_section_global_bank">Ĝenerala banka/karta kotizo</string>
     <string name="fee_section_specific_pair">Kotizo por specifa valuta paro</string>

--- a/app/src/main/res/values-es/strings_preference.xml
+++ b/app/src/main/res/values-es/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Comisión por transacción extranjera</string>
     <string name="fee_summary">Administra comisiones de cambio, banco/tarjeta y específicas por par</string>
     <string name="fee_manager_title">Comisiones</string>
-    <string name="fee_side_label">Lado de la comisión</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Convertido</string>
+    <string name="fee_side_label">Tipo de comisión</string>
+    <string name="fee_side_original">Comisión de conversión</string>
+    <string name="fee_side_converted">Comisión convertida</string>
     <string name="fee_section_global_exchange">Comisión global de cambio</string>
     <string name="fee_section_global_bank">Comisión global de banco/tarjeta</string>
     <string name="fee_section_specific_pair">Comisión de cambio de par específico</string>

--- a/app/src/main/res/values-et/strings_preference.xml
+++ b/app/src/main/res/values-et/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Valuutavahetuse teenustasu</string>
     <string name="fee_summary">Halda vahetus-, panga-/kaarditasusid ja konkreetsete valuutapaaride tasusid</string>
     <string name="fee_manager_title">Teenustasud</string>
-    <string name="fee_side_label">Teenustasu pool</string>
-    <string name="fee_side_original">Algne</string>
-    <string name="fee_side_converted">Konverteeritud</string>
+    <string name="fee_side_label">Teenustasu tüüp</string>
+    <string name="fee_side_original">Konverteerimistasu</string>
+    <string name="fee_side_converted">Konverteeritud tasu</string>
     <string name="fee_section_global_exchange">Üldine vahetustasu</string>
     <string name="fee_section_global_bank">Üldine panga-/kaarditasu</string>
     <string name="fee_section_specific_pair">Konkreetse valuutapaari vahetustasu</string>

--- a/app/src/main/res/values-fa/strings_preference.xml
+++ b/app/src/main/res/values-fa/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">کارمزد تراکنش‌های خارجی</string>
     <string name="fee_summary">مدیریت کارمزدهای تبدیل، بانک/کارت و جفت‌ارزهای خاص</string>
     <string name="fee_manager_title">کارمزدها</string>
-    <string name="fee_side_label">سمت کارمزد</string>
-    <string name="fee_side_original">اصلی</string>
-    <string name="fee_side_converted">تبدیل‌شده</string>
+    <string name="fee_side_label">نوع کارمزد</string>
+    <string name="fee_side_original">کارمزد تبدیل</string>
+    <string name="fee_side_converted">کارمزد تبدیل‌شده</string>
     <string name="fee_section_global_exchange">کارمزد کلی تبدیل</string>
     <string name="fee_section_global_bank">کارمزد کلی بانک/کارت</string>
     <string name="fee_section_specific_pair">کارمزد تبدیل جفت‌ارز خاص</string>

--- a/app/src/main/res/values-fr/strings_preference.xml
+++ b/app/src/main/res/values-fr/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Frais de transaction à l\'étranger</string>
     <string name="fee_summary">Gérer les frais de change, de banque/carte et spécifiques à une paire</string>
     <string name="fee_manager_title">Frais</string>
-    <string name="fee_side_label">Côté des frais</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Converti</string>
+    <string name="fee_side_label">Type de frais</string>
+    <string name="fee_side_original">Frais de conversion</string>
+    <string name="fee_side_converted">Frais convertis</string>
     <string name="fee_section_global_exchange">Frais de change globaux</string>
     <string name="fee_section_global_bank">Frais bancaires/de carte globaux</string>
     <string name="fee_section_specific_pair">Frais de change pour une paire spécifique</string>

--- a/app/src/main/res/values-hr/strings_preference.xml
+++ b/app/src/main/res/values-hr/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Provizija za inozemne transakcije</string>
     <string name="fee_summary">Upravljanje mjenjačkim, bankovnim/kartičnim provizijama i onima za pojedine parove</string>
     <string name="fee_manager_title">Provizije</string>
-    <string name="fee_side_label">Strana provizije</string>
-    <string name="fee_side_original">Izvorna</string>
-    <string name="fee_side_converted">Preračunata</string>
+    <string name="fee_side_label">Vrsta naknade</string>
+    <string name="fee_side_original">Naknada za konverziju</string>
+    <string name="fee_side_converted">Preračunata naknada</string>
     <string name="fee_section_global_exchange">Globalna mjenjačka provizija</string>
     <string name="fee_section_global_bank">Globalna bankovna/kartična provizija</string>
     <string name="fee_section_specific_pair">Provizija za određeni valutni par</string>

--- a/app/src/main/res/values-hu/strings_preference.xml
+++ b/app/src/main/res/values-hu/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Devizatranzakciós díj</string>
     <string name="fee_summary">Váltási, banki/kártya- és pénznempár-specifikus díjak kezelése</string>
     <string name="fee_manager_title">Díjak</string>
-    <string name="fee_side_label">Díj oldala</string>
-    <string name="fee_side_original">Eredeti</string>
-    <string name="fee_side_converted">Átváltott</string>
+    <string name="fee_side_label">Díj típusa</string>
+    <string name="fee_side_original">Átváltási díj</string>
+    <string name="fee_side_converted">Átváltott díj</string>
     <string name="fee_section_global_exchange">Globális váltási díj</string>
     <string name="fee_section_global_bank">Globális banki/kártyadíj</string>
     <string name="fee_section_specific_pair">Adott pénznempár váltási díja</string>

--- a/app/src/main/res/values-in/strings_preference.xml
+++ b/app/src/main/res/values-in/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Biaya transaksi luar negeri</string>
     <string name="fee_summary">Kelola biaya penukaran, bank/kartu, dan biaya pasangan mata uang tertentu</string>
     <string name="fee_manager_title">Biaya</string>
-    <string name="fee_side_label">Sisi biaya</string>
-    <string name="fee_side_original">Asli</string>
-    <string name="fee_side_converted">Dikonversi</string>
+    <string name="fee_side_label">Jenis biaya</string>
+    <string name="fee_side_original">Biaya konversi</string>
+    <string name="fee_side_converted">Biaya dikonversi</string>
     <string name="fee_section_global_exchange">Biaya penukaran global</string>
     <string name="fee_section_global_bank">Biaya bank/kartu global</string>
     <string name="fee_section_specific_pair">Biaya penukaran pasangan mata uang tertentu</string>

--- a/app/src/main/res/values-is/strings_preference.xml
+++ b/app/src/main/res/values-is/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Gjaldeyrisviðskiptagjald</string>
     <string name="fee_summary">Umsjón með skipti-, banka-/kortagjöldum og gjöldum fyrir tiltekin gjaldmiðlapör</string>
     <string name="fee_manager_title">Gjöld</string>
-    <string name="fee_side_label">Hlið gjalds</string>
-    <string name="fee_side_original">Upprunalegt</string>
-    <string name="fee_side_converted">Umreiknað</string>
+    <string name="fee_side_label">Tegund gjalds</string>
+    <string name="fee_side_original">Umbreytingargjald</string>
+    <string name="fee_side_converted">Umreiknað gjald</string>
     <string name="fee_section_global_exchange">Almennt skiptigjald</string>
     <string name="fee_section_global_bank">Almennt banka-/kortagjald</string>
     <string name="fee_section_specific_pair">Skiptigjald fyrir tiltekið gjaldmiðlapar</string>

--- a/app/src/main/res/values-it/strings_preference.xml
+++ b/app/src/main/res/values-it/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Commissione per transazioni estere</string>
     <string name="fee_summary">Gestisci commissioni di cambio, banca/carta e specifiche per coppia</string>
     <string name="fee_manager_title">Commissioni</string>
-    <string name="fee_side_label">Lato della commissione</string>
-    <string name="fee_side_original">Originale</string>
-    <string name="fee_side_converted">Convertito</string>
+    <string name="fee_side_label">Tipo di commissione</string>
+    <string name="fee_side_original">Commissione di conversione</string>
+    <string name="fee_side_converted">Commissione convertita</string>
     <string name="fee_section_global_exchange">Commissione di cambio globale</string>
     <string name="fee_section_global_bank">Commissione banca/carta globale</string>
     <string name="fee_section_specific_pair">Commissione per coppia di valute specifica</string>

--- a/app/src/main/res/values-iw/strings_preference.xml
+++ b/app/src/main/res/values-iw/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">עמלת עסקה במטבע זר</string>
     <string name="fee_summary">ניהול עמלות המרה, בנק/כרטיס ועמלות לזוגות מטבעות ספציפיים</string>
     <string name="fee_manager_title">עמלות</string>
-    <string name="fee_side_label">צד העמלה</string>
-    <string name="fee_side_original">מקורי</string>
-    <string name="fee_side_converted">מומר</string>
+    <string name="fee_side_label">סוג העמלה</string>
+    <string name="fee_side_original">דמי המרה</string>
+    <string name="fee_side_converted">עמלה מומרת</string>
     <string name="fee_section_global_exchange">עמלת המרה גלובלית</string>
     <string name="fee_section_global_bank">עמלת בנק/כרטיס גלובלית</string>
     <string name="fee_section_specific_pair">עמלת המרה לזוג מטבעות ספציפי</string>

--- a/app/src/main/res/values-ml/strings_preference.xml
+++ b/app/src/main/res/values-ml/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">വിദേശ ഇടപാട് ഫീസ്</string>
     <string name="fee_summary">വിനിമയ, ബാങ്ക്/കാർഡ്, കറൻസി ജോഡി അടിസ്ഥാനത്തിലുള്ള ഫീസുകൾ കൈകാര്യം ചെയ്യുക</string>
     <string name="fee_manager_title">ഫീസുകൾ</string>
-    <string name="fee_side_label">ഫീസ് വശം</string>
-    <string name="fee_side_original">യഥാർത്ഥം</string>
-    <string name="fee_side_converted">പരിവർത്തിതം</string>
+    <string name="fee_side_label">ഫീസിന്റെ തരം</string>
+    <string name="fee_side_original">പരിവർത്തന ഫീസ്</string>
+    <string name="fee_side_converted">പരിവർത്തിത ഫീസ്</string>
     <string name="fee_section_global_exchange">ആഗോള വിനിമയ ഫീസ്</string>
     <string name="fee_section_global_bank">ആഗോള ബാങ്ക്/കാർഡ് ഫീസ്</string>
     <string name="fee_section_specific_pair">നിർദ്ദിഷ്ട കറൻസി ജോഡിയുടെ വിനിമയ ഫീസ്</string>

--- a/app/src/main/res/values-nb/strings_preference.xml
+++ b/app/src/main/res/values-nb/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Valutagebyr</string>
     <string name="fee_summary">Administrer veksel-, bank-/kortgebyrer og gebyrer for spesifikke valutapar</string>
     <string name="fee_manager_title">Gebyrer</string>
-    <string name="fee_side_label">Gebyrside</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Konvertert</string>
+    <string name="fee_side_label">Gebyrtype</string>
+    <string name="fee_side_original">Konverteringsgebyr</string>
+    <string name="fee_side_converted">Konvertert gebyr</string>
     <string name="fee_section_global_exchange">Globalt vekslingsgebyr</string>
     <string name="fee_section_global_bank">Globalt bank-/kortgebyr</string>
     <string name="fee_section_specific_pair">Vekslingsgebyr for spesifikt valutapar</string>

--- a/app/src/main/res/values-nl/strings_preference.xml
+++ b/app/src/main/res/values-nl/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Buitenlandse transactiekosten</string>
     <string name="fee_summary">Beheer wissel-, bank-/kaartkosten en kosten voor specifieke valutaparen</string>
     <string name="fee_manager_title">Kosten</string>
-    <string name="fee_side_label">Kant van de kosten</string>
-    <string name="fee_side_original">Origineel</string>
-    <string name="fee_side_converted">Geconverteerd</string>
+    <string name="fee_side_label">Type kosten</string>
+    <string name="fee_side_original">Conversiekosten</string>
+    <string name="fee_side_converted">Geconverteerde kosten</string>
     <string name="fee_section_global_exchange">Globale wisselkosten</string>
     <string name="fee_section_global_bank">Globale bank-/kaartkosten</string>
     <string name="fee_section_specific_pair">Wisselkosten voor specifiek valutapaar</string>

--- a/app/src/main/res/values-pl/strings_preference.xml
+++ b/app/src/main/res/values-pl/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Opłata za transakcję zagraniczną</string>
     <string name="fee_summary">Zarządzaj opłatami wymiany, bankowymi/kartowymi oraz specyficznymi dla par walut</string>
     <string name="fee_manager_title">Opłaty</string>
-    <string name="fee_side_label">Strona opłaty</string>
-    <string name="fee_side_original">Oryginalna</string>
-    <string name="fee_side_converted">Przeliczona</string>
+    <string name="fee_side_label">Typ opłaty</string>
+    <string name="fee_side_original">Opłata za przewalutowanie</string>
+    <string name="fee_side_converted">Przeliczona opłata</string>
     <string name="fee_section_global_exchange">Globalna opłata za wymianę</string>
     <string name="fee_section_global_bank">Globalna opłata bankowa/kartowa</string>
     <string name="fee_section_specific_pair">Opłata za wymianę dla określonej pary walut</string>

--- a/app/src/main/res/values-pt-rBR/strings_preference.xml
+++ b/app/src/main/res/values-pt-rBR/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Taxa de transação estrangeira</string>
     <string name="fee_summary">Gerencie taxas de câmbio, banco/cartão e específicas por par de moedas</string>
     <string name="fee_manager_title">Taxas</string>
-    <string name="fee_side_label">Lado da taxa</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Convertido</string>
+    <string name="fee_side_label">Tipo de taxa</string>
+    <string name="fee_side_original">Taxa de conversão</string>
+    <string name="fee_side_converted">Taxa convertida</string>
     <string name="fee_section_global_exchange">Taxa global de câmbio</string>
     <string name="fee_section_global_bank">Taxa global de banco/cartão</string>
     <string name="fee_section_specific_pair">Taxa de câmbio para par específico</string>

--- a/app/src/main/res/values-ru/strings_preference.xml
+++ b/app/src/main/res/values-ru/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Комиссия за международный перевод</string>
     <string name="fee_summary">Управление комиссиями обмена, банка/карты и по конкретным парам валют</string>
     <string name="fee_manager_title">Комиссии</string>
-    <string name="fee_side_label">Сторона комиссии</string>
-    <string name="fee_side_original">Исходная</string>
-    <string name="fee_side_converted">Конвертированная</string>
+    <string name="fee_side_label">Тип комиссии</string>
+    <string name="fee_side_original">Комиссия за конвертацию</string>
+    <string name="fee_side_converted">Конвертированная комиссия</string>
     <string name="fee_section_global_exchange">Общая комиссия за обмен</string>
     <string name="fee_section_global_bank">Общая комиссия банка/карты</string>
     <string name="fee_section_specific_pair">Комиссия за обмен конкретной пары валют</string>

--- a/app/src/main/res/values-sv/strings_preference.xml
+++ b/app/src/main/res/values-sv/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Utländsk transaktionsavgift</string>
     <string name="fee_summary">Hantera växlings-, bank-/kortavgifter och avgifter för specifika valutapar</string>
     <string name="fee_manager_title">Avgifter</string>
-    <string name="fee_side_label">Avgiftssida</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Konverterad</string>
+    <string name="fee_side_label">Avgiftstyp</string>
+    <string name="fee_side_original">Konverteringsavgift</string>
+    <string name="fee_side_converted">Konverterad avgift</string>
     <string name="fee_section_global_exchange">Global växlingsavgift</string>
     <string name="fee_section_global_bank">Global bank-/kortavgift</string>
     <string name="fee_section_specific_pair">Växlingsavgift för specifikt valutapar</string>

--- a/app/src/main/res/values-tr/strings_preference.xml
+++ b/app/src/main/res/values-tr/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Döviz işlem ücreti</string>
     <string name="fee_summary">Kur, banka/kart ve belirli para birimi çiftlerine özel ücretleri yönet</string>
     <string name="fee_manager_title">Ücretler</string>
-    <string name="fee_side_label">Ücret tarafı</string>
-    <string name="fee_side_original">Orijinal</string>
-    <string name="fee_side_converted">Dönüştürülmüş</string>
+    <string name="fee_side_label">Ücret türü</string>
+    <string name="fee_side_original">Dönüşüm ücreti</string>
+    <string name="fee_side_converted">Dönüştürülmüş ücret</string>
     <string name="fee_section_global_exchange">Genel kur ücreti</string>
     <string name="fee_section_global_bank">Genel banka/kart ücreti</string>
     <string name="fee_section_specific_pair">Belirli para birimi çifti için kur ücreti</string>

--- a/app/src/main/res/values-uk/strings_preference.xml
+++ b/app/src/main/res/values-uk/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Комісія за міжнародні транзакції</string>
     <string name="fee_summary">Керуйте комісіями обміну, банку/картки та специфічними для пар валют</string>
     <string name="fee_manager_title">Комісії</string>
-    <string name="fee_side_label">Сторона комісії</string>
-    <string name="fee_side_original">Вихідна</string>
-    <string name="fee_side_converted">Конвертована</string>
+    <string name="fee_side_label">Тип комісії</string>
+    <string name="fee_side_original">Комісія за конвертацію</string>
+    <string name="fee_side_converted">Конвертована комісія</string>
     <string name="fee_section_global_exchange">Глобальна комісія за обмін</string>
     <string name="fee_section_global_bank">Глобальна комісія банку/картки</string>
     <string name="fee_section_specific_pair">Комісія за обмін конкретної пари валют</string>

--- a/app/src/main/res/values-vi/strings_preference.xml
+++ b/app/src/main/res/values-vi/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">Phí giao dịch nước ngoài</string>
     <string name="fee_summary">Quản lý phí chuyển đổi, ngân hàng/thẻ và phí cho cặp tiền tệ cụ thể</string>
     <string name="fee_manager_title">Phí</string>
-    <string name="fee_side_label">Bên tính phí</string>
-    <string name="fee_side_original">Gốc</string>
-    <string name="fee_side_converted">Đã chuyển đổi</string>
+    <string name="fee_side_label">Loại phí</string>
+    <string name="fee_side_original">Phí chuyển đổi</string>
+    <string name="fee_side_converted">Phí đã chuyển đổi</string>
     <string name="fee_section_global_exchange">Phí chuyển đổi chung</string>
     <string name="fee_section_global_bank">Phí ngân hàng/thẻ chung</string>
     <string name="fee_section_specific_pair">Phí chuyển đổi cho cặp tiền tệ cụ thể</string>

--- a/app/src/main/res/values-zh-rCN/strings_preference.xml
+++ b/app/src/main/res/values-zh-rCN/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">外汇交易手续费</string>
     <string name="fee_summary">管理汇兑、银行/银行卡以及特定货币对的手续费</string>
     <string name="fee_manager_title">手续费</string>
-    <string name="fee_side_label">手续费一侧</string>
-    <string name="fee_side_original">原始</string>
-    <string name="fee_side_converted">已换算</string>
+    <string name="fee_side_label">手续费类型</string>
+    <string name="fee_side_original">换算手续费</string>
+    <string name="fee_side_converted">已换算手续费</string>
     <string name="fee_section_global_exchange">全局汇兑手续费</string>
     <string name="fee_section_global_bank">全局银行/银行卡手续费</string>
     <string name="fee_section_specific_pair">特定货币对汇兑手续费</string>

--- a/app/src/main/res/values-zh-rTW/strings_preference.xml
+++ b/app/src/main/res/values-zh-rTW/strings_preference.xml
@@ -6,9 +6,9 @@
     <string name="fee_title">外匯手續費</string>
     <string name="fee_summary">管理匯兌、銀行/信用卡以及特定貨幣對的手續費</string>
     <string name="fee_manager_title">手續費</string>
-    <string name="fee_side_label">手續費一側</string>
-    <string name="fee_side_original">原始</string>
-    <string name="fee_side_converted">已換算</string>
+    <string name="fee_side_label">手續費類型</string>
+    <string name="fee_side_original">換算手續費</string>
+    <string name="fee_side_converted">已換算手續費</string>
     <string name="fee_section_global_exchange">全域匯兌手續費</string>
     <string name="fee_section_global_bank">全域銀行/信用卡手續費</string>
     <string name="fee_section_specific_pair">特定貨幣對匯兌手續費</string>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -8,9 +8,9 @@
     <string name="fee_summary">Manage exchange, bank/card, and pair-specific fees</string>
     <!-- fee manager -->
     <string name="fee_manager_title">Fees</string>
-    <string name="fee_side_label">Fee side</string>
-    <string name="fee_side_original">Original</string>
-    <string name="fee_side_converted">Converted</string>
+    <string name="fee_side_label">Fee type</string>
+    <string name="fee_side_original">Conversion fee</string>
+    <string name="fee_side_converted">Converted fee</string>
     <string name="fee_section_global_exchange">Global exchange fee</string>
     <string name="fee_section_global_bank">Global bank/card fee</string>
     <string name="fee_section_specific_pair">Specific currency exchange fee</string>

--- a/app/src/test/kotlin/com/eliormachlev/currencix/model/FeeCalculatorTest.kt
+++ b/app/src/test/kotlin/com/eliormachlev/currencix/model/FeeCalculatorTest.kt
@@ -185,6 +185,23 @@ class FeeCalculatorTest {
     }
 
     @Test
+    fun `mixed active and inactive fees keep only the active ones`() {
+        val fees =
+            listOf(
+                globalExchange("on", "2"),
+                globalExchange("off", "5", isActive = false),
+                pair("pOn", "3", from = "USD", to = "EUR"),
+                pair("pOff", "4", from = "USD", to = "EUR", isActive = false),
+            )
+        val applicable = FeeCalculator.applicableFees(fees, Currency.USD, Currency.EUR)
+        assertEquals(2, applicable.size)
+        assertTrue(applicable.any { it.id == "on" })
+        assertTrue(applicable.any { it.id == "pOn" })
+        // 1.02 * 1.03 = 1.0506 — off / pOff must not participate
+        near("1.0506", combined(fees, Currency.USD, Currency.EUR))
+    }
+
+    @Test
     fun `active picker selects one of several global exchange fees`() {
         val fees =
             listOf(


### PR DESCRIPTION
## Summary
- Split the global fee picker's tap semantics: **row-tap opens edit**, **radio-tap selects the active fee**.
- Removed the trailing pencil icon (now redundant with the row-wide edit affordance).
- Inactive fees render in a muted opaque colour so the existing "Inactive" text marker is reinforced visually.

## Accessibility (WCAG 2.1 AA)
- **1.4.1 Use of colour**: greying is paired with the "Inactive" text marker, so state is never colour-only. Uses `?attr/colorOnSurfaceVariant` (opaque, AA against surface on light/dark/OLED) — no alpha shortcut, per the accessibility statement.
- **2.5.5 Target size**: radio gets `minWidth=minHeight=48dp` and is its own clickable/focusable node.
- **3.3 Labels / Instructions**: the row's `ACTION_CLICK` accessibility label is set to "Edit" via `ViewCompat.replaceAccessibilityAction`, so TalkBack announces "double-tap to edit" instead of the generic "activate".

## Refactor notes
- Hoisted `Context.resolveThemeColor(attr)` to a new `util/ThemeUtils.kt` (was a private duplicate in `ParenButton.kt`).
- `choiceExplainerRow` gains optional `textColor` and `clickActionLabel` params; existing callers unchanged.

## Test plan
- [ ] Open **Settings → Fees → Global exchange** (or Bank/Card). Tap the row on an inactive entry → editor opens; tap its radio → active fee changes.
- [ ] Confirm inactive rows render greyed with "Inactive" marker still visible; active rows unchanged.
- [ ] TalkBack: navigate a picker row — announces title + description + "double-tap to edit"; navigate radio — announces "radio button, checked/not checked, double-tap to activate".
- [ ] Font scale 200% — row + radio remain tappable, no clipping.
- [ ] Light / dark / OLED themes — muted text passes contrast at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)