### PR TITLE
feat(fees): split fee amount from cost-with-fee + cart module refactor

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CartCsv.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CartCsv.kt
@@ -26,18 +26,18 @@ fun CartSnapshot.toCsv(
         append(csvRow("", ""))
         append(csvRow("Item", "Expression", "Value (${baseCurrency.iso4217Alpha()})"))
         evaluatedItems.forEach { (item, value) ->
-            append(csvRow(item.name, item.expression, value.toCartExportString()))
+            append(csvRow(item.name, item.expression, value.toCartDisplayString()))
         }
         append(csvRow("", "", ""))
-        append(csvRow("Subtotal", "", subtotal.toCartExportString()))
+        append(csvRow("Subtotal", "", subtotal.toCartDisplayString()))
         if (isConverting) {
-            append(csvRow("Converted (${destinationCurrency.iso4217Alpha()})", "", convertedSubtotal.toCartExportString()))
+            append(csvRow("Converted (${destinationCurrency.iso4217Alpha()})", "", convertedSubtotal.toCartDisplayString()))
         }
         val combinedStack = sideStacks.combined
         if (!combinedStack.isNeutralFeeStack()) {
             append(csvRow("Fees (${combinedStack.feePercentDelta().toPlainString()}%)", "", ""))
         }
-        append(csvRow("Total (${destinationCurrency.iso4217Alpha()})", "", total.toCartExportString()))
+        append(csvRow("Total (${destinationCurrency.iso4217Alpha()})", "", total.toCartDisplayString()))
     }
 
 private fun csvRow(vararg cells: String): String =

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CartExport.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CartExport.kt
@@ -1,7 +1,6 @@
 package com.eliormachlev.currencix.util
 
 import com.eliormachlev.currencix.viewmodel.cart.CartSnapshot
-import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -37,6 +36,3 @@ fun CartSnapshot.cartExportMeta(generatedAt: LocalDateTime): List<Pair<CartExpor
         ratesDate?.let { add(CartExportField.RATES_DATE to it.toString()) }
         add(CartExportField.EXPORTED_AT to generatedAt.format(CART_EXPORT_TIMESTAMP_FORMAT))
     }
-
-/** Rounded, plain-string form of a monetary value at [CART_EXPORT_DISPLAY_SCALE]. */
-fun BigDecimal.toCartExportString(): String = roundForDisplay(CART_EXPORT_DISPLAY_SCALE).toPlainString()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CartFormatting.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CartFormatting.kt
@@ -1,0 +1,36 @@
+package com.eliormachlev.currencix.util
+
+import android.content.Context
+import com.eliormachlev.currencix.model.Currency
+import java.math.BigDecimal
+
+// Shared display helpers used by every cart surface (footer view binding,
+// share text, PDF, CSV). The scale is aliased onto [CART_EXPORT_DISPLAY_SCALE]
+// so a change to the money-facing precision only needs one edit.
+
+/** Rounded, plain-string form of a monetary value at the cart's display scale. */
+fun BigDecimal.toCartDisplayString(): String = roundForDisplay(CART_EXPORT_DISPLAY_SCALE).toPlainString()
+
+/**
+ * Percentage delta of a fee stack ("2.50" for a 1.025 stack), pinned to the
+ * cart's display scale. Shared by the on-screen fee line and the "Fees:" row
+ * in shared text so both surfaces render identically.
+ */
+fun BigDecimal.toCartFeePercentDisplay(): String = feePercentDelta(CART_EXPORT_DISPLAY_SCALE).toPlainString()
+
+/**
+ * Locale-aware amount + currency marker in the shape the cart's footer rows
+ * show ("1,234.56 $"). Null value collapses to zero — cart callers routinely
+ * pass a still-loading LiveData value.
+ */
+fun Context.formatCartAmount(
+    value: BigDecimal?,
+    currency: Currency?,
+): String {
+    val amount =
+        (value ?: BigDecimal.ZERO)
+            .roundForDisplay(CART_EXPORT_DISPLAY_SCALE)
+            .toHumanReadableNumber(this, decimalPlaces = CART_EXPORT_DISPLAY_SCALE)
+    val marker = currency?.symbolOrIso()
+    return if (marker.isNullOrEmpty()) amount else "$amount $marker"
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CartPdf.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CartPdf.kt
@@ -73,18 +73,18 @@ private fun CartSnapshot.drawSnapshot(
     evaluatedItems.forEach { (item, value) ->
         val label = item.name.ifBlank { item.expression }
         canvas.drawText(label, PAGE_MARGIN_PT, y, bodyPaint)
-        canvas.drawText(value.toCartExportString(), rightX, y, bodyRight)
+        canvas.drawText(value.toCartDisplayString(), rightX, y, bodyRight)
         y += LINE_HEIGHT_PT
     }
 
     y += SECTION_GAP_PT
     canvas.drawText("Subtotal", PAGE_MARGIN_PT, y, headerPaint.apply { textAlign = Paint.Align.LEFT })
-    canvas.drawText("${subtotal.toCartExportString()} ${baseCurrency.iso4217Alpha()}", rightX, y, bodyRight)
+    canvas.drawText("${subtotal.toCartDisplayString()} ${baseCurrency.iso4217Alpha()}", rightX, y, bodyRight)
     y += LINE_HEIGHT_PT
 
     if (isConverting) {
         canvas.drawText("Converted", PAGE_MARGIN_PT, y, bodyPaint)
-        canvas.drawText("${convertedSubtotal.toCartExportString()} ${destinationCurrency.iso4217Alpha()}", rightX, y, bodyRight)
+        canvas.drawText("${convertedSubtotal.toCartDisplayString()} ${destinationCurrency.iso4217Alpha()}", rightX, y, bodyRight)
         y += LINE_HEIGHT_PT
     }
     val combinedStack = sideStacks.combined
@@ -97,7 +97,7 @@ private fun CartSnapshot.drawSnapshot(
     y += SECTION_GAP_PT
     canvas.drawText("Total", PAGE_MARGIN_PT, y, headerPaint.apply { textAlign = Paint.Align.LEFT })
     canvas.drawText(
-        "${total.toCartExportString()} ${destinationCurrency.iso4217Alpha()}",
+        "${total.toCartDisplayString()} ${destinationCurrency.iso4217Alpha()}",
         rightX,
         y,
         paint(BODY_TEXT_SIZE, bold = true).apply { textAlign = Paint.Align.RIGHT },

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/CartShareFile.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/CartShareFile.kt
@@ -4,9 +4,31 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.content.FileProvider
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private const val EXPORT_SUBDIR = "cart-exports"
 private const val AUTHORITY_SUFFIX = ".fileprovider"
+
+// Filename-safe timestamp used as the JSON-export suffix and as the fallback
+// name for share artefacts (CSV/PDF) when a cart has no user name. Stateless
+// formatter, no need to instantiate per call.
+private val FILENAME_TIMESTAMP: SimpleDateFormat = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US)
+
+fun filenameTimestampNow(): String = FILENAME_TIMESTAMP.format(Date())
+
+// Chars that can trip up FileProvider / OSes when embedded in a filename.
+// Collapsed to a single underscore so a cart named "Café / July 2026" becomes
+// "Café_July_2026", not "Café___July_2026".
+private val FILENAME_UNSAFE = Regex("""[\\/:*?"<>|\p{Cntrl}]+""")
+private val FILENAME_WHITESPACE = Regex("""\s+""")
+
+fun String.sanitizeForFilename(): String =
+    replace(FILENAME_UNSAFE, "_")
+        .replace(FILENAME_WHITESPACE, "_")
+        .trim('_', '.')
+        .ifBlank { "cart" }
 
 // Shared helper for cart share flows that produce a file (CSV, PDF, etc.).
 // Writes [bytes] into the FileProvider-mapped [EXPORT_SUBDIR] under cacheDir

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/MathUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/MathUtils.kt
@@ -22,6 +22,12 @@ fun calculateDifference(
 // predicate instead of open-coding `compareTo(BigDecimal.ONE) == 0`.
 fun BigDecimal.isNeutralFeeStack(): Boolean = compareTo(BigDecimal.ONE) == 0
 
+// Additive delta of a multiplicative fee stack: `stack - 1`. Signed —
+// positive for a markup, negative for a discount. `base * delta` gives the
+// fee amount itself; used by both the money-facing renderers and the
+// percent-facing [feePercentDelta].
+fun BigDecimal.feeStackDelta(): BigDecimal = subtract(BigDecimal.ONE)
+
 // Convert a multiplicative fee stack (e.g. `1.025`) to its percentage delta
 // (e.g. `2.50`). Callers vary the rounding mode: HALF_EVEN for money-facing
 // totals (main, cart), HALF_UP for user-visible "fees applied" labels that
@@ -30,7 +36,7 @@ fun BigDecimal.feePercentDelta(
     scale: Int = 2,
     roundingMode: RoundingMode = RoundingMode.HALF_EVEN,
 ): BigDecimal =
-    subtract(BigDecimal.ONE)
+    feeStackDelta()
         .multiply(PERCENT_MULTIPLIER, MathContext.DECIMAL128)
         .setScale(scale, roundingMode)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -3,7 +3,6 @@ package com.eliormachlev.currencix.view.cart
 import android.content.Context
 import android.content.Intent
 import android.graphics.Rect
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -16,8 +15,6 @@ import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatButton
 import androidx.compose.runtime.mutableStateListOf
@@ -37,7 +34,6 @@ import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.repository.CartExporter
-import com.eliormachlev.currencix.repository.CartFileResult
 import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CalculatorKeyListener
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
@@ -45,12 +41,14 @@ import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
 import com.eliormachlev.currencix.util.buildCartShareChooser
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.feeStackDelta
+import com.eliormachlev.currencix.util.filenameTimestampNow
 import com.eliormachlev.currencix.util.formatCartAmount
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.paddedDialogContainer
 import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
+import com.eliormachlev.currencix.util.sanitizeForFilename
 import com.eliormachlev.currencix.util.toCartDisplayString
 import com.eliormachlev.currencix.util.toCartFeePercentDisplay
 import com.eliormachlev.currencix.util.toCsv
@@ -68,37 +66,11 @@ import com.eliormachlev.currencix.viewmodel.main.CalculatorInputState
 import com.google.android.material.button.MaterialButton
 import java.math.BigDecimal
 import java.math.MathContext
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-
-// Suffix used when SAF asks for a suggested filename.
-private const val EXPORT_FILE_MIME = "application/json"
-private const val EXPORT_FILE_EXT = ".json"
-
-// Filename-safe timestamp used both as the JSON-export suffix and as the
-// fallback name for share artefacts (CSV/PDF) when a cart has no user name.
-// Stateless formatter, no need to instantiate per call.
-private val FILENAME_TIMESTAMP: SimpleDateFormat = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US)
-
-private fun filenameTimestampNow(): String = FILENAME_TIMESTAMP.format(Date())
 
 private const val CSV_MIME = "text/csv"
 private const val CSV_EXT = ".csv"
 private const val PDF_MIME = "application/pdf"
 private const val PDF_EXT = ".pdf"
-
-// Chars that can trip up FileProvider / OSes when embedded in a filename.
-// Collapsed to a single underscore so a cart named "Café / July 2026" becomes
-// "Café_July_2026", not "Café___July_2026".
-private val FILENAME_UNSAFE = Regex("""[\\/:*?"<>|\p{Cntrl}]+""")
-private val FILENAME_WHITESPACE = Regex("""\s+""")
-
-private fun String.sanitizeForFilename(): String =
-    replace(FILENAME_UNSAFE, "_")
-        .replace(FILENAME_WHITESPACE, "_")
-        .trim('_', '.')
-        .ifBlank { "cart" }
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
 private const val KEYPAD_ANIM_MS = 180L
@@ -117,6 +89,7 @@ private const val KEYPAD_DRAG_DISMISS_FRACTION = 0.35f
 class CartActivity : BaseActivity() {
     private lateinit var viewModel: CartViewModel
     private lateinit var exporter: CartExporter
+    private lateinit var fileIo: CartFileIo
 
     private lateinit var itemsView: ComposeView
     private lateinit var subtotalLabel: TextView
@@ -191,9 +164,6 @@ class CartActivity : BaseActivity() {
         viewModel.keyboardType.map { CalculatorKeyListener.forKeyboardType(it) }
     }
 
-    private lateinit var exportLauncher: ActivityResultLauncher<String>
-    private lateinit var importLauncher: ActivityResultLauncher<Array<String>>
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_cart)
@@ -205,6 +175,14 @@ class CartActivity : BaseActivity() {
 
         this.viewModel = ViewModelProvider(this)[CartViewModel::class.java]
         this.exporter = CartExporter(this)
+        this.fileIo =
+            CartFileIo(
+                activity = this,
+                viewModel = viewModel,
+                exporter = exporter,
+                flushPendingCommits = ::flushPendingCommits,
+                snackbar = ::showSnackbar,
+            )
 
         this.itemsView = findViewById(R.id.cart_items)
         this.subtotalLabel = findViewById(R.id.cart_subtotal_value)
@@ -307,15 +285,6 @@ class CartActivity : BaseActivity() {
             true
         }
 
-        exportLauncher =
-            registerForActivityResult(
-                ActivityResultContracts.CreateDocument(EXPORT_FILE_MIME),
-            ) { uri -> uri?.let(::doExport) }
-        importLauncher =
-            registerForActivityResult(
-                ActivityResultContracts.OpenDocument(),
-            ) { uri -> uri?.let(::doImport) }
-
         observe()
     }
 
@@ -347,11 +316,11 @@ class CartActivity : BaseActivity() {
                 true
             }
             R.id.cart_export -> {
-                launchExport()
+                fileIo.launchExport()
                 true
             }
             R.id.cart_import -> {
-                launchImport()
+                fileIo.launchImport()
                 true
             }
             R.id.cart_clear -> {
@@ -718,54 +687,6 @@ class CartActivity : BaseActivity() {
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
         dialog.show()
-    }
-
-    private fun launchExport() {
-        flushPendingCommits()
-        val name =
-            viewModel
-                .getCurrentCart()
-                .value
-                ?.name
-                ?.ifBlank { null } ?: "cart"
-        exportLauncher.launch("$name-${filenameTimestampNow()}$EXPORT_FILE_EXT")
-    }
-
-    private fun launchImport() {
-        importLauncher.launch(arrayOf(EXPORT_FILE_MIME))
-    }
-
-    private fun doExport(uri: Uri) {
-        val cart = viewModel.getCurrentCart().value ?: return
-        // Copy so the exported file always has a real name, even if the
-        // user hasn't gone through Save-as yet.
-        val toExport =
-            cart.copy(
-                name = cart.name.orDefaultCartName(),
-                createdAt = System.currentTimeMillis(),
-            )
-        when (val res = exporter.export(uri, toExport)) {
-            is CartFileResult.Success -> showSnackbar(getString(R.string.cart_export_ok))
-            is CartFileResult.Failure ->
-                showSnackbar(
-                    getString(R.string.cart_export_error, res.message),
-                )
-            is CartFileResult.Loaded -> Unit
-        }
-    }
-
-    private fun doImport(uri: Uri) {
-        when (val res = exporter.import(uri)) {
-            is CartFileResult.Loaded -> {
-                viewModel.setCurrent(res.cart)
-                showSnackbar(getString(R.string.cart_import_ok))
-            }
-            is CartFileResult.Failure ->
-                showSnackbar(
-                    getString(R.string.cart_import_error, res.message),
-                )
-            is CartFileResult.Success -> Unit
-        }
     }
 
     private fun confirmClear() {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -46,6 +46,7 @@ import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
 import com.eliormachlev.currencix.util.buildCartShareChooser
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.feePercentDelta
+import com.eliormachlev.currencix.util.feeStackDelta
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.paddedDialogContainer
@@ -129,11 +130,17 @@ class CartActivity : BaseActivity() {
     private lateinit var subtotalExtra: View
     private lateinit var subtotalExtraLabel: TextView
     private lateinit var subtotalExtraValue: TextView
+    private lateinit var subtotalFee: View
+    private lateinit var subtotalFeeLabel: TextView
+    private lateinit var subtotalFeeValue: TextView
     private lateinit var feeLine: TextView
     private lateinit var totalLabel: TextView
     private lateinit var totalExtra: View
     private lateinit var totalExtraLabel: TextView
     private lateinit var totalExtraValue: TextView
+    private lateinit var totalFee: View
+    private lateinit var totalFeeLabel: TextView
+    private lateinit var totalFeeValue: TextView
     private lateinit var spinnerFrom: SearchableSpinner
     private lateinit var spinnerTo: SearchableSpinner
     private lateinit var swapButton: ImageButton
@@ -211,11 +218,17 @@ class CartActivity : BaseActivity() {
         this.subtotalExtra = findViewById(R.id.cart_subtotal_extra)
         this.subtotalExtraLabel = findViewById(R.id.cart_subtotal_extra_label)
         this.subtotalExtraValue = findViewById(R.id.cart_subtotal_extra_value)
+        this.subtotalFee = findViewById(R.id.cart_subtotal_fee)
+        this.subtotalFeeLabel = findViewById(R.id.cart_subtotal_fee_label)
+        this.subtotalFeeValue = findViewById(R.id.cart_subtotal_fee_value)
         this.feeLine = findViewById(R.id.cart_fee_line)
         this.totalLabel = findViewById(R.id.cart_total_value)
         this.totalExtra = findViewById(R.id.cart_total_extra)
         this.totalExtraLabel = findViewById(R.id.cart_total_extra_label)
         this.totalExtraValue = findViewById(R.id.cart_total_extra_value)
+        this.totalFee = findViewById(R.id.cart_total_fee)
+        this.totalFeeLabel = findViewById(R.id.cart_total_fee_label)
+        this.totalFeeValue = findViewById(R.id.cart_total_fee_value)
         this.spinnerFrom = findViewById(R.id.cart_spinner_from)
         this.spinnerTo = findViewById(R.id.cart_spinner_to)
         this.swapButton = findViewById(R.id.cart_swap)
@@ -432,36 +445,60 @@ class CartActivity : BaseActivity() {
     }
 
     /**
-     * Show the "other side" of each per-side fee so users can see both anchor
-     * values: ORIGINAL-side fees inflate the subtotal in the base currency
-     * ("True cost"); CONVERTED-side fees discount the total in the destination
-     * currency ("Original value"). Either or both rows may be visible.
+     * Show both anchor values for each per-side fee: the fee amount itself
+     * ("Conversion fee" / "Reduction fee") and the effective total-with-fee /
+     * pre-fee value ("Cost with fee" / "Value before fee"). Ordering matches
+     * the on-screen layout: fee then cost-with-fee on ORIGINAL; value-before-
+     * fee then reduction-fee on CONVERTED. Either or both blocks may hide.
      */
     private fun updateFeeExtras() {
         val stacks = viewModel.currentSideStacks()
         renderFeeExtraRow(
-            container = subtotalExtra,
-            labelView = subtotalExtraLabel,
-            valueView = subtotalExtraValue,
+            container = subtotalFee,
+            labelView = subtotalFeeLabel,
+            valueView = subtotalFeeValue,
             prefixRes = R.string.fee_true_cost_prefix,
             stack = stacks.original,
             base = viewModel.getSubtotal().value,
             currency = viewModel.getBaseCurrency().value,
+            mode = FeeRowMode.DELTA,
+        )
+        renderFeeExtraRow(
+            container = subtotalExtra,
+            labelView = subtotalExtraLabel,
+            valueView = subtotalExtraValue,
+            prefixRes = R.string.fee_cost_with_fee_prefix,
+            stack = stacks.original,
+            base = viewModel.getSubtotal().value,
+            currency = viewModel.getBaseCurrency().value,
+            mode = FeeRowMode.TOTAL,
         )
         renderFeeExtraRow(
             container = totalExtra,
             labelView = totalExtraLabel,
             valueView = totalExtraValue,
+            prefixRes = R.string.fee_value_before_fee_prefix,
+            stack = stacks.converted,
+            base = viewModel.getTotal().value,
+            currency = viewModel.getDestinationCurrency().value,
+            mode = FeeRowMode.TOTAL,
+        )
+        renderFeeExtraRow(
+            container = totalFee,
+            labelView = totalFeeLabel,
+            valueView = totalFeeValue,
             prefixRes = R.string.fee_original_value_prefix,
             stack = stacks.converted,
             base = viewModel.getTotal().value,
             currency = viewModel.getDestinationCurrency().value,
+            mode = FeeRowMode.DELTA,
         )
     }
 
-    // A "true cost" / "original value" row: hidden when the [stack] is
-    // trivial, otherwise `base * stack` rendered in [currency] with the
-    // per-side percent appended so users see both magnitude and rate.
+    // Hidden when the [stack] is trivial. TOTAL renders `base * stack` (the
+    // effective with-fee cost or pre-fee value); DELTA renders `|base *
+    // (stack - 1)|` (the fee magnitude — the percent tail already carries
+    // the sign so we avoid a double negative).
     private fun renderFeeExtraRow(
         container: View,
         labelView: TextView,
@@ -470,12 +507,19 @@ class CartActivity : BaseActivity() {
         stack: BigDecimal,
         base: BigDecimal?,
         currency: Currency?,
+        mode: FeeRowMode,
     ) {
         if (stack.isNeutralFeeStack()) {
             container.visibility = View.GONE
             return
         }
-        val adjusted = (base ?: BigDecimal.ZERO).multiply(stack, MathContext.DECIMAL128)
+        val multiplier =
+            when (mode) {
+                FeeRowMode.TOTAL -> stack
+                FeeRowMode.DELTA -> stack.feeStackDelta()
+            }
+        val raw = (base ?: BigDecimal.ZERO).multiply(multiplier, MathContext.DECIMAL128)
+        val adjusted = if (mode == FeeRowMode.DELTA) raw.abs() else raw
         labelView.text = stripLabelSeparator(getString(prefixRes))
         valueView.text =
             getString(
@@ -485,6 +529,8 @@ class CartActivity : BaseActivity() {
             )
         container.visibility = View.VISIBLE
     }
+
+    private enum class FeeRowMode { TOTAL, DELTA }
 
     // Existing prefix strings end with a locale-specific ": " / " : " / "：" for
     // inline use. When we're showing them as a standalone left-aligned label,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -39,22 +39,21 @@ import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.repository.CartExporter
 import com.eliormachlev.currencix.repository.CartFileResult
 import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
-import com.eliormachlev.currencix.util.CART_EXPORT_DISPLAY_SCALE
 import com.eliormachlev.currencix.util.CalculatorKeyListener
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
 import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
 import com.eliormachlev.currencix.util.buildCartShareChooser
 import com.eliormachlev.currencix.util.choiceExplainerRow
-import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.feeStackDelta
+import com.eliormachlev.currencix.util.formatCartAmount
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.paddedDialogContainer
 import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
-import com.eliormachlev.currencix.util.roundForDisplay
+import com.eliormachlev.currencix.util.toCartDisplayString
+import com.eliormachlev.currencix.util.toCartFeePercentDisplay
 import com.eliormachlev.currencix.util.toCsv
-import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.util.toPdfBytes
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.cart.compose.CartEmptyHint
@@ -72,12 +71,6 @@ import java.math.MathContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-
-// Decimal places for cart display; matches the main-screen convention where
-// "money-facing" values render to two places by default. Aliased onto the
-// shared export scale so on-screen numbers and exported artefacts always
-// round identically.
-private const val CART_DISPLAY_SCALE = CART_EXPORT_DISPLAY_SCALE
 
 // Suffix used when SAF asks for a suggested filename.
 private const val EXPORT_FILE_MIME = "application/json"
@@ -440,7 +433,7 @@ class CartActivity : BaseActivity() {
             feeLine.visibility = View.GONE
             return
         }
-        feeLine.text = getString(R.string.cart_fee_line, stacks.combined.toFeePercentDisplay())
+        feeLine.text = getString(R.string.cart_fee_line, stacks.combined.toCartFeePercentDisplay())
         feeLine.visibility = View.VISIBLE
     }
 
@@ -527,7 +520,7 @@ class CartActivity : BaseActivity() {
         valueView.text =
             when (mode) {
                 FeeRowMode.TOTAL -> amountText
-                FeeRowMode.DELTA -> getString(R.string.cart_fee_extra_value, amountText, stack.toFeePercentDisplay())
+                FeeRowMode.DELTA -> getString(R.string.cart_fee_extra_value, amountText, stack.toCartFeePercentDisplay())
             }
         container.visibility = View.VISIBLE
     }
@@ -542,27 +535,7 @@ class CartActivity : BaseActivity() {
     private fun formatAmount(
         value: BigDecimal?,
         currency: Currency?,
-    ): String {
-        val amount =
-            (value ?: BigDecimal.ZERO)
-                .cartScale()
-                .toHumanReadableNumber(this, decimalPlaces = CART_DISPLAY_SCALE)
-        val marker = currency?.symbolOrIso()
-        return if (marker.isNullOrEmpty()) amount else "$amount $marker"
-    }
-
-    // Round to the two-decimal "money" scale used across the cart UI. Extracted
-    // so display, share text, and fee-percent all pin to the same rounding.
-    private fun BigDecimal.cartScale(): BigDecimal = roundForDisplay(CART_DISPLAY_SCALE)
-
-    // Rounded, plain string in the cart's display scale — the form used
-    // wherever we drop a number into shared text (share sheet).
-    private fun BigDecimal.toCartDisplayString(): String = cartScale().toPlainString()
-
-    // Percentage delta of the fee stack ("2.50" for a 1.025 stack), pinned to
-    // the cart's display scale. Shared by the on-screen fee line and the
-    // "Fees:" row in shared text.
-    private fun BigDecimal.toFeePercentDisplay(): String = feePercentDelta(CART_DISPLAY_SCALE).toPlainString()
+    ): String = formatCartAmount(value, currency)
 
     // Fallback to the localised "My cart" name when the user hasn't given
     // the cart one. Shared by Save-as, Rename, and Export.
@@ -941,7 +914,7 @@ class CartActivity : BaseActivity() {
             }
             val combinedStack = snapshot.sideStacks.combined
             if (!combinedStack.isNeutralFeeStack()) {
-                appendLine(getString(R.string.cart_share_fees, combinedStack.toFeePercentDisplay()))
+                appendLine(getString(R.string.cart_share_fees, combinedStack.toCartFeePercentDisplay()))
             }
             append(getString(R.string.cart_share_total, snapshot.total.toCartDisplayString(), destIso))
         }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -1,38 +1,24 @@
 package com.eliormachlev.currencix.view.cart
 
-import android.content.Context
-import android.graphics.Rect
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
-import android.view.ViewConfiguration
-import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import android.widget.ImageButton
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.AppCompatButton
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.map
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
-import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.repository.CartExporter
-import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CalculatorKeyListener
-import com.eliormachlev.currencix.util.OPERATOR_REGEX
-import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
 import com.eliormachlev.currencix.util.hapticTap
-import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.cart.compose.CartEmptyHint
@@ -40,22 +26,7 @@ import com.eliormachlev.currencix.view.cart.compose.CartItemsList
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinner
 import com.eliormachlev.currencix.view.preference.PreferenceActivity
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
-import com.eliormachlev.currencix.viewmodel.main.CalculatorInputState
 import com.google.android.material.button.MaterialButton
-
-// Duration of the slide-in / slide-out animation for the cart keypad.
-private const val KEYPAD_ANIM_MS = 180L
-
-// Grace window on outside taps before closing the keypad: a tap that lands on
-// another row's expression must run through Compose's click handler first so
-// it can swap the active id — otherwise we'd close, then re-open with an
-// unwanted flicker.
-private const val OUTSIDE_TAP_DEBOUNCE_MS = 40L
-
-// Fraction of the keypad container's height a drag-down must clear before
-// release commits the dismissal. Below this we snap back — matches the
-// behaviour of Material bottom sheets.
-private const val KEYPAD_DRAG_DISMISS_FRACTION = 0.35f
 
 class CartActivity : BaseActivity() {
     private lateinit var viewModel: CartViewModel
@@ -64,6 +35,7 @@ class CartActivity : BaseActivity() {
     private lateinit var shareCoordinator: CartShareCoordinator
     private lateinit var saveLoadCoordinator: CartSaveLoadCoordinator
     private lateinit var footerBinding: CartFooterBinding
+    private lateinit var keypad: CartKeypadController
 
     private lateinit var itemsView: ComposeView
     private lateinit var spinnerFrom: SearchableSpinner
@@ -74,37 +46,6 @@ class CartActivity : BaseActivity() {
 
     // Cached haptic setting so per-tap handlers don't need to touch prefs.
     private var hapticEnabled = false
-
-    // Mirrors the keyboard-type preference so row-tap handlers decide
-    // between the in-app keypad and a system-IME dialog without a pref read.
-    private var currentKeyboardType: KeyboardType = KeyboardType.DEFAULT
-
-    // Slide-up keypad state — behaves like a soft IME. The keypad edits the
-    // row identified by [activeItemId]; taps route through
-    // [activeCalculatorState] and every state change is mirrored into
-    // [liveExpression], which the composable row observes for its display.
-    private lateinit var keypadContainer: ViewGroup
-    private lateinit var keypadRegular: View
-    private lateinit var keypadExtended: View
-    private lateinit var contentColumn: View
-    private var activeCalculatorState: CalculatorInputState? = null
-    private val activeItemId = MutableLiveData<String?>(null)
-    private val liveExpression = MutableLiveData("")
-    private var activeStateObserver: Observer<String?>? = null
-    private var activeParenObserver: Observer<Char>? = null
-    private var keypadBackCallback: OnBackPressedCallback? = null
-
-    // Rising-edge latch for the IME-visibility guard; see [installImeVisibilityGuard].
-    private var systemImeVisible = false
-
-    // Drag-to-dismiss state — only meaningful once ACTION_DOWN lands inside
-    // the keypad and the pointer travels far enough downward to cross
-    // [touchSlop]. [keypadDragStartY] is null when no candidate gesture is
-    // being tracked; [keypadDragActive] flips true once slop is crossed and
-    // the child buttons have been sent an ACTION_CANCEL.
-    private var keypadDragStartY: Float? = null
-    private var keypadDragActive = false
-    private val touchSlop: Int by lazy { ViewConfiguration.get(this).scaledTouchSlop }
 
     // Pending, un-debounced name edits from the composable rows. Flushed
     // synchronously by [flushPendingCommits] before any save/share/snapshot.
@@ -173,47 +114,47 @@ class CartActivity : BaseActivity() {
                 setContent { CartEmptyHint() }
             }
         this.addButton = findViewById(R.id.cart_add_item)
-        this.keypadContainer = findViewById(R.id.cart_keypad_container)
-        this.keypadRegular = findViewById(R.id.cart_keypad_regular)
-        this.keypadExtended = findViewById(R.id.cart_keypad_extended)
-        this.contentColumn = findViewById(R.id.cart_content)
-        installImeVisibilityGuard()
 
-        // Registered before the keypad callback so the keypad's (which is
-        // added second) wins when it's enabled. When the keypad is closed
-        // and there are unsaved edits, we prompt instead of finishing.
+        // Registered before the keypad controller's callback so the keypad's
+        // (added second) wins when enabled. When the keypad is closed and
+        // there are unsaved edits, we prompt instead of finishing.
         onBackPressedDispatcher.addCallback(
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() = saveLoadCoordinator.attemptClose()
             },
         )
-        keypadBackCallback =
-            object : OnBackPressedCallback(false) {
-                override fun handleOnBackPressed() = closeKeypad()
-            }.also { onBackPressedDispatcher.addCallback(this, it) }
+        this.keypad =
+            CartKeypadController(
+                activity = this,
+                itemsView = itemsView,
+                keyboardType = viewModel.keyboardType,
+                hapticEnabled = { hapticEnabled },
+                onExpressionCommit = ::commitExpression,
+                dispatchCancel = ::superDispatchTouchEvent,
+            )
         itemsView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         itemsView.setContent {
             CartItemsList(
                 itemsSource = itemsLive,
                 currencySource = currencyLive,
-                activeItemIdSource = activeItemId,
-                activeExpressionSource = liveExpression,
+                activeItemIdSource = keypad.activeItemId,
+                activeExpressionSource = keypad.liveExpression,
                 keyListenerSource = keyListenerLive,
                 onNameCommit = ::commitName,
                 onNamePending = { id, name -> pendingNames[id] = name },
                 onExpressionTap = { item ->
                     itemsView.hapticTap(hapticEnabled)
-                    openKeypadFor(item.id, item.expression)
+                    keypad.openKeypadFor(item.id, item.expression)
                 },
-                onExpressionChange = ::onInlineExpressionChanged,
+                onExpressionChange = keypad::onInlineExpressionChanged,
                 onTogglePin = { id ->
                     itemsView.hapticTap(hapticEnabled)
                     viewModel.togglePinned(id)
                 },
                 onDelete = { id ->
                     itemsView.hapticTap(hapticEnabled)
-                    if (activeItemId.value == id) closeKeypad()
+                    if (keypad.activeItemId.value == id) keypad.closeKeypad()
                     pendingNames.remove(id)
                     viewModel.removeItem(id)
                 },
@@ -227,9 +168,9 @@ class CartActivity : BaseActivity() {
                     // Commit the current edit and close before the gesture takes
                     // over the visible list.
                     itemsView.hapticTap(hapticEnabled)
-                    closeKeypad()
+                    keypad.closeKeypad()
                 },
-                onBackgroundTap = ::dismissKeyboards,
+                onBackgroundTap = keypad::dismissKeyboards,
             )
         }
 
@@ -298,12 +239,6 @@ class CartActivity : BaseActivity() {
         viewModel.isHapticFeedbackEnabled.observe(this) {
             hapticEnabled = it
         }
-        viewModel.keyboardType.observe(this) { type ->
-            currentKeyboardType = type
-            val extended = type == KeyboardType.EXPANDED
-            keypadRegular.visibility = if (extended) View.GONE else View.VISIBLE
-            keypadExtended.visibility = if (extended) View.VISIBLE else View.GONE
-        }
         viewModel.getCurrentCart().observe(this) { cart ->
             currencyLive.value = cart.currency
             itemsLive.value = cart.items.toList()
@@ -312,7 +247,7 @@ class CartActivity : BaseActivity() {
             // that binding so the keypad doesn't linger over a missing row.
             val currentIds = cart.items.map { it.id }.toSet()
             pendingNames.keys.retainAll(currentIds)
-            activeItemId.value?.let { if (it !in currentIds) closeKeypad() }
+            keypad.activeItemId.value?.let { if (it !in currentIds) keypad.closeKeypad() }
             footerBinding.refreshFeeAnnotations()
         }
         viewModel.getBaseCurrency().observe(this) {
@@ -359,313 +294,27 @@ class CartActivity : BaseActivity() {
         )
     }
 
-    // ------------------------------------------------------------------
-    // Slide-up keypad — behaves like a soft IME. A value field taps calls
-    // `openKeypadFor`; taps on non-value regions (or a back-press) call
-    // `closeKeypad`; every keypad button routes through the reflection
-    // targets below.
-    // ------------------------------------------------------------------
-
-    // Only one keyboard should be visible at a time. `openKeypadFor` calls
-    // `hideSystemIme` when opening the app keypad; this listener handles the
-    // reverse — when the system IME rises (e.g. a row's name field takes
-    // focus while the app keypad is open), dismiss the app keypad. Rising-edge
-    // tracking via [systemImeVisible] avoids retriggering `closeKeypad` on
-    // redundant inset dispatches while the IME stays visible.
-    //
-    // Installing our own listener on cart_root disables its `fitsSystemWindows`
-    // auto-padding (that's how the view API works — a custom listener takes
-    // over), so we re-apply the system-bar insets as padding ourselves. Without
-    // this the toolbar slides under the status bar.
-    private fun installImeVisibilityGuard() {
-        val root = findViewById<View>(R.id.cart_root)
-        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
-            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-            if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
-                closeKeypad()
-            }
-            systemImeVisible = imeVisible
-            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
-            insets
-        }
-    }
-
-    /**
-     * Show the keypad for the row identified by [itemId], seeding a fresh
-     * [CalculatorInputState] with [seedExpression] and mirroring every state
-     * change into [liveExpression] — the composable row observes that
-     * LiveData for its inline display.
-     *
-     * In either system-IME mode there is no in-app keypad to raise; the
-     * row itself hosts an EditText once it becomes active, so we just seed
-     * [liveExpression] and flip [activeItemId] — the composable does the rest
-     * (focus request + IME show).
-     */
-    fun openKeypadFor(
-        itemId: String,
-        seedExpression: String,
-    ) {
-        if (currentKeyboardType.isSystem) {
-            if (activeItemId.value == itemId) return
-            detachActiveField()
-            liveExpression.value = seedExpression
-            activeItemId.value = itemId
-            return
-        }
-        hideSystemIme()
-        detachActiveField()
-        val state = CalculatorInputState().apply { seedExpression(seedExpression) }
-        liveExpression.value = state.toExpressionString().ifEmpty { seedExpression }
-        val observer = Observer<String?> { liveExpression.value = state.toExpressionString() }
-        state.baseValueText.observeForever(observer)
-        state.calculationValueText.observeForever(observer)
-        val parenObserver = Observer<Char> { next -> parenButton()?.paintParenCycle(next) }
-        state.nextParen.observeForever(parenObserver)
-        activeCalculatorState = state
-        activeItemId.value = itemId
-        activeStateObserver = observer
-        activeParenObserver = parenObserver
-        showKeypad()
-    }
-
-    // Bridge each keystroke from the row's inline EditText (ASCII) back into
-    // [liveExpression] (display glyphs) so the row's preview + eventual commit
-    // see the same round-tripped form the in-app keypad produces.
-    private fun onInlineExpressionChanged(
-        id: String,
-        ascii: String,
-    ) {
-        if (activeItemId.value != id) return
-        val glyphs = ascii.asciiToDisplayGlyphs()
-        if (liveExpression.value == glyphs) return
-        liveExpression.value = glyphs
-    }
-
-    // The `()` cycle-toggle key on the extended keypad. Absent from the basic
-    // layout, so callers must tolerate null.
-    private fun parenButton(): AppCompatButton? = keypadExtended.findViewById(R.id.btn_parens)
-
-    /** Hide the keypad and unbind whichever row was being edited. */
-    fun closeKeypad() {
-        if (activeItemId.value == null && keypadContainer.visibility == View.GONE) return
-        detachActiveField()
-        hideKeypad()
-    }
-
-    private fun showKeypad() {
-        keypadBackCallback?.isEnabled = true
-        if (keypadContainer.visibility == View.VISIBLE) return
-        keypadContainer.visibility = View.VISIBLE
-        keypadContainer.translationY = keypadContainer.height.toFloat().takeIf { it > 0f }
-            ?: resources.displayMetrics.heightPixels.toFloat()
-        keypadContainer
-            .animate()
-            .translationY(0f)
-            .setDuration(KEYPAD_ANIM_MS)
-            .start()
-        // Leave the totals card / add-item button pinned to the bottom of the
-        // screen (behind the keypad) and only inset the items list so its
-        // Compose content stops at the keypad's top edge instead of rendering
-        // underneath. Keeps the summary from being pushed above the keypad.
-        setItemsBottomInsetForKeypad()
-    }
-
-    private fun hideKeypad() {
-        keypadBackCallback?.isEnabled = false
-        if (keypadContainer.visibility != View.VISIBLE) return
-        keypadContainer
-            .animate()
-            .translationY(keypadContainer.height.toFloat())
-            .setDuration(KEYPAD_ANIM_MS)
-            .withEndAction { keypadContainer.visibility = View.GONE }
-            .start()
-        setItemsBottomInset(0)
-    }
-
-    private fun setItemsBottomInsetForKeypad() {
-        val apply = {
-            val keypadH =
-                keypadContainer.height.takeIf { it > 0 }
-                    ?: keypadContainer.layoutParams.height
-            // keypad is anchored to the bottom of cart_root; cart_content fills
-            // the same area, so its own height is our reference. The overlap
-            // is the amount by which the items view extends behind the keypad
-            // once the fixed footer (add button + totals card) has taken its
-            // own space at the bottom.
-            val overlap = itemsView.bottom - (contentColumn.height - keypadH)
-            setItemsBottomInset(overlap.coerceAtLeast(0))
-        }
-        if (keypadContainer.height > 0 && itemsView.height > 0) {
-            apply()
-        } else {
-            keypadContainer.post(apply)
-        }
-    }
-
-    private fun setItemsBottomInset(bottom: Int) {
-        itemsView.setPadding(
-            itemsView.paddingLeft,
-            itemsView.paddingTop,
-            itemsView.paddingRight,
-            bottom,
-        )
-    }
-
-    private fun detachActiveField() {
-        val state = activeCalculatorState
-        val observer = activeStateObserver
-        if (state != null && observer != null) {
-            state.baseValueText.removeObserver(observer)
-            state.calculationValueText.removeObserver(observer)
-        }
-        val parenObserver = activeParenObserver
-        if (state != null && parenObserver != null) {
-            state.nextParen.removeObserver(parenObserver)
-        }
-        // Reset the paren button to its rest state — `(` is the only sensible
-        // next glyph when no field is being edited.
-        parenButton()?.paintParenCycle('(')
-        // Commit the current keypad expression to the VM so the row's
-        // persisted value matches what the user just typed.
-        val id = activeItemId.value
-        if (id != null) {
-            val expression = liveExpression.value.orEmpty()
-            commitExpression(id, expression)
-        }
-        activeCalculatorState = null
-        activeItemId.value = null
-        activeStateObserver = null
-        activeParenObserver = null
-        liveExpression.value = ""
-    }
-
-    /**
-     * Route outside-taps to close whichever keyboard is up (app keypad or
-     * system IME) and, when a drag starts inside the keypad, convert it into
-     * a slide-down dismissal. Taps *inside* the keypad (button presses) pass
-     * through unchanged; a tap on another row's expression falls through to
-     * its Compose click handler, which re-opens [openKeypadFor] and swaps the
-     * active state without a visible close/open flicker.
-     */
+    // Route the activity's raw touch stream through the keypad controller so
+    // it can handle drag-to-dismiss (which needs to steal from the child
+    // buttons via ACTION_CANCEL) and outside-tap dismissal.
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        if (keypadContainer.visibility == View.VISIBLE && handleKeypadDrag(ev)) return true
-        if (ev.actionMasked == MotionEvent.ACTION_DOWN) handleOutsideTap(ev)
+        if (keypad.handleTouchEvent(ev)) return true
         return super.dispatchTouchEvent(ev)
     }
 
-    // Only owns taps outside the items ComposeView (toolbar, totals card,
-    // add-item button when the IME is up). Taps inside the items view are
-    // resolved by Compose in [CartItemsList] via onBackgroundTap.
-    private fun handleOutsideTap(ev: MotionEvent) {
-        val x = ev.rawX.toInt()
-        val y = ev.rawY.toInt()
-        val itemsRect = Rect().also(itemsView::getGlobalVisibleRect)
-        if (itemsRect.contains(x, y)) return
-        if (keypadContainer.visibility == View.VISIBLE) {
-            val keypadRect = Rect().also(keypadContainer::getGlobalVisibleRect)
-            if (keypadRect.contains(x, y)) return
-            val stillOn = activeItemId.value
-            keypadContainer.postDelayed({
-                if (activeItemId.value == stillOn && stillOn != null) closeKeypad()
-            }, OUTSIDE_TAP_DEBOUNCE_MS)
-        } else if (systemImeVisible) {
-            dismissKeyboards()
-        }
-    }
-
-    /**
-     * Vertical drag-to-dismiss: once a downward gesture starting inside the
-     * keypad crosses touch slop, steal it from the buttons (by dispatching
-     * ACTION_CANCEL), track the finger via [ViewGroup.setTranslationY], and
-     * either commit the dismiss ([KEYPAD_DRAG_DISMISS_FRACTION]) or snap back
-     * on release. Returns true once the gesture has been intercepted so the
-     * activity's super-dispatch is skipped for the rest of the stream.
-     */
-    private fun handleKeypadDrag(ev: MotionEvent): Boolean {
-        when (ev.actionMasked) {
-            MotionEvent.ACTION_DOWN -> {
-                val rect = Rect().also(keypadContainer::getGlobalVisibleRect)
-                if (rect.contains(ev.rawX.toInt(), ev.rawY.toInt())) {
-                    keypadDragStartY = ev.rawY
-                    keypadDragActive = false
-                }
-                return false
-            }
-            MotionEvent.ACTION_MOVE -> {
-                val start = keypadDragStartY ?: return false
-                val delta = ev.rawY - start
-                if (!keypadDragActive && delta > touchSlop) {
-                    keypadDragActive = true
-                    // Cancel the child press so no button fires when the
-                    // finger lifts — from here on the gesture is a drag.
-                    val cancel = MotionEvent.obtain(ev).also { it.action = MotionEvent.ACTION_CANCEL }
-                    super.dispatchTouchEvent(cancel)
-                    cancel.recycle()
-                }
-                if (keypadDragActive) {
-                    keypadContainer.translationY = delta.coerceAtLeast(0f)
-                    return true
-                }
-                return false
-            }
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                if (!keypadDragActive) {
-                    keypadDragStartY = null
-                    return false
-                }
-                val dragged = keypadContainer.translationY
-                val threshold = keypadContainer.height * KEYPAD_DRAG_DISMISS_FRACTION
-                if (dragged >= threshold) {
-                    // closeKeypad → hideKeypad animates from the current
-                    // translationY (which we just set) back down to full
-                    // height, so the release picks up exactly where the
-                    // finger left off.
-                    closeKeypad()
-                } else {
-                    keypadContainer.animate().cancel()
-                    keypadContainer
-                        .animate()
-                        .translationY(0f)
-                        .setDuration(KEYPAD_ANIM_MS)
-                        .start()
-                }
-                keypadDragActive = false
-                keypadDragStartY = null
-                return true
-            }
-            else -> return false
-        }
-    }
-
-    private fun hideSystemIme() {
-        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager ?: return
-        val token = currentFocus?.windowToken ?: window.decorView.windowToken ?: return
-        imm.hideSoftInputFromWindow(token, 0)
-    }
-
-    private fun dismissKeyboards() {
-        // closeKeypad already detaches for the in-app keypad; the else branch
-        // covers system-IME mode (no keypad) so the active row's typed value
-        // commits and its EditText tears down.
-        if (keypadContainer.visibility == View.VISIBLE) {
-            closeKeypad()
-        } else if (activeItemId.value != null) {
-            detachActiveField()
-        }
-        if (systemImeVisible) {
-            hideSystemIme()
-            currentFocus?.clearFocus()
-        }
+    // Bridge for the keypad controller's drag-to-dismiss: it needs to send an
+    // ACTION_CANCEL through the activity's *super* dispatch chain (not our
+    // override, or we'd infinitely re-enter the drag handler). Kotlin doesn't
+    // allow `super.foo(...)` from inside a lambda, so we expose this helper.
+    private fun superDispatchTouchEvent(ev: MotionEvent) {
+        super.dispatchTouchEvent(ev)
     }
 
     // Cancel every row's pending debounce and push its current buffer to the
     // view model synchronously. Must run before any snapshot/save/share so a
     // freshly-typed name or a pending keypad expression doesn't get lost.
     private fun flushPendingCommits() {
-        activeItemId.value?.let { id ->
-            commitExpression(id, liveExpression.value.orEmpty())
-        }
+        keypad.flushActiveExpression()
         val snapshot = pendingNames.toMap()
         pendingNames.clear()
         snapshot.forEach { (id, name) -> commitName(id, name) }
@@ -696,89 +345,22 @@ class CartActivity : BaseActivity() {
     // Keypad reflection targets. main_keypad.xml wires each button's
     // android:onClick to these names — Android's LayoutInflater resolves
     // them against the hosting Activity, so we mirror MainActivity's
-    // signatures here and forward to the currently-active state.
+    // signatures here and forward to the controller's active state.
     // ------------------------------------------------------------------
 
-    fun numberEvent(view: View) = keypadEvent(view) { it.addNumber((view as AppCompatButton).text.toString()) }
+    fun numberEvent(view: View) = keypad.forwardKeypadAction(view) { it.addNumber((view as AppCompatButton).text.toString()) }
 
-    fun decimalEvent(view: View) = keypadEvent(view) { it.addDecimal() }
+    fun decimalEvent(view: View) = keypad.forwardKeypadAction(view) { it.addDecimal() }
 
-    fun deleteEvent(view: View) = keypadEvent(view) { it.delete() }
+    fun deleteEvent(view: View) = keypad.forwardKeypadAction(view) { it.delete() }
 
-    fun percentEvent(view: View) = keypadEvent(view) { it.addPercent() }
+    fun percentEvent(view: View) = keypad.forwardKeypadAction(view) { it.addPercent() }
 
-    fun calculationEvent(view: View) = keypadEvent(view) { it.addOperator((view as AppCompatButton).text.toString()) }
+    fun calculationEvent(view: View) = keypad.forwardKeypadAction(view) { it.addOperator((view as AppCompatButton).text.toString()) }
 
-    fun parensEvent(view: View) = keypadEvent(view) { it.applyNextParen() }
-
-    // Every keypad button does the same two-step: haptic tap on the button,
-    // then forward the action to whichever row's calculator state is active.
-    private inline fun keypadEvent(
-        view: View,
-        action: (CalculatorInputState) -> Unit,
-    ) {
-        view.hapticTap(hapticEnabled)
-        activeCalculatorState?.let(action)
-    }
+    fun parensEvent(view: View) = keypad.forwardKeypadAction(view) { it.applyNextParen() }
 
     private fun showSnackbar(message: String) {
         snackbar(message).show()
     }
-}
-
-/**
- * Rebuild the input state from a previously-saved cart-row expression so the
- * keypad opens where the user left off. Empty input leaves the state at its
- * default "0" seed.
- */
-private fun CalculatorInputState.seedExpression(expression: String) {
-    val trimmed = expression.trim()
-    if (trimmed.isEmpty()) return
-    if (!trimmed.contains(CALC_TOKEN_REGEX)) {
-        replayDigits(trimmed)
-        return
-    }
-    // Split on operator/paren boundaries while keeping each structural token
-    // as its own entry — mirrors how the state serialises them back out.
-    val tokens = mutableListOf<String>()
-    val buf = StringBuilder()
-    trimmed.forEach { ch ->
-        if (ch.toString().matches(CALC_TOKEN_REGEX)) {
-            if (buf.isNotBlank()) tokens += buf.toString().trim()
-            tokens += ch.toString()
-            buf.clear()
-        } else {
-            buf.append(ch)
-        }
-    }
-    if (buf.isNotBlank()) tokens += buf.toString().trim()
-    // The digit-replay API is state-aware — it targets the base row before
-    // the first operator and the calculation row afterwards — so every
-    // operand goes through the same path.
-    tokens.forEach { token ->
-        when {
-            token == "(" -> addOpenParen()
-            token == ")" -> addCloseParen()
-            token.matches(OPERATOR_REGEX) -> addOperator(token)
-            else -> replayDigits(token)
-        }
-    }
-}
-
-private fun CalculatorInputState.replayDigits(number: String) {
-    number.forEach { ch ->
-        when {
-            ch.isDigit() -> addNumber(ch.toString())
-            ch == '.' -> addDecimal()
-        }
-    }
-}
-
-/**
- * Serialise the current input state back to a string the cart layer can
- * store and later evaluate (matches the expression format cart rows use).
- */
-private fun CalculatorInputState.toExpressionString(): String {
-    val calc = calculationValueText.value
-    return if (calc.isNullOrBlank()) baseValueText.value.orEmpty() else calc.trim()
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -10,13 +10,10 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatButton
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.ViewCompat
@@ -31,7 +28,6 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.KeyboardType
-import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.repository.CartExporter
 import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CalculatorKeyListener
@@ -47,8 +43,6 @@ import com.eliormachlev.currencix.util.toCartFeePercentDisplay
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.cart.compose.CartEmptyHint
 import com.eliormachlev.currencix.view.cart.compose.CartItemsList
-import com.eliormachlev.currencix.view.cart.compose.SavedCartsList
-import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinner
 import com.eliormachlev.currencix.view.preference.PreferenceActivity
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
@@ -76,6 +70,7 @@ class CartActivity : BaseActivity() {
     private lateinit var exporter: CartExporter
     private lateinit var fileIo: CartFileIo
     private lateinit var shareCoordinator: CartShareCoordinator
+    private lateinit var saveLoadCoordinator: CartSaveLoadCoordinator
 
     private lateinit var itemsView: ComposeView
     private lateinit var subtotalLabel: TextView
@@ -176,6 +171,13 @@ class CartActivity : BaseActivity() {
                 flushPendingCommits = ::flushPendingCommits,
                 snackbar = ::showSnackbar,
             )
+        this.saveLoadCoordinator =
+            CartSaveLoadCoordinator(
+                activity = this,
+                viewModel = viewModel,
+                flushPendingCommits = ::flushPendingCommits,
+                snackbar = ::showSnackbar,
+            )
 
         this.itemsView = findViewById(R.id.cart_items)
         this.subtotalLabel = findViewById(R.id.cart_subtotal_value)
@@ -214,7 +216,7 @@ class CartActivity : BaseActivity() {
         onBackPressedDispatcher.addCallback(
             this,
             object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() = attemptClose()
+                override fun handleOnBackPressed() = saveLoadCoordinator.attemptClose()
             },
         )
         keypadBackCallback =
@@ -289,7 +291,7 @@ class CartActivity : BaseActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean =
         when (item.itemId) {
             android.R.id.home -> {
-                attemptClose()
+                saveLoadCoordinator.attemptClose()
                 true
             }
             R.id.cart_share -> {
@@ -297,15 +299,15 @@ class CartActivity : BaseActivity() {
                 true
             }
             R.id.cart_save -> {
-                saveOrPromptForName()
+                saveLoadCoordinator.saveOrPromptForName()
                 true
             }
             R.id.cart_save_as -> {
-                showSaveAsDialog()
+                saveLoadCoordinator.showSaveAsDialog()
                 true
             }
             R.id.cart_load -> {
-                showLoadDialog()
+                saveLoadCoordinator.showLoadDialog()
                 true
             }
             R.id.cart_export -> {
@@ -498,189 +500,6 @@ class CartActivity : BaseActivity() {
         value: BigDecimal?,
         currency: Currency?,
     ): String = formatCartAmount(value, currency)
-
-    // Fallback to the localised "My cart" name when the user hasn't given
-    // the cart one. Shared by Save-as, Rename, and Export.
-    private fun String.orDefaultCartName(): String = ifBlank { getString(R.string.cart_default_saved_name) }
-
-    private fun showSaveAsDialog(onSaved: () -> Unit = {}) {
-        if (guardEmptyForSave()) return
-        showNameInputDialog(
-            titleRes = R.string.cart_menu_save_as,
-            initial =
-                viewModel
-                    .getCurrentCart()
-                    .value
-                    ?.name
-                    .orEmpty(),
-        ) { name ->
-            // "Save as" always creates a fresh entry so users can keep
-            // multiple snapshots of the same cart under different names.
-            flushPendingCommits()
-            viewModel.saveCurrentAs(name)
-            showSnackbar(getString(R.string.cart_saved_toast, name))
-            onSaved()
-        }
-    }
-
-    /**
-     * "Save" menu action — overwrites the current saved cart in-place. Falls
-     * back to Save-as when there's nothing to overwrite (never saved yet).
-     */
-    private fun saveOrPromptForName(onSaved: () -> Unit = {}) {
-        if (guardEmptyForSave()) return
-        flushPendingCommits()
-        if (viewModel.saveCurrent()) {
-            val name =
-                viewModel
-                    .getCurrentCart()
-                    .value
-                    ?.name
-                    .orEmpty()
-            showSnackbar(getString(R.string.cart_saved_toast, name))
-            onSaved()
-        } else {
-            showSaveAsDialog(onSaved = onSaved)
-        }
-    }
-
-    // Shared "one-line text input" dialog for cart name prompts (Save-as,
-    // Rename). Blank input collapses to the localised default cart name so
-    // every entry point produces a nameable, findable saved cart.
-    private fun showNameInputDialog(
-        titleRes: Int,
-        initial: String,
-        onOk: (String) -> Unit,
-    ) {
-        val input =
-            EditText(this).apply {
-                hint = getString(R.string.cart_save_name_hint)
-                setText(initial)
-            }
-        AlertDialog
-            .Builder(this)
-            .setTitle(titleRes)
-            .setView(input)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                onOk(
-                    input.text
-                        .toString()
-                        .trim()
-                        .orDefaultCartName(),
-                )
-            }.setNegativeButton(android.R.string.cancel, null)
-            .show()
-    }
-
-    // Refuse to persist an empty cart — matches Share's "nothing to share"
-    // guard so both write paths behave consistently. Returns true when the
-    // caller should abort.
-    private fun guardEmptyForSave(): Boolean {
-        val items = viewModel.getCurrentCart().value?.items
-        if (items.isNullOrEmpty()) {
-            showSnackbar(getString(R.string.cart_save_empty))
-            return true
-        }
-        return false
-    }
-
-    /**
-     * Gate a destructive action (switching carts, closing the screen) behind
-     * an unsaved-changes prompt. Presents Save (overwrite — only when the
-     * cart has a persisted counterpart), Save as (new entry), Continue
-     * (discard), and Cancel (abort). Each save path invokes [action] after
-     * the write completes.
-     */
-    private fun confirmUnsavedThen(action: () -> Unit) {
-        // An empty cart has nothing worth saving, so skip the prompt entirely
-        // even if a persisted counterpart differs — the destructive action
-        // would just replace an empty working set with something else.
-        val items = viewModel.getCurrentCart().value?.items
-        if (items.isNullOrEmpty() || !viewModel.hasUnsavedChanges()) {
-            action()
-            return
-        }
-        val canOverwrite =
-            viewModel
-                .getCurrentCart()
-                .value
-                ?.id
-                ?.isNotEmpty() == true
-        val options = mutableListOf<Pair<String, () -> Unit>>()
-        if (canOverwrite) {
-            options += getString(R.string.cart_unsaved_save) to { saveOrPromptForName(action) }
-        }
-        options += getString(R.string.cart_unsaved_save_as) to { showSaveAsDialog(onSaved = action) }
-        options += getString(R.string.cart_unsaved_discard) to {
-            viewModel.discardChanges()
-            action()
-        }
-        options += getString(R.string.cart_unsaved_continue) to action
-        AlertDialog
-            .Builder(this)
-            .setTitle(R.string.cart_unsaved_title)
-            .setItems(options.map { it.first }.toTypedArray()) { _, which ->
-                options[which].second.invoke()
-            }.setNegativeButton(android.R.string.cancel, null)
-            .show()
-    }
-
-    private fun attemptClose() = confirmUnsavedThen { finish() }
-
-    private fun showLoadDialog() {
-        val initial = viewModel.getSavedCartsSnapshot()
-        if (initial.isEmpty()) {
-            showSnackbar(getString(R.string.cart_no_saved))
-            return
-        }
-        val saved = mutableStateListOf<SavedCart>().apply { addAll(initial) }
-        lateinit var dialog: AlertDialog
-        val composeView =
-            ComposeView(this).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-                setContent {
-                    AppTheme {
-                        SavedCartsList(
-                            items = saved,
-                            onPick = { cart ->
-                                dialog.dismiss()
-                                confirmUnsavedThen { viewModel.loadSaved(cart.id) }
-                            },
-                            onRename = { cart ->
-                                showNameInputDialog(
-                                    titleRes = R.string.cart_rename_title,
-                                    initial = cart.name,
-                                ) { name ->
-                                    viewModel.renameSaved(cart.id, name)
-                                    val idx = saved.indexOfFirst { it.id == cart.id }
-                                    if (idx >= 0) saved[idx] = cart.copy(name = name)
-                                }
-                            },
-                            onDelete = { cart ->
-                                AlertDialog
-                                    .Builder(this@CartActivity)
-                                    .setTitle(cart.name.ifBlank { cart.id.take(8) })
-                                    .setMessage(getString(R.string.cart_delete_confirm, cart.name))
-                                    .setPositiveButton(R.string.cart_delete_confirm_button) { _, _ ->
-                                        viewModel.deleteSaved(cart.id)
-                                        saved.removeAll { it.id == cart.id }
-                                        if (saved.isEmpty()) dialog.dismiss()
-                                    }.setNegativeButton(android.R.string.cancel, null)
-                                    .show()
-                            },
-                        )
-                    }
-                }
-            }
-        dialog =
-            AlertDialog
-                .Builder(this)
-                .setTitle(R.string.cart_menu_load)
-                .setView(composeView)
-                .setNegativeButton(android.R.string.cancel, null)
-                .create()
-        dialog.show()
-    }
 
     private fun confirmClear() {
         showCartChoiceExplainerDialog(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -11,7 +11,6 @@ import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageButton
-import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.AppCompatButton
 import androidx.compose.ui.platform.ComposeView
@@ -26,20 +25,15 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.map
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
-import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.repository.CartExporter
 import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CalculatorKeyListener
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
 import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
-import com.eliormachlev.currencix.util.feeStackDelta
-import com.eliormachlev.currencix.util.formatCartAmount
 import com.eliormachlev.currencix.util.hapticTap
-import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
-import com.eliormachlev.currencix.util.toCartFeePercentDisplay
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.cart.compose.CartEmptyHint
 import com.eliormachlev.currencix.view.cart.compose.CartItemsList
@@ -48,8 +42,6 @@ import com.eliormachlev.currencix.view.preference.PreferenceActivity
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
 import com.eliormachlev.currencix.viewmodel.main.CalculatorInputState
 import com.google.android.material.button.MaterialButton
-import java.math.BigDecimal
-import java.math.MathContext
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
 private const val KEYPAD_ANIM_MS = 180L
@@ -71,23 +63,9 @@ class CartActivity : BaseActivity() {
     private lateinit var fileIo: CartFileIo
     private lateinit var shareCoordinator: CartShareCoordinator
     private lateinit var saveLoadCoordinator: CartSaveLoadCoordinator
+    private lateinit var footerBinding: CartFooterBinding
 
     private lateinit var itemsView: ComposeView
-    private lateinit var subtotalLabel: TextView
-    private lateinit var subtotalExtra: View
-    private lateinit var subtotalExtraLabel: TextView
-    private lateinit var subtotalExtraValue: TextView
-    private lateinit var subtotalFee: View
-    private lateinit var subtotalFeeLabel: TextView
-    private lateinit var subtotalFeeValue: TextView
-    private lateinit var feeLine: TextView
-    private lateinit var totalLabel: TextView
-    private lateinit var totalExtra: View
-    private lateinit var totalExtraLabel: TextView
-    private lateinit var totalExtraValue: TextView
-    private lateinit var totalFee: View
-    private lateinit var totalFeeLabel: TextView
-    private lateinit var totalFeeValue: TextView
     private lateinit var spinnerFrom: SearchableSpinner
     private lateinit var spinnerTo: SearchableSpinner
     private lateinit var swapButton: ImageButton
@@ -180,21 +158,12 @@ class CartActivity : BaseActivity() {
             )
 
         this.itemsView = findViewById(R.id.cart_items)
-        this.subtotalLabel = findViewById(R.id.cart_subtotal_value)
-        this.subtotalExtra = findViewById(R.id.cart_subtotal_extra)
-        this.subtotalExtraLabel = findViewById(R.id.cart_subtotal_extra_label)
-        this.subtotalExtraValue = findViewById(R.id.cart_subtotal_extra_value)
-        this.subtotalFee = findViewById(R.id.cart_subtotal_fee)
-        this.subtotalFeeLabel = findViewById(R.id.cart_subtotal_fee_label)
-        this.subtotalFeeValue = findViewById(R.id.cart_subtotal_fee_value)
-        this.feeLine = findViewById(R.id.cart_fee_line)
-        this.totalLabel = findViewById(R.id.cart_total_value)
-        this.totalExtra = findViewById(R.id.cart_total_extra)
-        this.totalExtraLabel = findViewById(R.id.cart_total_extra_label)
-        this.totalExtraValue = findViewById(R.id.cart_total_extra_value)
-        this.totalFee = findViewById(R.id.cart_total_fee)
-        this.totalFeeLabel = findViewById(R.id.cart_total_fee_label)
-        this.totalFeeValue = findViewById(R.id.cart_total_fee_value)
+        this.footerBinding =
+            CartFooterBinding(
+                root = findViewById(R.id.cart_root),
+                ctx = this,
+                viewModel = viewModel,
+            )
         this.spinnerFrom = findViewById(R.id.cart_spinner_from)
         this.spinnerTo = findViewById(R.id.cart_spinner_to)
         this.swapButton = findViewById(R.id.cart_swap)
@@ -344,7 +313,7 @@ class CartActivity : BaseActivity() {
             val currentIds = cart.items.map { it.id }.toSet()
             pendingNames.keys.retainAll(currentIds)
             activeItemId.value?.let { if (it !in currentIds) closeKeypad() }
-            updateFeeVisuals()
+            footerBinding.refreshFeeAnnotations()
         }
         viewModel.getBaseCurrency().observe(this) {
             spinnerFrom.setSelection(it)
@@ -356,15 +325,9 @@ class CartActivity : BaseActivity() {
             spinnerTo.setSelection(it)
             spinnerFrom.setDisabledCurrency(it)
         }
-        viewModel.getSubtotal().observe(this) { value ->
-            subtotalLabel.text = formatAmount(value, viewModel.getBaseCurrency().value)
-            updateFeeExtras()
-        }
-        viewModel.getTotal().observe(this) { value ->
-            totalLabel.text = formatAmount(value, viewModel.getDestinationCurrency().value)
-            updateFeeExtras()
-        }
-        viewModel.getFees().observe(this) { updateFeeVisuals() }
+        viewModel.getSubtotal().observe(this) { footerBinding.onSubtotalChanged(it) }
+        viewModel.getTotal().observe(this) { footerBinding.onTotalChanged(it) }
+        viewModel.getFees().observe(this) { footerBinding.refreshFeeAnnotations() }
         viewModel.getExchangeRates().observe(this) { rates ->
             // Feed the same rate list the spinner shows on the main screen so
             // its picker shows flags, ISO codes, and (when enabled) preview
@@ -375,131 +338,9 @@ class CartActivity : BaseActivity() {
             // adapter, which drops the previous selection unless we re-set it.
             spinnerFrom.setSelection(viewModel.getBaseCurrency().value)
             spinnerTo.setSelection(viewModel.getDestinationCurrency().value)
-            updateFeeLine()
+            footerBinding.refreshFeeAnnotations()
         }
     }
-
-    // Both the arrow/percentage line and the "other side" total need to re-run
-    // whenever fees or the cart's currencies change — bundle so callers don't
-    // have to know which slot depends on what.
-    private fun updateFeeVisuals() {
-        updateFeeLine()
-        updateFeeExtras()
-    }
-
-    private fun updateFeeLine() {
-        // Only surface the combined percent when *both* sides carry a fee —
-        // otherwise the per-side annotation block already spells out the same
-        // number ("Fee: +2%") and this row is a duplicate.
-        val stacks = viewModel.currentSideStacks()
-        val bothSides = !stacks.original.isNeutralFeeStack() && !stacks.converted.isNeutralFeeStack()
-        if (!bothSides) {
-            feeLine.visibility = View.GONE
-            return
-        }
-        feeLine.text = getString(R.string.cart_fee_line, stacks.combined.toCartFeePercentDisplay())
-        feeLine.visibility = View.VISIBLE
-    }
-
-    /**
-     * Show both anchor values for each per-side fee: the fee amount itself
-     * ("Conversion fee" / "Reduction fee") and the effective total-with-fee /
-     * pre-fee value ("Cost with fee" / "Value before fee"). Ordering matches
-     * the on-screen layout: fee then cost-with-fee on ORIGINAL; value-before-
-     * fee then reduction-fee on CONVERTED. Either or both blocks may hide.
-     */
-    private fun updateFeeExtras() {
-        val stacks = viewModel.currentSideStacks()
-        renderFeeExtraRow(
-            container = subtotalFee,
-            labelView = subtotalFeeLabel,
-            valueView = subtotalFeeValue,
-            prefixRes = R.string.fee_true_cost_prefix,
-            stack = stacks.original,
-            base = viewModel.getSubtotal().value,
-            currency = viewModel.getBaseCurrency().value,
-            mode = FeeRowMode.DELTA,
-        )
-        renderFeeExtraRow(
-            container = subtotalExtra,
-            labelView = subtotalExtraLabel,
-            valueView = subtotalExtraValue,
-            prefixRes = R.string.fee_cost_with_fee_prefix,
-            stack = stacks.original,
-            base = viewModel.getSubtotal().value,
-            currency = viewModel.getBaseCurrency().value,
-            mode = FeeRowMode.TOTAL,
-        )
-        renderFeeExtraRow(
-            container = totalExtra,
-            labelView = totalExtraLabel,
-            valueView = totalExtraValue,
-            prefixRes = R.string.fee_value_before_fee_prefix,
-            stack = stacks.converted,
-            base = viewModel.getTotal().value,
-            currency = viewModel.getDestinationCurrency().value,
-            mode = FeeRowMode.TOTAL,
-        )
-        renderFeeExtraRow(
-            container = totalFee,
-            labelView = totalFeeLabel,
-            valueView = totalFeeValue,
-            prefixRes = R.string.fee_original_value_prefix,
-            stack = stacks.converted,
-            base = viewModel.getTotal().value,
-            currency = viewModel.getDestinationCurrency().value,
-            mode = FeeRowMode.DELTA,
-        )
-    }
-
-    // Hidden when the [stack] is trivial. TOTAL renders `base * stack` (the
-    // effective with-fee cost or pre-fee value); DELTA renders `|base *
-    // (stack - 1)|` (the fee magnitude — the percent tail already carries
-    // the sign so we avoid a double negative). Only DELTA rows show the
-    // percent — TOTAL rows sit next to a DELTA row that already spells it
-    // out, so restating it here would just be a duplicate.
-    private fun renderFeeExtraRow(
-        container: View,
-        labelView: TextView,
-        valueView: TextView,
-        prefixRes: Int,
-        stack: BigDecimal,
-        base: BigDecimal?,
-        currency: Currency?,
-        mode: FeeRowMode,
-    ) {
-        if (stack.isNeutralFeeStack()) {
-            container.visibility = View.GONE
-            return
-        }
-        val multiplier =
-            when (mode) {
-                FeeRowMode.TOTAL -> stack
-                FeeRowMode.DELTA -> stack.feeStackDelta()
-            }
-        val raw = (base ?: BigDecimal.ZERO).multiply(multiplier, MathContext.DECIMAL128)
-        val adjusted = if (mode == FeeRowMode.DELTA) raw.abs() else raw
-        labelView.text = stripLabelSeparator(getString(prefixRes))
-        val amountText = formatAmount(adjusted, currency)
-        valueView.text =
-            when (mode) {
-                FeeRowMode.TOTAL -> amountText
-                FeeRowMode.DELTA -> getString(R.string.cart_fee_extra_value, amountText, stack.toCartFeePercentDisplay())
-            }
-        container.visibility = View.VISIBLE
-    }
-
-    private enum class FeeRowMode { TOTAL, DELTA }
-
-    // Existing prefix strings end with a locale-specific ": " / " : " / "：" for
-    // inline use. When we're showing them as a standalone left-aligned label,
-    // strip the trailing separator so it doesn't dangle before the right column.
-    private fun stripLabelSeparator(text: String): String = text.trimEnd(' ', '\u00A0', ':', '：')
-
-    private fun formatAmount(
-        value: BigDecimal?,
-        currency: Currency?,
-    ): String = formatCartAmount(value, currency)
 
     private fun confirmClear() {
         showCartChoiceExplainerDialog(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -498,7 +498,9 @@ class CartActivity : BaseActivity() {
     // Hidden when the [stack] is trivial. TOTAL renders `base * stack` (the
     // effective with-fee cost or pre-fee value); DELTA renders `|base *
     // (stack - 1)|` (the fee magnitude — the percent tail already carries
-    // the sign so we avoid a double negative).
+    // the sign so we avoid a double negative). Only DELTA rows show the
+    // percent — TOTAL rows sit next to a DELTA row that already spells it
+    // out, so restating it here would just be a duplicate.
     private fun renderFeeExtraRow(
         container: View,
         labelView: TextView,
@@ -521,12 +523,12 @@ class CartActivity : BaseActivity() {
         val raw = (base ?: BigDecimal.ZERO).multiply(multiplier, MathContext.DECIMAL128)
         val adjusted = if (mode == FeeRowMode.DELTA) raw.abs() else raw
         labelView.text = stripLabelSeparator(getString(prefixRes))
+        val amountText = formatAmount(adjusted, currency)
         valueView.text =
-            getString(
-                R.string.cart_fee_extra_value,
-                formatAmount(adjusted, currency),
-                stack.toFeePercentDisplay(),
-            )
+            when (mode) {
+                FeeRowMode.TOTAL -> amountText
+                FeeRowMode.DELTA -> getString(R.string.cart_fee_extra_value, amountText, stack.toFeePercentDisplay())
+            }
         container.visibility = View.VISIBLE
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -1,7 +1,6 @@
 package com.eliormachlev.currencix.view.cart
 
 import android.content.Context
-import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.Menu
@@ -38,21 +37,13 @@ import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
 import com.eliormachlev.currencix.util.CalculatorKeyListener
 import com.eliormachlev.currencix.util.OPERATOR_REGEX
 import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
-import com.eliormachlev.currencix.util.buildCartShareChooser
-import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.feeStackDelta
-import com.eliormachlev.currencix.util.filenameTimestampNow
 import com.eliormachlev.currencix.util.formatCartAmount
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.isNeutralFeeStack
-import com.eliormachlev.currencix.util.paddedDialogContainer
 import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
-import com.eliormachlev.currencix.util.sanitizeForFilename
-import com.eliormachlev.currencix.util.toCartDisplayString
 import com.eliormachlev.currencix.util.toCartFeePercentDisplay
-import com.eliormachlev.currencix.util.toCsv
-import com.eliormachlev.currencix.util.toPdfBytes
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.cart.compose.CartEmptyHint
 import com.eliormachlev.currencix.view.cart.compose.CartItemsList
@@ -60,17 +51,11 @@ import com.eliormachlev.currencix.view.cart.compose.SavedCartsList
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinner
 import com.eliormachlev.currencix.view.preference.PreferenceActivity
-import com.eliormachlev.currencix.viewmodel.cart.CartSnapshot
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
 import com.eliormachlev.currencix.viewmodel.main.CalculatorInputState
 import com.google.android.material.button.MaterialButton
 import java.math.BigDecimal
 import java.math.MathContext
-
-private const val CSV_MIME = "text/csv"
-private const val CSV_EXT = ".csv"
-private const val PDF_MIME = "application/pdf"
-private const val PDF_EXT = ".pdf"
 
 // Duration of the slide-in / slide-out animation for the cart keypad.
 private const val KEYPAD_ANIM_MS = 180L
@@ -90,6 +75,7 @@ class CartActivity : BaseActivity() {
     private lateinit var viewModel: CartViewModel
     private lateinit var exporter: CartExporter
     private lateinit var fileIo: CartFileIo
+    private lateinit var shareCoordinator: CartShareCoordinator
 
     private lateinit var itemsView: ComposeView
     private lateinit var subtotalLabel: TextView
@@ -180,6 +166,13 @@ class CartActivity : BaseActivity() {
                 activity = this,
                 viewModel = viewModel,
                 exporter = exporter,
+                flushPendingCommits = ::flushPendingCommits,
+                snackbar = ::showSnackbar,
+            )
+        this.shareCoordinator =
+            CartShareCoordinator(
+                activity = this,
+                viewModel = viewModel,
                 flushPendingCommits = ::flushPendingCommits,
                 snackbar = ::showSnackbar,
             )
@@ -300,7 +293,7 @@ class CartActivity : BaseActivity() {
                 true
             }
             R.id.cart_share -> {
-                showShareDialog()
+                shareCoordinator.show()
                 true
             }
             R.id.cart_save -> {
@@ -690,155 +683,21 @@ class CartActivity : BaseActivity() {
     }
 
     private fun confirmClear() {
-        showChoiceExplainerDialog(
+        showCartChoiceExplainerDialog(
             titleRes = R.string.cart_menu_clear,
             choices =
                 listOf(
-                    ChoiceRow(
+                    CartChoice(
                         R.string.cart_clear_items_only,
                         R.string.cart_clear_items_only_desc,
                     ) { viewModel.clearItems() },
-                    ChoiceRow(
+                    CartChoice(
                         R.string.cart_clear_reset_all,
                         R.string.cart_clear_reset_all_desc,
                     ) { viewModel.resetToMainDefaults() },
                 ),
         )
     }
-
-    // Shared "title + one-line explainer per option" picker. Mirrors the
-    // preference-screen fee-side dialog so users get the same shape of
-    // guidance in the cart's destructive flows.
-    private data class ChoiceRow(
-        val title: Int,
-        val description: Int,
-        val onPick: () -> Unit,
-    )
-
-    private fun showChoiceExplainerDialog(
-        titleRes: Int,
-        choices: List<ChoiceRow>,
-    ) {
-        val padV = resources.getDimensionPixelSize(R.dimen.margin2x)
-        val container = paddedDialogContainer(this, topPadding = padV)
-        val dialogHolder = arrayOfNulls<AlertDialog>(1)
-        choices.forEach { choice ->
-            container.addView(
-                choiceExplainerRow(
-                    ctx = this,
-                    title = getString(choice.title),
-                    description = getString(choice.description),
-                ) {
-                    choice.onPick()
-                    dialogHolder[0]?.dismiss()
-                },
-            )
-        }
-        dialogHolder[0] =
-            AlertDialog
-                .Builder(this)
-                .setTitle(titleRes)
-                .setView(container)
-                .setNegativeButton(android.R.string.cancel, null)
-                .show()
-    }
-
-    // Single "Share" entry point — presents plain-text / CSV / PDF as picker
-    // rows so the top-level overflow menu stays short. Flush + empty-guard run
-    // once up-front so an empty cart never surfaces a picker it can't act on.
-    private fun showShareDialog() {
-        flushPendingCommits()
-        val snapshot = viewModel.snapshotForShare()
-        if (snapshot == null) {
-            showSnackbar(getString(R.string.cart_share_empty))
-            return
-        }
-        showChoiceExplainerDialog(
-            titleRes = R.string.menu_share,
-            choices =
-                listOf(
-                    ChoiceRow(
-                        R.string.cart_share_option_text,
-                        R.string.cart_share_option_text_desc,
-                    ) { shareCartAsText(snapshot) },
-                    ChoiceRow(
-                        R.string.cart_share_option_csv,
-                        R.string.cart_share_option_csv_desc,
-                    ) { shareCartAsCsv(snapshot) },
-                    ChoiceRow(
-                        R.string.cart_share_option_pdf,
-                        R.string.cart_share_option_pdf_desc,
-                    ) { shareCartAsPdf(snapshot) },
-                ),
-        )
-    }
-
-    private fun shareCartAsText(snapshot: CartSnapshot) {
-        val text = buildShareText(snapshot)
-        val intent =
-            Intent(Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                putExtra(Intent.EXTRA_TEXT, text)
-            }
-        startActivity(Intent.createChooser(intent, null))
-    }
-
-    private fun shareCartAsCsv(snapshot: CartSnapshot) {
-        val title = shareTitle(snapshot)
-        val chooser =
-            buildCartShareChooser(
-                context = this,
-                filename = shareFilename(title, CSV_EXT),
-                mimeType = CSV_MIME,
-                bytes = snapshot.toCsv(title = title).toByteArray(Charsets.UTF_8),
-            )
-        startActivity(chooser)
-    }
-
-    private fun shareCartAsPdf(snapshot: CartSnapshot) {
-        val title = shareTitle(snapshot)
-        val chooser =
-            buildCartShareChooser(
-                context = this,
-                filename = shareFilename(title, PDF_EXT),
-                mimeType = PDF_MIME,
-                bytes = snapshot.toPdfBytes(title = title),
-            )
-        startActivity(chooser)
-    }
-
-    // Cart name if the user has one (from Save-as), otherwise a phone-local
-    // timestamp so the artefact still has an identifying handle.
-    private fun shareTitle(snapshot: CartSnapshot): String = snapshot.cart.name.ifBlank { filenameTimestampNow() }
-
-    private fun shareFilename(
-        title: String,
-        extension: String,
-    ): String = title.sanitizeForFilename() + extension
-
-    private fun buildShareText(snapshot: CartSnapshot): String =
-        buildString {
-            val baseIso = snapshot.baseCurrency.iso4217Alpha()
-            val destIso = snapshot.destinationCurrency.iso4217Alpha()
-            val name = snapshot.cart.name.ifBlank { getString(R.string.cart_share_default_title) }
-            appendLine(getString(R.string.cart_share_header, name, baseIso))
-            snapshot.evaluatedItems.forEach { (item, value) ->
-                val label = item.name.ifBlank { item.expression }
-                appendLine("• $label: ${value.toCartDisplayString()}")
-            }
-            appendLine("—")
-            appendLine(getString(R.string.cart_share_subtotal, snapshot.subtotal.toCartDisplayString(), baseIso))
-            if (snapshot.isConverting) {
-                appendLine(
-                    getString(R.string.cart_share_converted, snapshot.convertedSubtotal.toCartDisplayString(), destIso),
-                )
-            }
-            val combinedStack = snapshot.sideStacks.combined
-            if (!combinedStack.isNeutralFeeStack()) {
-                appendLine(getString(R.string.cart_share_fees, combinedStack.toCartFeePercentDisplay()))
-            }
-            append(getString(R.string.cart_share_total, snapshot.total.toCartDisplayString(), destIso))
-        }
 
     // ------------------------------------------------------------------
     // Slide-up keypad — behaves like a soft IME. A value field taps calls

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
@@ -1,0 +1,47 @@
+package com.eliormachlev.currencix.view.cart
+
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.util.choiceExplainerRow
+import com.eliormachlev.currencix.util.paddedDialogContainer
+
+/**
+ * Shared "title + one-line explainer per option" picker used by every
+ * destructive/branch-y cart flow (Share, Clear). Mirrors the preference-screen
+ * fee-side dialog so users get the same shape of guidance.
+ */
+data class CartChoice(
+    @StringRes val title: Int,
+    @StringRes val description: Int,
+    val onPick: () -> Unit,
+)
+
+fun AppCompatActivity.showCartChoiceExplainerDialog(
+    @StringRes titleRes: Int,
+    choices: List<CartChoice>,
+) {
+    val padV = resources.getDimensionPixelSize(R.dimen.margin2x)
+    val container = paddedDialogContainer(this, topPadding = padV)
+    val dialogHolder = arrayOfNulls<AlertDialog>(1)
+    choices.forEach { choice ->
+        container.addView(
+            choiceExplainerRow(
+                ctx = this,
+                title = getString(choice.title),
+                description = getString(choice.description),
+            ) {
+                choice.onPick()
+                dialogHolder[0]?.dismiss()
+            },
+        )
+    }
+    dialogHolder[0] =
+        AlertDialog
+            .Builder(this)
+            .setTitle(titleRes)
+            .setView(container)
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartFileIo.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartFileIo.kt
@@ -1,0 +1,82 @@
+package com.eliormachlev.currencix.view.cart
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.repository.CartExporter
+import com.eliormachlev.currencix.repository.CartFileResult
+import com.eliormachlev.currencix.util.filenameTimestampNow
+import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
+
+private const val EXPORT_FILE_MIME = "application/json"
+private const val EXPORT_FILE_EXT = ".json"
+
+/**
+ * Owns the SAF launcher pair for cart JSON export / import. Registration must
+ * happen before the host activity reaches STARTED, so construct this in the
+ * activity's onCreate before observe() runs. The [snackbar] callback bridges
+ * result messages back to the host's snackbar host.
+ */
+class CartFileIo(
+    private val activity: AppCompatActivity,
+    private val viewModel: CartViewModel,
+    private val exporter: CartExporter,
+    private val flushPendingCommits: () -> Unit,
+    private val snackbar: (String) -> Unit,
+) {
+    private val exportLauncher: ActivityResultLauncher<String> =
+        activity.registerForActivityResult(
+            ActivityResultContracts.CreateDocument(EXPORT_FILE_MIME),
+        ) { uri -> uri?.let(::doExport) }
+
+    private val importLauncher: ActivityResultLauncher<Array<String>> =
+        activity.registerForActivityResult(
+            ActivityResultContracts.OpenDocument(),
+        ) { uri -> uri?.let(::doImport) }
+
+    fun launchExport() {
+        flushPendingCommits()
+        val name =
+            viewModel
+                .getCurrentCart()
+                .value
+                ?.name
+                ?.ifBlank { null } ?: "cart"
+        exportLauncher.launch("$name-${filenameTimestampNow()}$EXPORT_FILE_EXT")
+    }
+
+    fun launchImport() {
+        importLauncher.launch(arrayOf(EXPORT_FILE_MIME))
+    }
+
+    private fun doExport(uri: Uri) {
+        val cart = viewModel.getCurrentCart().value ?: return
+        // Copy so the exported file always has a real name, even if the
+        // user hasn't gone through Save-as yet.
+        val toExport =
+            cart.copy(
+                name = cart.name.ifBlank { activity.getString(R.string.cart_default_saved_name) },
+                createdAt = System.currentTimeMillis(),
+            )
+        when (val res = exporter.export(uri, toExport)) {
+            is CartFileResult.Success -> snackbar(activity.getString(R.string.cart_export_ok))
+            is CartFileResult.Failure ->
+                snackbar(activity.getString(R.string.cart_export_error, res.message))
+            is CartFileResult.Loaded -> Unit
+        }
+    }
+
+    private fun doImport(uri: Uri) {
+        when (val res = exporter.import(uri)) {
+            is CartFileResult.Loaded -> {
+                viewModel.setCurrent(res.cart)
+                snackbar(activity.getString(R.string.cart_import_ok))
+            }
+            is CartFileResult.Failure ->
+                snackbar(activity.getString(R.string.cart_import_error, res.message))
+            is CartFileResult.Success -> Unit
+        }
+    }
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartFooterBinding.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartFooterBinding.kt
@@ -1,0 +1,176 @@
+package com.eliormachlev.currencix.view.cart
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.StringRes
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.model.Currency
+import com.eliormachlev.currencix.util.feeStackDelta
+import com.eliormachlev.currencix.util.formatCartAmount
+import com.eliormachlev.currencix.util.isNeutralFeeStack
+import com.eliormachlev.currencix.util.toCartFeePercentDisplay
+import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
+import java.math.BigDecimal
+import java.math.MathContext
+
+/**
+ * Binds the cart footer (subtotal / total rows plus the per-side fee-extra
+ * annotations) to the [CartViewModel]. Owns the 14 footer views so the host
+ * activity only needs to forward LiveData emissions via [onSubtotalChanged] /
+ * [onTotalChanged] / [refreshFeeAnnotations].
+ */
+class CartFooterBinding(
+    root: View,
+    private val ctx: Context,
+    private val viewModel: CartViewModel,
+) {
+    private val subtotalLabel: TextView = root.findViewById(R.id.cart_subtotal_value)
+    private val subtotalExtra: View = root.findViewById(R.id.cart_subtotal_extra)
+    private val subtotalExtraLabel: TextView = root.findViewById(R.id.cart_subtotal_extra_label)
+    private val subtotalExtraValue: TextView = root.findViewById(R.id.cart_subtotal_extra_value)
+    private val subtotalFee: View = root.findViewById(R.id.cart_subtotal_fee)
+    private val subtotalFeeLabel: TextView = root.findViewById(R.id.cart_subtotal_fee_label)
+    private val subtotalFeeValue: TextView = root.findViewById(R.id.cart_subtotal_fee_value)
+    private val feeLine: TextView = root.findViewById(R.id.cart_fee_line)
+    private val totalLabel: TextView = root.findViewById(R.id.cart_total_value)
+    private val totalExtra: View = root.findViewById(R.id.cart_total_extra)
+    private val totalExtraLabel: TextView = root.findViewById(R.id.cart_total_extra_label)
+    private val totalExtraValue: TextView = root.findViewById(R.id.cart_total_extra_value)
+    private val totalFee: View = root.findViewById(R.id.cart_total_fee)
+    private val totalFeeLabel: TextView = root.findViewById(R.id.cart_total_fee_label)
+    private val totalFeeValue: TextView = root.findViewById(R.id.cart_total_fee_value)
+
+    fun onSubtotalChanged(value: BigDecimal?) {
+        subtotalLabel.text = ctx.formatCartAmount(value, viewModel.getBaseCurrency().value)
+        updateFeeExtras()
+    }
+
+    fun onTotalChanged(value: BigDecimal?) {
+        totalLabel.text = ctx.formatCartAmount(value, viewModel.getDestinationCurrency().value)
+        updateFeeExtras()
+    }
+
+    /**
+     * Re-render every fee-driven row when either the fee list or the cart's
+     * currencies change — both the combined-percent line and the per-side
+     * annotations depend on that state.
+     */
+    fun refreshFeeAnnotations() {
+        updateFeeLine()
+        updateFeeExtras()
+    }
+
+    private fun updateFeeLine() {
+        // Only surface the combined percent when *both* sides carry a fee —
+        // otherwise the per-side annotation block already spells out the same
+        // number ("Fee: +2%") and this row is a duplicate.
+        val stacks = viewModel.currentSideStacks()
+        val bothSides = !stacks.original.isNeutralFeeStack() && !stacks.converted.isNeutralFeeStack()
+        if (!bothSides) {
+            feeLine.visibility = View.GONE
+            return
+        }
+        feeLine.text = ctx.getString(R.string.cart_fee_line, stacks.combined.toCartFeePercentDisplay())
+        feeLine.visibility = View.VISIBLE
+    }
+
+    /**
+     * Show both anchor values for each per-side fee: the fee amount itself
+     * ("Conversion fee" / "Reduction fee") and the effective total-with-fee /
+     * pre-fee value ("Cost with fee" / "Value before fee"). Ordering matches
+     * the on-screen layout: fee then cost-with-fee on ORIGINAL; value-before-
+     * fee then reduction-fee on CONVERTED. Either or both blocks may hide.
+     */
+    private fun updateFeeExtras() {
+        val stacks = viewModel.currentSideStacks()
+        val baseCurrency = viewModel.getBaseCurrency().value
+        val destCurrency = viewModel.getDestinationCurrency().value
+        val subtotal = viewModel.getSubtotal().value
+        val total = viewModel.getTotal().value
+        renderFeeExtraRow(
+            subtotalFee,
+            subtotalFeeLabel,
+            subtotalFeeValue,
+            R.string.fee_true_cost_prefix,
+            stacks.original,
+            subtotal,
+            baseCurrency,
+            FeeRowMode.DELTA,
+        )
+        renderFeeExtraRow(
+            subtotalExtra,
+            subtotalExtraLabel,
+            subtotalExtraValue,
+            R.string.fee_cost_with_fee_prefix,
+            stacks.original,
+            subtotal,
+            baseCurrency,
+            FeeRowMode.TOTAL,
+        )
+        renderFeeExtraRow(
+            totalExtra,
+            totalExtraLabel,
+            totalExtraValue,
+            R.string.fee_value_before_fee_prefix,
+            stacks.converted,
+            total,
+            destCurrency,
+            FeeRowMode.TOTAL,
+        )
+        renderFeeExtraRow(
+            totalFee,
+            totalFeeLabel,
+            totalFeeValue,
+            R.string.fee_original_value_prefix,
+            stacks.converted,
+            total,
+            destCurrency,
+            FeeRowMode.DELTA,
+        )
+    }
+
+    // Hidden when the [stack] is trivial. TOTAL renders `base * stack` (the
+    // effective with-fee cost or pre-fee value); DELTA renders `|base *
+    // (stack - 1)|` (the fee magnitude — the percent tail already carries
+    // the sign so we avoid a double negative). Only DELTA rows show the
+    // percent — TOTAL rows sit next to a DELTA row that already spells it
+    // out, so restating it here would just be a duplicate.
+    private fun renderFeeExtraRow(
+        container: View,
+        labelView: TextView,
+        valueView: TextView,
+        @StringRes prefixRes: Int,
+        stack: BigDecimal,
+        base: BigDecimal?,
+        currency: Currency?,
+        mode: FeeRowMode,
+    ) {
+        if (stack.isNeutralFeeStack()) {
+            container.visibility = View.GONE
+            return
+        }
+        val multiplier =
+            when (mode) {
+                FeeRowMode.TOTAL -> stack
+                FeeRowMode.DELTA -> stack.feeStackDelta()
+            }
+        val raw = (base ?: BigDecimal.ZERO).multiply(multiplier, MathContext.DECIMAL128)
+        val adjusted = if (mode == FeeRowMode.DELTA) raw.abs() else raw
+        labelView.text = stripLabelSeparator(ctx.getString(prefixRes))
+        val amountText = ctx.formatCartAmount(adjusted, currency)
+        valueView.text =
+            when (mode) {
+                FeeRowMode.TOTAL -> amountText
+                FeeRowMode.DELTA -> ctx.getString(R.string.cart_fee_extra_value, amountText, stack.toCartFeePercentDisplay())
+            }
+        container.visibility = View.VISIBLE
+    }
+
+    private enum class FeeRowMode { TOTAL, DELTA }
+
+    // Existing prefix strings end with a locale-specific ": " / " : " / "：" for
+    // inline use. When we're showing them as a standalone left-aligned label,
+    // strip the trailing separator so it doesn't dangle before the right column.
+    private fun stripLabelSeparator(text: String): String = text.trimEnd(' ', '\u00A0', ':', '：')
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartKeypadController.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartKeypadController.kt
@@ -1,0 +1,465 @@
+package com.eliormachlev.currencix.view.cart
+
+import android.content.Context
+import android.graphics.Rect
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatButton
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.model.KeyboardType
+import com.eliormachlev.currencix.util.CALC_TOKEN_REGEX
+import com.eliormachlev.currencix.util.OPERATOR_REGEX
+import com.eliormachlev.currencix.util.asciiToDisplayGlyphs
+import com.eliormachlev.currencix.util.hapticTap
+import com.eliormachlev.currencix.util.paintParenCycle
+import com.eliormachlev.currencix.viewmodel.main.CalculatorInputState
+
+// Duration of the slide-in / slide-out animation for the cart keypad.
+private const val KEYPAD_ANIM_MS = 180L
+
+// Grace window on outside taps before closing the keypad: a tap that lands on
+// another row's expression must run through Compose's click handler first so
+// it can swap the active id — otherwise we'd close, then re-open with an
+// unwanted flicker.
+private const val OUTSIDE_TAP_DEBOUNCE_MS = 40L
+
+// Fraction of the keypad container's height a drag-down must clear before
+// release commits the dismissal. Below this we snap back — matches the
+// behaviour of Material bottom sheets.
+private const val KEYPAD_DRAG_DISMISS_FRACTION = 0.35f
+
+/**
+ * Owns the slide-up cart keypad: view refs, active-row bookkeeping, IME
+ * coordination, drag-to-dismiss, and the touch-dispatch overrides. The host
+ * activity keeps the `android:onClick` reflection targets (LayoutInflater
+ * resolves those against the Activity) and forwards each press through
+ * [forwardKeypadAction].
+ *
+ * `activeItemId` and `liveExpression` are exposed for the compose row to
+ * observe (active-row highlight + inline display), and [onExpressionCommit] is
+ * invoked whenever a keypad session ends so the host can push the buffered
+ * value into the view model.
+ */
+class CartKeypadController(
+    private val activity: AppCompatActivity,
+    private val itemsView: ComposeView,
+    keyboardType: LiveData<KeyboardType>,
+    private val hapticEnabled: () -> Boolean,
+    private val onExpressionCommit: (id: String, expression: String) -> Unit,
+    private val dispatchCancel: (MotionEvent) -> Unit,
+) {
+    private val keypadContainer: ViewGroup = activity.findViewById(R.id.cart_keypad_container)
+    private val keypadRegular: View = activity.findViewById(R.id.cart_keypad_regular)
+    private val keypadExtended: View = activity.findViewById(R.id.cart_keypad_extended)
+    private val contentColumn: View = activity.findViewById(R.id.cart_content)
+
+    val activeItemId = MutableLiveData<String?>(null)
+    val liveExpression = MutableLiveData("")
+
+    private var currentKeyboardType: KeyboardType = KeyboardType.DEFAULT
+    private var activeCalculatorState: CalculatorInputState? = null
+    private var activeStateObserver: Observer<String?>? = null
+    private var activeParenObserver: Observer<Char>? = null
+    private val keypadBackCallback: OnBackPressedCallback
+
+    // Rising-edge latch for the IME-visibility guard; see [installImeVisibilityGuard].
+    private var systemImeVisible = false
+
+    // Drag-to-dismiss state — only meaningful once ACTION_DOWN lands inside
+    // the keypad and the pointer travels far enough downward to cross
+    // [touchSlop]. [keypadDragStartY] is null when no candidate gesture is
+    // being tracked; [keypadDragActive] flips true once slop is crossed and
+    // the child buttons have been sent an ACTION_CANCEL.
+    private var keypadDragStartY: Float? = null
+    private var keypadDragActive = false
+    private val touchSlop: Int by lazy { ViewConfiguration.get(activity).scaledTouchSlop }
+
+    init {
+        installImeVisibilityGuard()
+        keypadBackCallback =
+            object : OnBackPressedCallback(false) {
+                override fun handleOnBackPressed() = closeKeypad()
+            }.also { activity.onBackPressedDispatcher.addCallback(activity, it) }
+        keyboardType.observe(activity) { type ->
+            currentKeyboardType = type
+            val extended = type == KeyboardType.EXPANDED
+            keypadRegular.visibility = if (extended) View.GONE else View.VISIBLE
+            keypadExtended.visibility = if (extended) View.VISIBLE else View.GONE
+        }
+    }
+
+    /**
+     * Show the keypad for the row identified by [itemId], seeding a fresh
+     * [CalculatorInputState] with [seedExpression] and mirroring every state
+     * change into [liveExpression] — the composable row observes that
+     * LiveData for its inline display.
+     *
+     * In either system-IME mode there is no in-app keypad to raise; the
+     * row itself hosts an EditText once it becomes active, so we just seed
+     * [liveExpression] and flip [activeItemId] — the composable does the rest
+     * (focus request + IME show).
+     */
+    fun openKeypadFor(
+        itemId: String,
+        seedExpression: String,
+    ) {
+        if (currentKeyboardType.isSystem) {
+            if (activeItemId.value == itemId) return
+            detachActiveField()
+            liveExpression.value = seedExpression
+            activeItemId.value = itemId
+            return
+        }
+        hideSystemIme()
+        detachActiveField()
+        val state = CalculatorInputState().apply { seedExpression(seedExpression) }
+        liveExpression.value = state.toExpressionString().ifEmpty { seedExpression }
+        val observer = Observer<String?> { liveExpression.value = state.toExpressionString() }
+        state.baseValueText.observeForever(observer)
+        state.calculationValueText.observeForever(observer)
+        val parenObserver = Observer<Char> { next -> parenButton()?.paintParenCycle(next) }
+        state.nextParen.observeForever(parenObserver)
+        activeCalculatorState = state
+        activeItemId.value = itemId
+        activeStateObserver = observer
+        activeParenObserver = parenObserver
+        showKeypad()
+    }
+
+    /** Hide the keypad and unbind whichever row was being edited. */
+    fun closeKeypad() {
+        if (activeItemId.value == null && keypadContainer.visibility == View.GONE) return
+        detachActiveField()
+        hideKeypad()
+    }
+
+    // Bridge each keystroke from the row's inline EditText (ASCII) back into
+    // [liveExpression] (display glyphs) so the row's preview + eventual commit
+    // see the same round-tripped form the in-app keypad produces.
+    fun onInlineExpressionChanged(
+        id: String,
+        ascii: String,
+    ) {
+        if (activeItemId.value != id) return
+        val glyphs = ascii.asciiToDisplayGlyphs()
+        if (liveExpression.value == glyphs) return
+        liveExpression.value = glyphs
+    }
+
+    fun dismissKeyboards() {
+        // closeKeypad already detaches for the in-app keypad; the else branch
+        // covers system-IME mode (no keypad) so the active row's typed value
+        // commits and its EditText tears down.
+        if (keypadContainer.visibility == View.VISIBLE) {
+            closeKeypad()
+        } else if (activeItemId.value != null) {
+            detachActiveField()
+        }
+        if (systemImeVisible) {
+            hideSystemIme()
+            activity.currentFocus?.clearFocus()
+        }
+    }
+
+    /** Commit whichever expression is currently buffered on the active row. */
+    fun flushActiveExpression() {
+        val id = activeItemId.value ?: return
+        onExpressionCommit(id, liveExpression.value.orEmpty())
+    }
+
+    /**
+     * Called from the host activity's `dispatchTouchEvent`. Returns true when
+     * the event has been consumed (drag interception) so the caller should
+     * skip its `super.dispatchTouchEvent`.
+     */
+    fun handleTouchEvent(ev: MotionEvent): Boolean {
+        if (keypadContainer.visibility == View.VISIBLE && handleKeypadDrag(ev)) return true
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN) handleOutsideTap(ev)
+        return false
+    }
+
+    // Route each keypad button press through the currently-active state, with
+    // a haptic tap on the button that fired.
+    fun forwardKeypadAction(
+        view: View,
+        action: (CalculatorInputState) -> Unit,
+    ) {
+        view.hapticTap(hapticEnabled())
+        activeCalculatorState?.let(action)
+    }
+
+    // Only one keyboard should be visible at a time. `openKeypadFor` calls
+    // `hideSystemIme` when opening the app keypad; this listener handles the
+    // reverse — when the system IME rises (e.g. a row's name field takes
+    // focus while the app keypad is open), dismiss the app keypad. Rising-edge
+    // tracking via [systemImeVisible] avoids retriggering `closeKeypad` on
+    // redundant inset dispatches while the IME stays visible.
+    //
+    // Installing our own listener on cart_root disables its `fitsSystemWindows`
+    // auto-padding (that's how the view API works — a custom listener takes
+    // over), so we re-apply the system-bar insets as padding ourselves. Without
+    // this the toolbar slides under the status bar.
+    private fun installImeVisibilityGuard() {
+        val root = activity.findViewById<View>(R.id.cart_root)
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+            if (imeVisible && !systemImeVisible && keypadContainer.visibility == View.VISIBLE) {
+                closeKeypad()
+            }
+            systemImeVisible = imeVisible
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+            insets
+        }
+    }
+
+    // The `()` cycle-toggle key on the extended keypad. Absent from the basic
+    // layout, so callers must tolerate null.
+    private fun parenButton(): AppCompatButton? = keypadExtended.findViewById(R.id.btn_parens)
+
+    private fun showKeypad() {
+        keypadBackCallback.isEnabled = true
+        if (keypadContainer.visibility == View.VISIBLE) return
+        keypadContainer.visibility = View.VISIBLE
+        keypadContainer.translationY = keypadContainer.height.toFloat().takeIf { it > 0f }
+            ?: activity.resources.displayMetrics.heightPixels
+                .toFloat()
+        keypadContainer
+            .animate()
+            .translationY(0f)
+            .setDuration(KEYPAD_ANIM_MS)
+            .start()
+        // Leave the totals card / add-item button pinned to the bottom of the
+        // screen (behind the keypad) and only inset the items list so its
+        // Compose content stops at the keypad's top edge instead of rendering
+        // underneath. Keeps the summary from being pushed above the keypad.
+        setItemsBottomInsetForKeypad()
+    }
+
+    private fun hideKeypad() {
+        keypadBackCallback.isEnabled = false
+        if (keypadContainer.visibility != View.VISIBLE) return
+        keypadContainer
+            .animate()
+            .translationY(keypadContainer.height.toFloat())
+            .setDuration(KEYPAD_ANIM_MS)
+            .withEndAction { keypadContainer.visibility = View.GONE }
+            .start()
+        setItemsBottomInset(0)
+    }
+
+    private fun setItemsBottomInsetForKeypad() {
+        val apply = {
+            val keypadH =
+                keypadContainer.height.takeIf { it > 0 }
+                    ?: keypadContainer.layoutParams.height
+            // keypad is anchored to the bottom of cart_root; cart_content fills
+            // the same area, so its own height is our reference. The overlap
+            // is the amount by which the items view extends behind the keypad
+            // once the fixed footer (add button + totals card) has taken its
+            // own space at the bottom.
+            val overlap = itemsView.bottom - (contentColumn.height - keypadH)
+            setItemsBottomInset(overlap.coerceAtLeast(0))
+        }
+        if (keypadContainer.height > 0 && itemsView.height > 0) {
+            apply()
+        } else {
+            keypadContainer.post(apply)
+        }
+    }
+
+    private fun setItemsBottomInset(bottom: Int) {
+        itemsView.setPadding(
+            itemsView.paddingLeft,
+            itemsView.paddingTop,
+            itemsView.paddingRight,
+            bottom,
+        )
+    }
+
+    private fun detachActiveField() {
+        val state = activeCalculatorState
+        val observer = activeStateObserver
+        if (state != null && observer != null) {
+            state.baseValueText.removeObserver(observer)
+            state.calculationValueText.removeObserver(observer)
+        }
+        val parenObserver = activeParenObserver
+        if (state != null && parenObserver != null) {
+            state.nextParen.removeObserver(parenObserver)
+        }
+        // Reset the paren button to its rest state — `(` is the only sensible
+        // next glyph when no field is being edited.
+        parenButton()?.paintParenCycle('(')
+        // Commit the current keypad expression to the VM so the row's
+        // persisted value matches what the user just typed.
+        val id = activeItemId.value
+        if (id != null) {
+            val expression = liveExpression.value.orEmpty()
+            onExpressionCommit(id, expression)
+        }
+        activeCalculatorState = null
+        activeItemId.value = null
+        activeStateObserver = null
+        activeParenObserver = null
+        liveExpression.value = ""
+    }
+
+    // Only owns taps outside the items ComposeView (toolbar, totals card,
+    // add-item button when the IME is up). Taps inside the items view are
+    // resolved by Compose in [CartItemsList] via onBackgroundTap.
+    private fun handleOutsideTap(ev: MotionEvent) {
+        val x = ev.rawX.toInt()
+        val y = ev.rawY.toInt()
+        val itemsRect = Rect().also(itemsView::getGlobalVisibleRect)
+        if (itemsRect.contains(x, y)) return
+        if (keypadContainer.visibility == View.VISIBLE) {
+            val keypadRect = Rect().also(keypadContainer::getGlobalVisibleRect)
+            if (keypadRect.contains(x, y)) return
+            val stillOn = activeItemId.value
+            keypadContainer.postDelayed({
+                if (activeItemId.value == stillOn && stillOn != null) closeKeypad()
+            }, OUTSIDE_TAP_DEBOUNCE_MS)
+        } else if (systemImeVisible) {
+            dismissKeyboards()
+        }
+    }
+
+    /**
+     * Vertical drag-to-dismiss: once a downward gesture starting inside the
+     * keypad crosses touch slop, steal it from the buttons (by dispatching
+     * ACTION_CANCEL), track the finger via [ViewGroup.setTranslationY], and
+     * either commit the dismiss ([KEYPAD_DRAG_DISMISS_FRACTION]) or snap back
+     * on release. Returns true once the gesture has been intercepted so the
+     * activity's super-dispatch is skipped for the rest of the stream.
+     */
+    private fun handleKeypadDrag(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                val rect = Rect().also(keypadContainer::getGlobalVisibleRect)
+                if (rect.contains(ev.rawX.toInt(), ev.rawY.toInt())) {
+                    keypadDragStartY = ev.rawY
+                    keypadDragActive = false
+                }
+                return false
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val start = keypadDragStartY ?: return false
+                val delta = ev.rawY - start
+                if (!keypadDragActive && delta > touchSlop) {
+                    keypadDragActive = true
+                    // Cancel the child press so no button fires when the
+                    // finger lifts — from here on the gesture is a drag.
+                    val cancel = MotionEvent.obtain(ev).also { it.action = MotionEvent.ACTION_CANCEL }
+                    dispatchCancel(cancel)
+                    cancel.recycle()
+                }
+                if (keypadDragActive) {
+                    keypadContainer.translationY = delta.coerceAtLeast(0f)
+                    return true
+                }
+                return false
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (!keypadDragActive) {
+                    keypadDragStartY = null
+                    return false
+                }
+                val dragged = keypadContainer.translationY
+                val threshold = keypadContainer.height * KEYPAD_DRAG_DISMISS_FRACTION
+                if (dragged >= threshold) {
+                    // closeKeypad → hideKeypad animates from the current
+                    // translationY (which we just set) back down to full
+                    // height, so the release picks up exactly where the
+                    // finger left off.
+                    closeKeypad()
+                } else {
+                    keypadContainer.animate().cancel()
+                    keypadContainer
+                        .animate()
+                        .translationY(0f)
+                        .setDuration(KEYPAD_ANIM_MS)
+                        .start()
+                }
+                keypadDragActive = false
+                keypadDragStartY = null
+                return true
+            }
+            else -> return false
+        }
+    }
+
+    private fun hideSystemIme() {
+        val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager ?: return
+        val token = activity.currentFocus?.windowToken ?: activity.window.decorView.windowToken ?: return
+        imm.hideSoftInputFromWindow(token, 0)
+    }
+}
+
+/**
+ * Rebuild the input state from a previously-saved cart-row expression so the
+ * keypad opens where the user left off. Empty input leaves the state at its
+ * default "0" seed.
+ */
+private fun CalculatorInputState.seedExpression(expression: String) {
+    val trimmed = expression.trim()
+    if (trimmed.isEmpty()) return
+    if (!trimmed.contains(CALC_TOKEN_REGEX)) {
+        replayDigits(trimmed)
+        return
+    }
+    // Split on operator/paren boundaries while keeping each structural token
+    // as its own entry — mirrors how the state serialises them back out.
+    val tokens = mutableListOf<String>()
+    val buf = StringBuilder()
+    trimmed.forEach { ch ->
+        if (ch.toString().matches(CALC_TOKEN_REGEX)) {
+            if (buf.isNotBlank()) tokens += buf.toString().trim()
+            tokens += ch.toString()
+            buf.clear()
+        } else {
+            buf.append(ch)
+        }
+    }
+    if (buf.isNotBlank()) tokens += buf.toString().trim()
+    // The digit-replay API is state-aware — it targets the base row before
+    // the first operator and the calculation row afterwards — so every
+    // operand goes through the same path.
+    tokens.forEach { token ->
+        when {
+            token == "(" -> addOpenParen()
+            token == ")" -> addCloseParen()
+            token.matches(OPERATOR_REGEX) -> addOperator(token)
+            else -> replayDigits(token)
+        }
+    }
+}
+
+private fun CalculatorInputState.replayDigits(number: String) {
+    number.forEach { ch ->
+        when {
+            ch.isDigit() -> addNumber(ch.toString())
+            ch == '.' -> addDecimal()
+        }
+    }
+}
+
+/**
+ * Serialise the current input state back to a string the cart layer can
+ * store and later evaluate (matches the expression format cart rows use).
+ */
+private fun CalculatorInputState.toExpressionString(): String {
+    val calc = calculationValueText.value
+    return if (calc.isNullOrBlank()) baseValueText.value.orEmpty() else calc.trim()
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartKeypadController.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartKeypadController.kt
@@ -190,8 +190,10 @@ class CartKeypadController(
     }
 
     // Route each keypad button press through the currently-active state, with
-    // a haptic tap on the button that fired.
-    fun forwardKeypadAction(
+    // a haptic tap on the button that fired. Internal because
+    // [CalculatorInputState] is module-scoped — callers are all in the same
+    // module (the reflection targets on [CartActivity]).
+    internal fun forwardKeypadAction(
         view: View,
         action: (CalculatorInputState) -> Unit,
     ) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
@@ -1,0 +1,206 @@
+package com.eliormachlev.currencix.view.cart
+
+import android.widget.EditText
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.model.SavedCart
+import com.eliormachlev.currencix.view.cart.compose.SavedCartsList
+import com.eliormachlev.currencix.view.compose.AppTheme
+import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
+
+/**
+ * Owns the Save / Save-as / Load / Rename / Delete flows plus the
+ * unsaved-changes prompt that gates destructive transitions (loading another
+ * cart, closing the screen). Persistence is delegated to [CartViewModel];
+ * this class only mediates the dialog UX.
+ */
+class CartSaveLoadCoordinator(
+    private val activity: AppCompatActivity,
+    private val viewModel: CartViewModel,
+    private val flushPendingCommits: () -> Unit,
+    private val snackbar: (String) -> Unit,
+) {
+    fun attemptClose() = confirmUnsavedThen { activity.finish() }
+
+    /**
+     * "Save" menu action — overwrites the current saved cart in-place. Falls
+     * back to Save-as when there's nothing to overwrite (never saved yet).
+     */
+    fun saveOrPromptForName(onSaved: () -> Unit = {}) {
+        if (guardEmptyForSave()) return
+        flushPendingCommits()
+        if (viewModel.saveCurrent()) {
+            val name =
+                viewModel
+                    .getCurrentCart()
+                    .value
+                    ?.name
+                    .orEmpty()
+            snackbar(activity.getString(R.string.cart_saved_toast, name))
+            onSaved()
+        } else {
+            showSaveAsDialog(onSaved = onSaved)
+        }
+    }
+
+    fun showSaveAsDialog(onSaved: () -> Unit = {}) {
+        if (guardEmptyForSave()) return
+        showNameInputDialog(
+            titleRes = R.string.cart_menu_save_as,
+            initial =
+                viewModel
+                    .getCurrentCart()
+                    .value
+                    ?.name
+                    .orEmpty(),
+        ) { name ->
+            // "Save as" always creates a fresh entry so users can keep
+            // multiple snapshots of the same cart under different names.
+            flushPendingCommits()
+            viewModel.saveCurrentAs(name)
+            snackbar(activity.getString(R.string.cart_saved_toast, name))
+            onSaved()
+        }
+    }
+
+    fun showLoadDialog() {
+        val initial = viewModel.getSavedCartsSnapshot()
+        if (initial.isEmpty()) {
+            snackbar(activity.getString(R.string.cart_no_saved))
+            return
+        }
+        val saved = mutableStateListOf<SavedCart>().apply { addAll(initial) }
+        lateinit var dialog: AlertDialog
+        val composeView =
+            ComposeView(activity).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                setContent {
+                    AppTheme {
+                        SavedCartsList(
+                            items = saved,
+                            onPick = { cart ->
+                                dialog.dismiss()
+                                confirmUnsavedThen { viewModel.loadSaved(cart.id) }
+                            },
+                            onRename = { cart ->
+                                showNameInputDialog(
+                                    titleRes = R.string.cart_rename_title,
+                                    initial = cart.name,
+                                ) { name ->
+                                    viewModel.renameSaved(cart.id, name)
+                                    val idx = saved.indexOfFirst { it.id == cart.id }
+                                    if (idx >= 0) saved[idx] = cart.copy(name = name)
+                                }
+                            },
+                            onDelete = { cart ->
+                                AlertDialog
+                                    .Builder(activity)
+                                    .setTitle(cart.name.ifBlank { cart.id.take(8) })
+                                    .setMessage(activity.getString(R.string.cart_delete_confirm, cart.name))
+                                    .setPositiveButton(R.string.cart_delete_confirm_button) { _, _ ->
+                                        viewModel.deleteSaved(cart.id)
+                                        saved.removeAll { it.id == cart.id }
+                                        if (saved.isEmpty()) dialog.dismiss()
+                                    }.setNegativeButton(android.R.string.cancel, null)
+                                    .show()
+                            },
+                        )
+                    }
+                }
+            }
+        dialog =
+            AlertDialog
+                .Builder(activity)
+                .setTitle(R.string.cart_menu_load)
+                .setView(composeView)
+                .setNegativeButton(android.R.string.cancel, null)
+                .create()
+        dialog.show()
+    }
+
+    // Refuse to persist an empty cart — matches Share's "nothing to share"
+    // guard so both write paths behave consistently. Returns true when the
+    // caller should abort.
+    private fun guardEmptyForSave(): Boolean {
+        val items = viewModel.getCurrentCart().value?.items
+        if (items.isNullOrEmpty()) {
+            snackbar(activity.getString(R.string.cart_save_empty))
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Gate a destructive action (switching carts, closing the screen) behind
+     * an unsaved-changes prompt. Presents Save (overwrite — only when the
+     * cart has a persisted counterpart), Save as (new entry), Continue
+     * (discard), and Cancel (abort). Each save path invokes [action] after
+     * the write completes.
+     */
+    private fun confirmUnsavedThen(action: () -> Unit) {
+        // An empty cart has nothing worth saving, so skip the prompt entirely
+        // even if a persisted counterpart differs — the destructive action
+        // would just replace an empty working set with something else.
+        val items = viewModel.getCurrentCart().value?.items
+        if (items.isNullOrEmpty() || !viewModel.hasUnsavedChanges()) {
+            action()
+            return
+        }
+        val canOverwrite =
+            viewModel
+                .getCurrentCart()
+                .value
+                ?.id
+                ?.isNotEmpty() == true
+        val options = mutableListOf<Pair<String, () -> Unit>>()
+        if (canOverwrite) {
+            options += activity.getString(R.string.cart_unsaved_save) to { saveOrPromptForName(action) }
+        }
+        options += activity.getString(R.string.cart_unsaved_save_as) to { showSaveAsDialog(onSaved = action) }
+        options += activity.getString(R.string.cart_unsaved_discard) to {
+            viewModel.discardChanges()
+            action()
+        }
+        options += activity.getString(R.string.cart_unsaved_continue) to action
+        AlertDialog
+            .Builder(activity)
+            .setTitle(R.string.cart_unsaved_title)
+            .setItems(options.map { it.first }.toTypedArray()) { _, which ->
+                options[which].second.invoke()
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    // Shared "one-line text input" dialog for cart name prompts (Save-as,
+    // Rename). Blank input collapses to the localised default cart name so
+    // every entry point produces a nameable, findable saved cart.
+    private fun showNameInputDialog(
+        @StringRes titleRes: Int,
+        initial: String,
+        onOk: (String) -> Unit,
+    ) {
+        val input =
+            EditText(activity).apply {
+                hint = activity.getString(R.string.cart_save_name_hint)
+                setText(initial)
+            }
+        AlertDialog
+            .Builder(activity)
+            .setTitle(titleRes)
+            .setView(input)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                onOk(
+                    input.text
+                        .toString()
+                        .trim()
+                        .ifBlank { activity.getString(R.string.cart_default_saved_name) },
+                )
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartShareCoordinator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartShareCoordinator.kt
@@ -1,0 +1,126 @@
+package com.eliormachlev.currencix.view.cart
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.util.buildCartShareChooser
+import com.eliormachlev.currencix.util.filenameTimestampNow
+import com.eliormachlev.currencix.util.isNeutralFeeStack
+import com.eliormachlev.currencix.util.sanitizeForFilename
+import com.eliormachlev.currencix.util.toCartDisplayString
+import com.eliormachlev.currencix.util.toCartFeePercentDisplay
+import com.eliormachlev.currencix.util.toCsv
+import com.eliormachlev.currencix.util.toPdfBytes
+import com.eliormachlev.currencix.viewmodel.cart.CartSnapshot
+import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
+
+private const val CSV_MIME = "text/csv"
+private const val CSV_EXT = ".csv"
+private const val PDF_MIME = "application/pdf"
+private const val PDF_EXT = ".pdf"
+
+/**
+ * Presents the Share picker and dispatches to the selected format
+ * (plain-text / CSV / PDF). Snapshots the cart before showing the picker so
+ * every option renders the same numbers even if the user keeps typing.
+ */
+class CartShareCoordinator(
+    private val activity: AppCompatActivity,
+    private val viewModel: CartViewModel,
+    private val flushPendingCommits: () -> Unit,
+    private val snackbar: (String) -> Unit,
+) {
+    fun show() {
+        flushPendingCommits()
+        val snapshot = viewModel.snapshotForShare()
+        if (snapshot == null) {
+            snackbar(activity.getString(R.string.cart_share_empty))
+            return
+        }
+        activity.showCartChoiceExplainerDialog(
+            titleRes = R.string.menu_share,
+            choices =
+                listOf(
+                    CartChoice(
+                        R.string.cart_share_option_text,
+                        R.string.cart_share_option_text_desc,
+                    ) { shareAsText(snapshot) },
+                    CartChoice(
+                        R.string.cart_share_option_csv,
+                        R.string.cart_share_option_csv_desc,
+                    ) { shareAsCsv(snapshot) },
+                    CartChoice(
+                        R.string.cart_share_option_pdf,
+                        R.string.cart_share_option_pdf_desc,
+                    ) { shareAsPdf(snapshot) },
+                ),
+        )
+    }
+
+    private fun shareAsText(snapshot: CartSnapshot) {
+        val text = buildShareText(snapshot)
+        val intent =
+            Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, text)
+            }
+        activity.startActivity(Intent.createChooser(intent, null))
+    }
+
+    private fun shareAsCsv(snapshot: CartSnapshot) {
+        val title = shareTitle(snapshot)
+        val chooser =
+            buildCartShareChooser(
+                context = activity,
+                filename = shareFilename(title, CSV_EXT),
+                mimeType = CSV_MIME,
+                bytes = snapshot.toCsv(title = title).toByteArray(Charsets.UTF_8),
+            )
+        activity.startActivity(chooser)
+    }
+
+    private fun shareAsPdf(snapshot: CartSnapshot) {
+        val title = shareTitle(snapshot)
+        val chooser =
+            buildCartShareChooser(
+                context = activity,
+                filename = shareFilename(title, PDF_EXT),
+                mimeType = PDF_MIME,
+                bytes = snapshot.toPdfBytes(title = title),
+            )
+        activity.startActivity(chooser)
+    }
+
+    // Cart name if the user has one (from Save-as), otherwise a phone-local
+    // timestamp so the artefact still has an identifying handle.
+    private fun shareTitle(snapshot: CartSnapshot): String = snapshot.cart.name.ifBlank { filenameTimestampNow() }
+
+    private fun shareFilename(
+        title: String,
+        extension: String,
+    ): String = title.sanitizeForFilename() + extension
+
+    private fun buildShareText(snapshot: CartSnapshot): String =
+        buildString {
+            val baseIso = snapshot.baseCurrency.iso4217Alpha()
+            val destIso = snapshot.destinationCurrency.iso4217Alpha()
+            val name = snapshot.cart.name.ifBlank { activity.getString(R.string.cart_share_default_title) }
+            appendLine(activity.getString(R.string.cart_share_header, name, baseIso))
+            snapshot.evaluatedItems.forEach { (item, value) ->
+                val label = item.name.ifBlank { item.expression }
+                appendLine("• $label: ${value.toCartDisplayString()}")
+            }
+            appendLine("—")
+            appendLine(activity.getString(R.string.cart_share_subtotal, snapshot.subtotal.toCartDisplayString(), baseIso))
+            if (snapshot.isConverting) {
+                appendLine(
+                    activity.getString(R.string.cart_share_converted, snapshot.convertedSubtotal.toCartDisplayString(), destIso),
+                )
+            }
+            val combinedStack = snapshot.sideStacks.combined
+            if (!combinedStack.isNeutralFeeStack()) {
+                appendLine(activity.getString(R.string.cart_share_fees, combinedStack.toCartFeePercentDisplay()))
+            }
+            append(activity.getString(R.string.cart_share_total, snapshot.total.toCartDisplayString(), destIso))
+        }
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -283,8 +283,8 @@ class MainActivity : BaseActivity() {
         ): String? = value?.let { buildFeeAmountLine(prefixRes, it, currency, stack) }
         return listOfNotNull(
             line(R.string.fee_true_cost_prefix, viewModel.getOriginalFeeAmount().value, base, stacks?.original),
-            line(R.string.fee_cost_with_fee_prefix, viewModel.getTrueCost().value, base, stacks?.original),
-            line(R.string.fee_value_before_fee_prefix, viewModel.getOriginalValue().value, dest, stacks?.converted),
+            line(R.string.fee_cost_with_fee_prefix, viewModel.getTrueCost().value, base, null),
+            line(R.string.fee_value_before_fee_prefix, viewModel.getOriginalValue().value, dest, null),
             line(R.string.fee_original_value_prefix, viewModel.getConvertedFeeAmount().value, dest, stacks?.converted),
         ).takeIf { it.isNotEmpty() }
             ?.joinToString("\n")
@@ -527,13 +527,16 @@ class MainActivity : BaseActivity() {
         offlineBanner.visibility = View.VISIBLE
     }
 
+    // Cost-with-fee and value-before-fee are companion rows to the
+    // conversion/reduction-fee lines, which already carry the percent tail.
+    // Passing null stack suppresses the duplicate.
     private fun observeTrueCost(value: BigDecimal?) {
         renderFeeAmount(
             target = tvTrueCost,
             prefixRes = R.string.fee_cost_with_fee_prefix,
             value = value,
             currency = viewModel.getBaseCurrency().value,
-            stack = viewModel.getSideStacks().value?.original,
+            stack = null,
         )
     }
 
@@ -543,7 +546,7 @@ class MainActivity : BaseActivity() {
             prefixRes = R.string.fee_value_before_fee_prefix,
             value = value,
             currency = viewModel.getDestinationCurrency().value,
-            stack = viewModel.getSideStacks().value?.converted,
+            stack = null,
         )
     }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -134,6 +134,8 @@ class MainActivity : BaseActivity() {
     private lateinit var tvInfoDate: TextView
     private lateinit var tvTrueCost: TextView
     private lateinit var tvOriginalValue: TextView
+    private lateinit var tvOriginalFeeAmount: TextView
+    private lateinit var tvConvertedFeeAmount: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -158,6 +160,8 @@ class MainActivity : BaseActivity() {
         this.tvInfoDate = findViewById(R.id.textInfoDate)
         this.tvTrueCost = findViewById(R.id.textTrueCost)
         this.tvOriginalValue = findViewById(R.id.textOriginalValue)
+        this.tvOriginalFeeAmount = findViewById(R.id.textOriginalFeeAmount)
+        this.tvConvertedFeeAmount = findViewById(R.id.textConvertedFeeAmount)
         this.offlineBanner = findViewById(R.id.offlineBanner)
         this.offlineBannerText = findViewById(R.id.offlineBannerText)
 
@@ -262,23 +266,28 @@ class MainActivity : BaseActivity() {
         return if (extra != null) "$main\n$extra" else main
     }
 
-    // Small annotation line(s) shown under the shared result: "True cost" on
-    // the ORIGINAL side, "Original value" on the CONVERTED side. Either or
-    // both may apply, so callers get them joined with a newline.
+    // Small annotation line(s) shown under the shared result. Order matches
+    // the on-screen layout: ORIGINAL side surfaces fee then cost-with-fee;
+    // CONVERTED side surfaces value-before-fee then reduction-fee.
     private fun buildShareFeeExtra(
         base: Currency,
         dest: Currency,
     ): String? {
         val stacks = viewModel.getSideStacks().value
-        val trueCost =
-            viewModel.getTrueCost().value?.let {
-                buildFeeAmountLine(R.string.fee_true_cost_prefix, it, base, stacks?.original)
-            }
-        val originalValue =
-            viewModel.getOriginalValue().value?.let {
-                buildFeeAmountLine(R.string.fee_original_value_prefix, it, dest, stacks?.converted)
-            }
-        return listOfNotNull(trueCost, originalValue).takeIf { it.isNotEmpty() }?.joinToString("\n")
+
+        fun line(
+            prefixRes: Int,
+            value: BigDecimal?,
+            currency: Currency,
+            stack: BigDecimal?,
+        ): String? = value?.let { buildFeeAmountLine(prefixRes, it, currency, stack) }
+        return listOfNotNull(
+            line(R.string.fee_true_cost_prefix, viewModel.getOriginalFeeAmount().value, base, stacks?.original),
+            line(R.string.fee_cost_with_fee_prefix, viewModel.getTrueCost().value, base, stacks?.original),
+            line(R.string.fee_value_before_fee_prefix, viewModel.getOriginalValue().value, dest, stacks?.converted),
+            line(R.string.fee_original_value_prefix, viewModel.getConvertedFeeAmount().value, dest, stacks?.converted),
+        ).takeIf { it.isNotEmpty() }
+            ?.joinToString("\n")
     }
 
     private fun buildShareFooter(rates: ExchangeRates?): String? {
@@ -495,6 +504,8 @@ class MainActivity : BaseActivity() {
         viewModel.isHapticFeedbackEnabled.observe(this) { hapticEnabled = it }
         viewModel.getTrueCost().observe(this) { observeTrueCost(it) }
         viewModel.getOriginalValue().observe(this) { observeOriginalValue(it) }
+        viewModel.getOriginalFeeAmount().observe(this) { observeOriginalFeeAmount(it) }
+        viewModel.getConvertedFeeAmount().observe(this) { observeConvertedFeeAmount(it) }
         NetworkStatusLiveData(this).observe(this) { online ->
             isOnline = online
             renderOfflineBanner()
@@ -519,7 +530,7 @@ class MainActivity : BaseActivity() {
     private fun observeTrueCost(value: BigDecimal?) {
         renderFeeAmount(
             target = tvTrueCost,
-            prefixRes = R.string.fee_true_cost_prefix,
+            prefixRes = R.string.fee_cost_with_fee_prefix,
             value = value,
             currency = viewModel.getBaseCurrency().value,
             stack = viewModel.getSideStacks().value?.original,
@@ -529,6 +540,26 @@ class MainActivity : BaseActivity() {
     private fun observeOriginalValue(value: BigDecimal?) {
         renderFeeAmount(
             target = tvOriginalValue,
+            prefixRes = R.string.fee_value_before_fee_prefix,
+            value = value,
+            currency = viewModel.getDestinationCurrency().value,
+            stack = viewModel.getSideStacks().value?.converted,
+        )
+    }
+
+    private fun observeOriginalFeeAmount(value: BigDecimal?) {
+        renderFeeAmount(
+            target = tvOriginalFeeAmount,
+            prefixRes = R.string.fee_true_cost_prefix,
+            value = value,
+            currency = viewModel.getBaseCurrency().value,
+            stack = viewModel.getSideStacks().value?.original,
+        )
+    }
+
+    private fun observeConvertedFeeAmount(value: BigDecimal?) {
+        renderFeeAmount(
+            target = tvConvertedFeeAmount,
             prefixRes = R.string.fee_original_value_prefix,
             value = value,
             currency = viewModel.getDestinationCurrency().value,
@@ -635,6 +666,7 @@ class MainActivity : BaseActivity() {
         // arrival (e.g. process restart, DB load after trueCost fires) still
         // paints the "$" marker.
         observeTrueCost(viewModel.getTrueCost().value)
+        observeOriginalFeeAmount(viewModel.getOriginalFeeAmount().value)
         currency ?: return
         findRateFor(currency)?.let { spinnerTo.setCurrentRate(Rate(currency, it)) }
     }
@@ -643,6 +675,7 @@ class MainActivity : BaseActivity() {
         spinnerTo.setSelection(currency)
         spinnerFrom.setDisabledCurrency(currency)
         observeOriginalValue(viewModel.getOriginalValue().value)
+        observeConvertedFeeAmount(viewModel.getConvertedFeeAmount().value)
         currency ?: return
         findRateFor(currency)?.let { spinnerFrom.setCurrentRate(Rate(currency, it)) }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
@@ -16,12 +16,12 @@ import com.eliormachlev.currencix.model.SideStacks
 import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.view.compose.AppTheme
-import com.eliormachlev.currencix.view.main.compose.FeeRowPrefixes
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsContent
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsRow
 import com.eliormachlev.currencix.view.main.compose.buildQuickConversionRows
 import com.eliormachlev.currencix.view.preference.PreferenceActivity
 import com.eliormachlev.currencix.viewmodel.main.MainViewModel
+import java.math.BigDecimal
 import java.math.RoundingMode
 
 private const val FEE_PERCENT_DECIMAL_PLACES = 2
@@ -30,13 +30,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val ctx = requireContext()
         val viewModel = ViewModelProvider(requireActivity())[MainViewModel::class.java]
-        val prefixes =
-            FeeRowPrefixes(
-                fee = getString(R.string.fee_true_cost_prefix),
-                costWithFee = getString(R.string.fee_cost_with_fee_prefix),
-                valueBeforeFee = getString(R.string.fee_value_before_fee_prefix),
-                reduction = getString(R.string.fee_original_value_prefix),
-            )
+        val costWithFeePrefix = getString(R.string.fee_cost_with_fee_prefix)
         val emptyText = getString(R.string.quick_conversions_no_rates)
 
         val view =
@@ -68,27 +62,12 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
                                     to = to!!,
                                     rates = rates!!,
                                     sideStacks = stacks,
-                                    prefixes = prefixes,
+                                    costWithFeePrefix = costWithFeePrefix,
                                 )
                             } else {
                                 emptyList()
                             }
-                        val combined = stacks.combined
-                        val feeInfoText =
-                            if (!combined.isNeutralFeeStack()) {
-                                val percent =
-                                    combined.feePercentDelta(
-                                        FEE_PERCENT_DECIMAL_PLACES,
-                                        RoundingMode.HALF_UP,
-                                    )
-                                val sign = if (percent.signum() >= 0) "+" else ""
-                                getString(
-                                    R.string.quick_conversions_fees_applied,
-                                    "$sign$percent%",
-                                )
-                            } else {
-                                null
-                            }
+                        val feeInfoText = buildFeeInfoText(stacks.original, stacks.converted)
                         QuickConversionsContent(
                             from = from,
                             to = to,
@@ -112,5 +91,31 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
 
     private fun openFeesSettings(ctx: Context) {
         startActivity(PreferenceActivity.feesIntent(ctx))
+    }
+
+    // Split the top-of-dialog "fees applied" line by side so users see which
+    // is the conversion (ORIGINAL) fee vs the reduction (CONVERTED) fee,
+    // instead of a single combined percentage that hides the breakdown.
+    private fun buildFeeInfoText(
+        original: BigDecimal,
+        converted: BigDecimal,
+    ): String? {
+        val parts =
+            listOfNotNull(
+                feeSegment(original, R.string.quick_conversions_fee_conversion),
+                feeSegment(converted, R.string.quick_conversions_fee_reduction),
+            )
+        if (parts.isEmpty()) return null
+        return getString(R.string.quick_conversions_fees_applied, parts.joinToString(", "))
+    }
+
+    private fun feeSegment(
+        stack: BigDecimal,
+        templateRes: Int,
+    ): String? {
+        if (stack.isNeutralFeeStack()) return null
+        val percent = stack.feePercentDelta(FEE_PERCENT_DECIMAL_PLACES, RoundingMode.HALF_UP)
+        val sign = if (percent.signum() >= 0) "+" else ""
+        return getString(templateRes, "$sign$percent%")
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
@@ -16,6 +16,7 @@ import com.eliormachlev.currencix.model.SideStacks
 import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.view.compose.AppTheme
+import com.eliormachlev.currencix.view.main.compose.FeeRowPrefixes
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsContent
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsRow
 import com.eliormachlev.currencix.view.main.compose.buildQuickConversionRows
@@ -29,8 +30,13 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val ctx = requireContext()
         val viewModel = ViewModelProvider(requireActivity())[MainViewModel::class.java]
-        val truePrefix = getString(R.string.fee_true_cost_prefix)
-        val originalPrefix = getString(R.string.fee_original_value_prefix)
+        val prefixes =
+            FeeRowPrefixes(
+                fee = getString(R.string.fee_true_cost_prefix),
+                costWithFee = getString(R.string.fee_cost_with_fee_prefix),
+                valueBeforeFee = getString(R.string.fee_value_before_fee_prefix),
+                reduction = getString(R.string.fee_original_value_prefix),
+            )
         val emptyText = getString(R.string.quick_conversions_no_rates)
 
         val view =
@@ -62,8 +68,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
                                     to = to!!,
                                     rates = rates!!,
                                     sideStacks = stacks,
-                                    truePrefix = truePrefix,
-                                    originalPrefix = originalPrefix,
+                                    prefixes = prefixes,
                                 )
                             } else {
                                 emptyList()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
@@ -44,10 +44,7 @@ private const val ICON_BUTTON_SIZE_DP = 48
 data class QuickConversionsRow(
     val amountFromText: String,
     val amountToText: String,
-    val originalFeeText: String?,
     val costWithFeeText: String?,
-    val valueBeforeFeeText: String?,
-    val convertedFeeText: String?,
 )
 
 @Composable
@@ -207,7 +204,7 @@ private fun QuickConversionsRowUi(row: QuickConversionsRow) {
                 .fillMaxWidth()
                 .padding(vertical = dimensionResource(id = R.dimen.margin1x))
                 // Merge so TalkBack reads "$FROM equals $TO" as one item rather
-                // than swiping through five separate text nodes per row.
+                // than swiping through several separate text nodes per row.
                 .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -219,13 +216,6 @@ private fun QuickConversionsRowUi(row: QuickConversionsRow) {
                 text = row.amountFromText,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            if (row.originalFeeText != null) {
-                Text(
-                    text = row.originalFeeText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
             if (row.costWithFeeText != null) {
                 Text(
                     text = row.costWithFeeText,
@@ -247,20 +237,6 @@ private fun QuickConversionsRowUi(row: QuickConversionsRow) {
             modifier = Modifier.weight(1f),
             horizontalAlignment = Alignment.Start,
         ) {
-            if (row.valueBeforeFeeText != null) {
-                Text(
-                    text = row.valueBeforeFeeText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-            if (row.convertedFeeText != null) {
-                Text(
-                    text = row.convertedFeeText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
             Text(
                 text = row.amountToText,
                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
@@ -44,8 +44,10 @@ private const val ICON_BUTTON_SIZE_DP = 48
 data class QuickConversionsRow(
     val amountFromText: String,
     val amountToText: String,
-    val trueCostText: String?,
-    val originalValueText: String?,
+    val originalFeeText: String?,
+    val costWithFeeText: String?,
+    val valueBeforeFeeText: String?,
+    val convertedFeeText: String?,
 )
 
 @Composable
@@ -217,9 +219,16 @@ private fun QuickConversionsRowUi(row: QuickConversionsRow) {
                 text = row.amountFromText,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            if (row.trueCostText != null) {
+            if (row.originalFeeText != null) {
                 Text(
-                    text = row.trueCostText,
+                    text = row.originalFeeText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            if (row.costWithFeeText != null) {
+                Text(
+                    text = row.costWithFeeText,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.error,
                 )
@@ -238,17 +247,24 @@ private fun QuickConversionsRowUi(row: QuickConversionsRow) {
             modifier = Modifier.weight(1f),
             horizontalAlignment = Alignment.Start,
         ) {
-            Text(
-                text = row.amountToText,
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            if (row.originalValueText != null) {
+            if (row.valueBeforeFeeText != null) {
                 Text(
-                    text = row.originalValueText,
+                    text = row.valueBeforeFeeText,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.error,
                 )
             }
+            if (row.convertedFeeText != null) {
+                Text(
+                    text = row.convertedFeeText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Text(
+                text = row.amountToText,
+                style = MaterialTheme.typography.bodyLarge,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.SideStacks
-import com.eliormachlev.currencix.util.feeStackDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.ltrIsolate
 import com.eliormachlev.currencix.util.toHumanReadableNumber
@@ -17,20 +16,13 @@ private const val ROW_DEFAULT_DECIMALS = 2
 private const val ROW_SMALL_AMOUNT_DECIMALS = 4
 private val ROW_SMALL_AMOUNT_THRESHOLD: BigDecimal = BigDecimal.ONE
 
-data class FeeRowPrefixes(
-    val fee: String,
-    val costWithFee: String,
-    val valueBeforeFee: String,
-    val reduction: String,
-)
-
 fun buildQuickConversionRows(
     ctx: Context,
     from: Currency,
     to: Currency,
     rates: ExchangeRates,
     sideStacks: SideStacks,
-    prefixes: FeeRowPrefixes,
+    costWithFeePrefix: String,
 ): List<QuickConversionsRow> {
     val baseRate = rates.rates?.find { it.currency == from }?.value ?: return emptyList()
     val destRate = rates.rates.find { it.currency == to }?.value ?: return emptyList()
@@ -39,9 +31,6 @@ fun buildQuickConversionRows(
     val fromIso = from.iso4217Alpha()
     val toIso = to.iso4217Alpha()
     val fromMarker = from.symbolOrIso()
-    val toMarker = to.symbolOrIso()
-    val originalDelta = sideStacks.original.feeStackDelta()
-    val convertedDelta = sideStacks.converted.feeStackDelta()
     return QUICK_AMOUNTS.map { amountStr ->
         val amt = BigDecimal(amountStr)
         val fair = amt.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
@@ -51,40 +40,17 @@ fun buildQuickConversionRows(
             } else {
                 fair
             }
-        val originalFee =
-            if (hasOriginalFee) {
-                val fee = amt.multiply(originalDelta, MathContext.DECIMAL128).abs()
-                prefixes.fee + ltrIsolate("${fee.formatForRow(ctx)} $fromMarker")
-            } else {
-                null
-            }
         val costWithFee =
             if (hasOriginalFee) {
                 val actual = amt.multiply(sideStacks.original, MathContext.DECIMAL128)
-                prefixes.costWithFee + ltrIsolate("${actual.formatForRow(ctx)} $fromMarker")
-            } else {
-                null
-            }
-        val valueBeforeFee =
-            if (hasConvertedFee) {
-                prefixes.valueBeforeFee + ltrIsolate("${fair.formatForRow(ctx)} $toMarker")
-            } else {
-                null
-            }
-        val convertedFee =
-            if (hasConvertedFee) {
-                val fee = displayed.multiply(convertedDelta, MathContext.DECIMAL128).abs()
-                prefixes.reduction + ltrIsolate("${fee.formatForRow(ctx)} $toMarker")
+                costWithFeePrefix + ltrIsolate("${actual.formatForRow(ctx)} $fromMarker")
             } else {
                 null
             }
         QuickConversionsRow(
             amountFromText = "$amountStr $fromIso",
             amountToText = "${displayed.formatForRow(ctx)} $toIso",
-            originalFeeText = originalFee,
             costWithFeeText = costWithFee,
-            valueBeforeFeeText = valueBeforeFee,
-            convertedFeeText = convertedFee,
         )
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.SideStacks
+import com.eliormachlev.currencix.util.feeStackDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.ltrIsolate
 import com.eliormachlev.currencix.util.toHumanReadableNumber
@@ -16,14 +17,20 @@ private const val ROW_DEFAULT_DECIMALS = 2
 private const val ROW_SMALL_AMOUNT_DECIMALS = 4
 private val ROW_SMALL_AMOUNT_THRESHOLD: BigDecimal = BigDecimal.ONE
 
+data class FeeRowPrefixes(
+    val fee: String,
+    val costWithFee: String,
+    val valueBeforeFee: String,
+    val reduction: String,
+)
+
 fun buildQuickConversionRows(
     ctx: Context,
     from: Currency,
     to: Currency,
     rates: ExchangeRates,
     sideStacks: SideStacks,
-    truePrefix: String,
-    originalPrefix: String,
+    prefixes: FeeRowPrefixes,
 ): List<QuickConversionsRow> {
     val baseRate = rates.rates?.find { it.currency == from }?.value ?: return emptyList()
     val destRate = rates.rates.find { it.currency == to }?.value ?: return emptyList()
@@ -33,6 +40,8 @@ fun buildQuickConversionRows(
     val toIso = to.iso4217Alpha()
     val fromMarker = from.symbolOrIso()
     val toMarker = to.symbolOrIso()
+    val originalDelta = sideStacks.original.feeStackDelta()
+    val convertedDelta = sideStacks.converted.feeStackDelta()
     return QUICK_AMOUNTS.map { amountStr ->
         val amt = BigDecimal(amountStr)
         val fair = amt.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
@@ -42,24 +51,40 @@ fun buildQuickConversionRows(
             } else {
                 fair
             }
-        val trueCost =
+        val originalFee =
             if (hasOriginalFee) {
-                val actual = amt.multiply(sideStacks.original, MathContext.DECIMAL128)
-                truePrefix + ltrIsolate("${actual.formatForRow(ctx)} $fromMarker")
+                val fee = amt.multiply(originalDelta, MathContext.DECIMAL128).abs()
+                prefixes.fee + ltrIsolate("${fee.formatForRow(ctx)} $fromMarker")
             } else {
                 null
             }
-        val originalValue =
+        val costWithFee =
+            if (hasOriginalFee) {
+                val actual = amt.multiply(sideStacks.original, MathContext.DECIMAL128)
+                prefixes.costWithFee + ltrIsolate("${actual.formatForRow(ctx)} $fromMarker")
+            } else {
+                null
+            }
+        val valueBeforeFee =
             if (hasConvertedFee) {
-                originalPrefix + ltrIsolate("${fair.formatForRow(ctx)} $toMarker")
+                prefixes.valueBeforeFee + ltrIsolate("${fair.formatForRow(ctx)} $toMarker")
+            } else {
+                null
+            }
+        val convertedFee =
+            if (hasConvertedFee) {
+                val fee = displayed.multiply(convertedDelta, MathContext.DECIMAL128).abs()
+                prefixes.reduction + ltrIsolate("${fee.formatForRow(ctx)} $toMarker")
             } else {
                 null
             }
         QuickConversionsRow(
             amountFromText = "$amountStr $fromIso",
             amountToText = "${displayed.formatForRow(ctx)} $toIso",
-            trueCostText = trueCost,
-            originalValueText = originalValue,
+            originalFeeText = originalFee,
+            costWithFeeText = costWithFee,
+            valueBeforeFeeText = valueBeforeFee,
+            convertedFeeText = convertedFee,
         )
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartMath.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartMath.kt
@@ -1,0 +1,100 @@
+package com.eliormachlev.currencix.viewmodel.cart
+
+import com.eliormachlev.currencix.model.CartItem
+import com.eliormachlev.currencix.model.Currency
+import com.eliormachlev.currencix.model.ExchangeRates
+import com.eliormachlev.currencix.model.Fee
+import com.eliormachlev.currencix.model.FeeCalculator
+import com.eliormachlev.currencix.model.SavedCart
+import com.eliormachlev.currencix.util.evaluateCalculatorExpression
+import com.eliormachlev.currencix.util.isNeutralFeeStack
+import java.math.BigDecimal
+import java.math.MathContext
+
+/**
+ * Evaluate a cart row's expression string to a numeric amount. Empty and
+ * malformed expressions collapse to zero so a partially-typed row never
+ * derails a totals calculation.
+ */
+fun evaluateItem(item: CartItem): BigDecimal {
+    val raw = item.expression.trim()
+    if (raw.isEmpty()) return BigDecimal.ZERO
+    return runCatching { raw.evaluateCalculatorExpression().toBigDecimal() }
+        .getOrDefault(BigDecimal.ZERO)
+}
+
+/** Sum every row's evaluated value in the cart's base currency. */
+internal fun subtotalOf(cart: SavedCart?): BigDecimal {
+    cart ?: return BigDecimal.ZERO
+    return cart.items.fold(BigDecimal.ZERO) { acc, item -> acc + evaluateItem(item) }
+}
+
+/**
+ * Total in the destination currency: subtotal → converted at [rates] →
+ * reduced by the CONVERTED-side fee stack from [feeList]. ORIGINAL-side
+ * fees don't change the displayed total; they surface separately as "true
+ * cost" on the base side.
+ */
+internal fun totalOf(
+    cart: SavedCart?,
+    feeList: List<Fee>,
+    rates: ExchangeRates?,
+    activeExchangeId: String?,
+    activeBankId: String?,
+): BigDecimal {
+    cart ?: return BigDecimal.ZERO
+    val (base, dest) = cart.resolvedPair()
+    val subtotal = subtotalOf(cart)
+    val converted = convertAmount(subtotal, base, dest, rates)
+    val stacks = FeeCalculator.sideStacks(feeList, base, dest, activeExchangeId, activeBankId)
+    return applyConvertedStack(converted, stacks.converted)
+}
+
+/**
+ * Persisted ISO codes are strings, so unknown values (legacy carts,
+ * imported files) can slip through and return `null` from
+ * [Currency.fromString]. Fall back to USD in that case so downstream math
+ * and UI stay non-null instead of exploding on an edge case.
+ */
+internal fun resolveCurrency(iso: String): Currency = Currency.fromString(iso) ?: Currency.USD
+
+// A cart's persisted currency pair, resolved once (both ISO strings become
+// [Currency]s) with the "unset destination collapses to base" fallback. Every
+// pipeline stage — fee stack, share snapshot, total math — needs this shape.
+internal fun SavedCart.resolvedPair(): Pair<Currency, Currency> {
+    val base = resolveCurrency(currency)
+    val dest = destinationCurrency?.let { resolveCurrency(it) } ?: base
+    return base to dest
+}
+
+/**
+ * Convert [amount] from [base] to [dest] using cached rates. Returns
+ * [amount] unchanged when base == dest or when the pair's rate is missing —
+ * the latter avoids showing "0" while rates trickle in.
+ */
+internal fun convertAmount(
+    amount: BigDecimal,
+    base: Currency,
+    dest: Currency,
+    rates: ExchangeRates?,
+): BigDecimal {
+    if (base == dest) return amount
+    val baseRate = rates?.rates?.find { it.currency == base }?.value ?: return amount
+    val destRate = rates.rates.find { it.currency == dest }?.value ?: return amount
+    return amount.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
+}
+
+/**
+ * Fold the CONVERTED-side [convertedStack] into [converted]. A neutral
+ * stack (no CONVERTED-side fees) leaves the destination amount alone;
+ * otherwise divide so the fee reduces what you'd actually receive.
+ * ORIGINAL-side fees don't participate here — they surface as "true cost"
+ * on the input side instead.
+ */
+internal fun applyConvertedStack(
+    converted: BigDecimal,
+    convertedStack: BigDecimal,
+): BigDecimal {
+    if (convertedStack.isNeutralFeeStack()) return converted
+    return converted.divide(convertedStack, MathContext.DECIMAL128)
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartRatesCache.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartRatesCache.kt
@@ -1,0 +1,55 @@
+package com.eliormachlev.currencix.viewmodel.cart
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.eliormachlev.currencix.model.ExchangeRates
+import com.eliormachlev.currencix.model.Fee
+import com.eliormachlev.currencix.repository.Database
+
+/**
+ * Owns the fee list, exchange rates, and active-exchange/bank ids the cart's
+ * fee-math needs. Each source is exposed both as a [LiveData] (for observers
+ * that want to re-render on change) and as a last-known scalar so synchronous
+ * callers — share snapshot, fee-line rendering, MediatorLiveData recomputes —
+ * can read the current value without a suspend hop.
+ *
+ * The four `observeForever` subscriptions are unregistered from [clear],
+ * which the owning view model should call from `onCleared`.
+ */
+class CartRatesCache(
+    db: Database,
+) {
+    val fees: LiveData<List<Fee>> = db.getFees()
+    val rates: LiveData<ExchangeRates?> = db.getExchangeRates()
+
+    var lastFees: List<Fee> = emptyList()
+        private set
+    var lastRates: ExchangeRates? = null
+        private set
+    var lastActiveExchangeId: String? = db.getActiveExchangeIdBlocking()
+        private set
+    var lastActiveBankId: String? = db.getActiveBankIdBlocking()
+        private set
+
+    private val activeExchange: LiveData<String?> = db.getActiveExchangeId()
+    private val activeBank: LiveData<String?> = db.getActiveBankId()
+
+    private val feesObserver = Observer<List<Fee>> { lastFees = it }
+    private val ratesObserver = Observer<ExchangeRates?> { lastRates = it }
+    private val activeExchangeObserver = Observer<String?> { lastActiveExchangeId = it }
+    private val activeBankObserver = Observer<String?> { lastActiveBankId = it }
+
+    init {
+        fees.observeForever(feesObserver)
+        rates.observeForever(ratesObserver)
+        activeExchange.observeForever(activeExchangeObserver)
+        activeBank.observeForever(activeBankObserver)
+    }
+
+    fun clear() {
+        fees.removeObserver(feesObserver)
+        rates.removeObserver(ratesObserver)
+        activeExchange.removeObserver(activeExchangeObserver)
+        activeBank.removeObserver(activeBankObserver)
+    }
+}

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -91,24 +91,17 @@ class CartViewModel(
     /** Shared with the main screen — same preference gates haptics everywhere. */
     val isHapticFeedbackEnabled: LiveData<Boolean> = db.isHapticFeedbackEnabled()
 
-    fun getBaseCurrency(): LiveData<Currency> = current.map { resolveCurrency(it.currency) }
-
-    /** Destination for the running total. Falls back to base when unset. */
-    fun getDestinationCurrency(): LiveData<Currency> =
-        current.map {
-            resolveCurrency(it.destinationCurrency ?: it.currency)
-        }
-
-    /** Subtotal from summing every item's evaluated expression in the base currency. */
-    fun getSubtotal(): LiveData<BigDecimal> = current.map { subtotalOf(it) }
-
-    /**
-     * Total in the destination currency: subtotal → converted at cached rates
-     * → reduced by the CONVERTED-side fee stack. ORIGINAL-side fees don't
-     * change the displayed total; they surface separately as "true cost" on
-     * the base side.
-     */
-    fun getTotal(): LiveData<BigDecimal> =
+    // Memoize the derived LiveData instances. Returning a fresh instance from
+    // each getter left synchronous `.value` reads at null (the caller's instance
+    // has no active observer, so its MediatorLiveData never advances) — which
+    // silently zeroed the fee-extra rows even though the observed instance had
+    // the right value.
+    private val baseCurrency: LiveData<Currency> by lazy { current.map { resolveCurrency(it.currency) } }
+    private val destinationCurrency: LiveData<Currency> by lazy {
+        current.map { resolveCurrency(it.destinationCurrency ?: it.currency) }
+    }
+    private val subtotal: LiveData<BigDecimal> by lazy { current.map { subtotalOf(it) } }
+    private val total: LiveData<BigDecimal> by lazy {
         MediatorLiveData<BigDecimal>().apply {
             val recompute = {
                 value = totalOf(current.value, fees.value.orEmpty(), rates.value)
@@ -117,6 +110,23 @@ class CartViewModel(
             addSource(fees) { recompute() }
             addSource(rates) { recompute() }
         }
+    }
+
+    fun getBaseCurrency(): LiveData<Currency> = baseCurrency
+
+    /** Destination for the running total. Falls back to base when unset. */
+    fun getDestinationCurrency(): LiveData<Currency> = destinationCurrency
+
+    /** Subtotal from summing every item's evaluated expression in the base currency. */
+    fun getSubtotal(): LiveData<BigDecimal> = subtotal
+
+    /**
+     * Total in the destination currency: subtotal → converted at cached rates
+     * → reduced by the CONVERTED-side fee stack. ORIGINAL-side fees don't
+     * change the displayed total; they surface separately as "true cost" on
+     * the base side.
+     */
+    fun getTotal(): LiveData<BigDecimal> = total
 
     fun addItem(
         name: String,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -66,12 +66,12 @@ class CartViewModel(
     // has no active observer, so its MediatorLiveData never advances) — which
     // silently zeroed the fee-extra rows even though the observed instance had
     // the right value.
-    private val baseCurrency: LiveData<Currency> by lazy { current.map { resolveCurrency(it.currency) } }
-    private val destinationCurrency: LiveData<Currency> by lazy {
+    private val baseCurrencyLive: LiveData<Currency> by lazy { current.map { resolveCurrency(it.currency) } }
+    private val destinationCurrencyLive: LiveData<Currency> by lazy {
         current.map { resolveCurrency(it.destinationCurrency ?: it.currency) }
     }
-    private val subtotal: LiveData<BigDecimal> by lazy { current.map { subtotalOf(it) } }
-    private val total: LiveData<BigDecimal> by lazy {
+    private val subtotalLive: LiveData<BigDecimal> by lazy { current.map { subtotalOf(it) } }
+    private val totalLive: LiveData<BigDecimal> by lazy {
         MediatorLiveData<BigDecimal>().apply {
             val recompute = {
                 value =
@@ -89,13 +89,13 @@ class CartViewModel(
         }
     }
 
-    fun getBaseCurrency(): LiveData<Currency> = baseCurrency
+    fun getBaseCurrency(): LiveData<Currency> = baseCurrencyLive
 
     /** Destination for the running total. Falls back to base when unset. */
-    fun getDestinationCurrency(): LiveData<Currency> = destinationCurrency
+    fun getDestinationCurrency(): LiveData<Currency> = destinationCurrencyLive
 
     /** Subtotal from summing every item's evaluated expression in the base currency. */
-    fun getSubtotal(): LiveData<BigDecimal> = subtotal
+    fun getSubtotal(): LiveData<BigDecimal> = subtotalLive
 
     /**
      * Total in the destination currency: subtotal → converted at cached rates
@@ -103,7 +103,7 @@ class CartViewModel(
      * change the displayed total; they surface separately as "true cost" on
      * the base side.
      */
-    fun getTotal(): LiveData<BigDecimal> = total
+    fun getTotal(): LiveData<BigDecimal> = totalLive
 
     fun addItem(
         name: String,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.map
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.model.Currency
@@ -16,10 +15,7 @@ import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.model.SideStacks
 import com.eliormachlev.currencix.repository.Database
-import com.eliormachlev.currencix.util.evaluateCalculatorExpression
-import com.eliormachlev.currencix.util.isNeutralFeeStack
 import java.math.BigDecimal
-import java.math.MathContext
 import java.time.LocalDate
 import java.util.UUID
 
@@ -27,40 +23,14 @@ class CartViewModel(
     app: Application,
 ) : AndroidViewModel(app) {
     private val db = Database(app)
+    private val ratesCache = CartRatesCache(db)
 
     // The session cart. Backed by the `_cart_current_json` pref, so it
     // survives process death but can be cleared explicitly.
     private val current: MutableLiveData<SavedCart> = MutableLiveData(loadCurrentOrEmpty())
 
-    private val fees: LiveData<List<Fee>> = db.getFees()
-    private val rates: LiveData<ExchangeRates?> = db.getExchangeRates()
-
-    // Cache the last-known fee list and rates so synchronous callers (share
-    // text, fee line rendering) can reflect the same totals the UI shows
-    // without a suspend hop.
-    private var lastFees: List<Fee> = emptyList()
-    private var lastRates: ExchangeRates? = null
-    private var lastActiveExchangeId: String? = db.getActiveExchangeIdBlocking()
-    private var lastActiveBankId: String? = db.getActiveBankIdBlocking()
-    private val feesObserver = Observer<List<Fee>> { lastFees = it }
-    private val ratesObserver = Observer<ExchangeRates?> { lastRates = it }
-    private val activeExchange: LiveData<String?> = db.getActiveExchangeId()
-    private val activeBank: LiveData<String?> = db.getActiveBankId()
-    private val activeExchangeObserver = Observer<String?> { lastActiveExchangeId = it }
-    private val activeBankObserver = Observer<String?> { lastActiveBankId = it }
-
-    init {
-        fees.observeForever(feesObserver)
-        rates.observeForever(ratesObserver)
-        activeExchange.observeForever(activeExchangeObserver)
-        activeBank.observeForever(activeBankObserver)
-    }
-
     override fun onCleared() {
-        fees.removeObserver(feesObserver)
-        rates.removeObserver(ratesObserver)
-        activeExchange.removeObserver(activeExchangeObserver)
-        activeBank.removeObserver(activeBankObserver)
+        ratesCache.clear()
         super.onCleared()
     }
 
@@ -75,9 +45,9 @@ class CartViewModel(
      */
     fun getSavedCartsSnapshot(): List<SavedCart> = db.getSavedCartsBlocking()
 
-    fun getFees(): LiveData<List<Fee>> = fees
+    fun getFees(): LiveData<List<Fee>> = ratesCache.fees
 
-    fun getExchangeRates(): LiveData<ExchangeRates?> = rates
+    fun getExchangeRates(): LiveData<ExchangeRates?> = ratesCache.rates
 
     /**
      * Currently-selected keyboard type. Same source of truth as the main
@@ -104,11 +74,18 @@ class CartViewModel(
     private val total: LiveData<BigDecimal> by lazy {
         MediatorLiveData<BigDecimal>().apply {
             val recompute = {
-                value = totalOf(current.value, fees.value.orEmpty(), rates.value)
+                value =
+                    totalOf(
+                        current.value,
+                        ratesCache.fees.value.orEmpty(),
+                        ratesCache.rates.value,
+                        ratesCache.lastActiveExchangeId,
+                        ratesCache.lastActiveBankId,
+                    )
             }
             addSource(current) { recompute() }
-            addSource(fees) { recompute() }
-            addSource(rates) { recompute() }
+            addSource(ratesCache.fees) { recompute() }
+            addSource(ratesCache.rates) { recompute() }
         }
     }
 
@@ -333,7 +310,13 @@ class CartViewModel(
     fun currentSideStacks(): SideStacks {
         val cart = current.value ?: return SideStacks.NEUTRAL
         val (base, dest) = cart.resolvedPair()
-        return FeeCalculator.sideStacks(lastFees, base, dest, lastActiveExchangeId, lastActiveBankId)
+        return FeeCalculator.sideStacks(
+            ratesCache.lastFees,
+            base,
+            dest,
+            ratesCache.lastActiveExchangeId,
+            ratesCache.lastActiveBankId,
+        )
     }
 
     /** Snapshot used by the "Share" flow — computed against the latest fees & rates. */
@@ -343,8 +326,15 @@ class CartViewModel(
         val evaluated = cart.items.map { it to evaluateItem(it) }
         val subtotal = evaluated.fold(BigDecimal.ZERO) { acc, (_, value) -> acc + value }
         val (base, dest) = cart.resolvedPair()
-        val stacks = FeeCalculator.sideStacks(lastFees, base, dest, lastActiveExchangeId, lastActiveBankId)
-        val converted = convertAmount(subtotal, base, dest, lastRates)
+        val stacks =
+            FeeCalculator.sideStacks(
+                ratesCache.lastFees,
+                base,
+                dest,
+                ratesCache.lastActiveExchangeId,
+                ratesCache.lastActiveBankId,
+            )
+        val converted = convertAmount(subtotal, base, dest, ratesCache.lastRates)
         val total = applyConvertedStack(converted, stacks.converted)
         return CartSnapshot(
             cart,
@@ -353,11 +343,15 @@ class CartViewModel(
             converted,
             stacks,
             total,
-            lastFees,
+            ratesCache.lastFees,
             base,
             dest,
-            providerName = lastRates?.provider?.getName()?.toString(),
-            ratesDate = lastRates?.date,
+            providerName =
+                ratesCache.lastRates
+                    ?.provider
+                    ?.getName()
+                    ?.toString(),
+            ratesDate = ratesCache.lastRates?.date,
         )
     }
 
@@ -427,80 +421,6 @@ class CartViewModel(
             createdAt = System.currentTimeMillis(),
         )
     }
-
-    private fun subtotalOf(cart: SavedCart?): BigDecimal {
-        cart ?: return BigDecimal.ZERO
-        return cart.items.fold(BigDecimal.ZERO) { acc, item -> acc + evaluateItem(item) }
-    }
-
-    private fun totalOf(
-        cart: SavedCart?,
-        feeList: List<Fee>,
-        rates: ExchangeRates?,
-    ): BigDecimal {
-        cart ?: return BigDecimal.ZERO
-        val (base, dest) = cart.resolvedPair()
-        val subtotal = subtotalOf(cart)
-        val converted = convertAmount(subtotal, base, dest, rates)
-        val stacks = FeeCalculator.sideStacks(feeList, base, dest, lastActiveExchangeId, lastActiveBankId)
-        return applyConvertedStack(converted, stacks.converted)
-    }
-
-    // A cart's persisted currency pair, resolved once (both ISO strings become
-    // [Currency]s) with the "unset destination collapses to base" fallback. Every
-    // pipeline stage — fee stack, share snapshot, total math — needs this shape.
-    private fun SavedCart.resolvedPair(): Pair<Currency, Currency> {
-        val base = resolveCurrency(currency)
-        val dest = destinationCurrency?.let { resolveCurrency(it) } ?: base
-        return base to dest
-    }
-
-    /**
-     * Fold the CONVERTED-side [convertedStack] into [converted]. A neutral
-     * stack (no CONVERTED-side fees) leaves the destination amount alone;
-     * otherwise divide so the fee reduces what you'd actually receive.
-     * ORIGINAL-side fees don't participate here — they surface as "true
-     * cost" on the input side instead.
-     */
-    private fun applyConvertedStack(
-        converted: BigDecimal,
-        convertedStack: BigDecimal,
-    ): BigDecimal {
-        if (convertedStack.isNeutralFeeStack()) return converted
-        return converted.divide(convertedStack, MathContext.DECIMAL128)
-    }
-
-    /**
-     * Persisted ISO codes are strings, so unknown values (legacy carts,
-     * imported files) can slip through and return `null` from
-     * [Currency.fromString]. Fall back to USD in that case so downstream
-     * math and UI stay non-null instead of exploding on an edge case.
-     */
-    private fun resolveCurrency(iso: String): Currency = Currency.fromString(iso) ?: Currency.USD
-
-    /**
-     * Convert [amount] from [base] to [dest] using cached rates. Returns
-     * [amount] unchanged when base == dest or when the pair's rate is
-     * missing — the latter avoids showing "0" while rates trickle in.
-     */
-    private fun convertAmount(
-        amount: BigDecimal,
-        base: Currency,
-        dest: Currency,
-        rates: ExchangeRates?,
-    ): BigDecimal {
-        if (base == dest) return amount
-        val baseRate = rates?.rates?.find { it.currency == base }?.value ?: return amount
-        val destRate = rates.rates.find { it.currency == dest }?.value ?: return amount
-        return amount.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
-    }
-}
-
-fun evaluateItem(item: CartItem): BigDecimal {
-    val raw = item.expression.trim()
-    if (raw.isEmpty()) return BigDecimal.ZERO
-    return runCatching { raw.evaluateCalculatorExpression().toBigDecimal() }
-        .getOrDefault(BigDecimal.ZERO)
 }
 
 data class CartSnapshot(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -26,6 +26,7 @@ import com.eliormachlev.currencix.util.OPERATOR_MULTIPLY
 import com.eliormachlev.currencix.util.OPERATOR_PLUS
 import com.eliormachlev.currencix.util.combineWith
 import com.eliormachlev.currencix.util.evaluateCalculatorExpression
+import com.eliormachlev.currencix.util.feeStackDelta
 import com.eliormachlev.currencix.util.fromHtmlLegacy
 import com.eliormachlev.currencix.util.getDecimalSeparator
 import com.eliormachlev.currencix.util.getSignificantDecimalPlaces
@@ -562,75 +563,54 @@ class MainViewModel(
             activeBankId.value,
         )
 
-    /**
-     * The additional "true cost" on the input side: `input * originalStack`.
-     * `null` when no ORIGINAL-side fee applies (stack is trivial).
-     */
-    private val trueCost =
-        object : MediatorLiveData<BigDecimal?>() {
-            var amount: BigDecimal = BigDecimal.ZERO
-            var originalStack: BigDecimal = BigDecimal.ONE
-
-            init {
-                addSource(getCurrentBaseValueAsNumber()) {
-                    amount = it ?: BigDecimal.ZERO
-                    update()
-                }
-                addSource(sideStacks) {
-                    originalStack = it?.original ?: BigDecimal.ONE
-                    update()
-                }
-            }
-
-            private fun update() {
-                this.value =
-                    if (originalStack.compareTo(BigDecimal.ONE) == 0) {
-                        null
-                    } else {
-                        amount.multiply(originalStack, MathContext.DECIMAL128)
-                    }
+    // `source * multiplier(stack)` gated on the stack being non-trivial; null
+    // otherwise. Bridges every per-side fee derivation onto one shape so
+    // "raw total" and "signed delta" vs "abs delta" callers share a pipeline.
+    private fun feeSideLiveData(
+        source: LiveData<BigDecimal>,
+        stackSelector: (SideStacks) -> BigDecimal,
+        multiplier: (BigDecimal) -> BigDecimal,
+    ): LiveData<BigDecimal?> =
+        source.combineWith(sideStacks) { value, sides ->
+            val stack = sides?.let(stackSelector) ?: BigDecimal.ONE
+            if (stack.isNeutralFeeStack()) {
+                null
+            } else {
+                (value ?: BigDecimal.ZERO).multiply(multiplier(stack), MathContext.DECIMAL128)
             }
         }
 
     /**
-     * See [trueCost].
+     * The additional "true cost" on the input side: `input * originalStack`.
+     * `null` when no ORIGINAL-side fee applies.
      */
+    private val trueCost: LiveData<BigDecimal?> =
+        feeSideLiveData(getCurrentBaseValueAsNumber(), { it.original }) { it }
+
     internal fun getTrueCost(): LiveData<BigDecimal?> = trueCost
 
     /**
      * The undiscounted (pre-fee) destination amount: `result * convertedStack`.
-     * `null` when no CONVERTED-side fee applies (stack is trivial).
+     * `null` when no CONVERTED-side fee applies.
      */
-    private val originalValue =
-        object : MediatorLiveData<BigDecimal?>() {
-            var resultVal: BigDecimal = BigDecimal.ZERO
-            var convertedStack: BigDecimal = BigDecimal.ONE
+    private val originalValue: LiveData<BigDecimal?> =
+        feeSideLiveData(getResultAsNumber(), { it.converted }) { it }
 
-            init {
-                addSource(getResultAsNumber()) {
-                    resultVal = it ?: BigDecimal.ZERO
-                    update()
-                }
-                addSource(sideStacks) {
-                    convertedStack = it?.converted ?: BigDecimal.ONE
-                    update()
-                }
-            }
-
-            private fun update() {
-                this.value =
-                    if (convertedStack.compareTo(BigDecimal.ONE) == 0) {
-                        null
-                    } else {
-                        resultVal.multiply(convertedStack, MathContext.DECIMAL128)
-                    }
-            }
-        }
-
-    /**
-     * See [originalValue].
-     */
     internal fun getOriginalValue(): LiveData<BigDecimal?> = originalValue
+
+    // Magnitude of the ORIGINAL-side fee in the input currency. The percent
+    // tail rendered alongside carries the sign, so we `.abs()` at source to
+    // stop every consumer from repeating it.
+    private val originalFeeAmount: LiveData<BigDecimal?> =
+        feeSideLiveData(getCurrentBaseValueAsNumber(), { it.original }) { it.feeStackDelta().abs() }
+
+    internal fun getOriginalFeeAmount(): LiveData<BigDecimal?> = originalFeeAmount
+
+    // See [originalFeeAmount] — same rationale, converted side.
+    private val convertedFeeAmount: LiveData<BigDecimal?> =
+        feeSideLiveData(getResultAsNumber(), { it.converted }) { it.feeStackDelta().abs() }
+
+    internal fun getConvertedFeeAmount(): LiveData<BigDecimal?> = convertedFeeAmount
 
     /**
      * Per-side fee stacks for the current pair.

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -111,7 +111,33 @@
                 android:textDirection="ltr"
                 android:visibility="gone" />
 
-            <!-- "True cost" in the base currency: shown only for fee-side ORIGINAL. -->
+            <!-- ORIGINAL-side rows: fee amount first, cost-with-fee under it. -->
+            <LinearLayout
+                android:id="@+id/cart_subtotal_fee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/cart_subtotal_fee_label"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textColor="?attr/colorError"
+                    tools:text="Conversion fee" />
+
+                <TextView
+                    android:id="@+id/cart_subtotal_fee_value"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?attr/colorError"
+                    android:textDirection="ltr"
+                    tools:text="0.25 USD (+ 0.5 %)" />
+            </LinearLayout>
+
             <LinearLayout
                 android:id="@+id/cart_subtotal_extra"
                 android:layout_width="match_parent"
@@ -126,7 +152,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:textColor="?attr/colorError"
-                    tools:text="True cost" />
+                    tools:text="Cost with fee" />
 
                 <TextView
                     android:id="@+id/cart_subtotal_extra_value"
@@ -135,10 +161,10 @@
                     android:layout_height="wrap_content"
                     android:textColor="?attr/colorError"
                     android:textDirection="ltr"
-                    tools:text="150.00 USD" />
+                    tools:text="150.00 USD (+ 0.5 %)" />
             </LinearLayout>
 
-            <!-- "Original value" in the destination currency: shown only for fee-side CONVERTED. -->
+            <!-- CONVERTED-side rows: value-before-fee first, reduction-fee under it. -->
             <LinearLayout
                 android:id="@+id/cart_total_extra"
                 android:layout_width="match_parent"
@@ -153,7 +179,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:textColor="?attr/colorError"
-                    tools:text="Original value" />
+                    tools:text="Value before fee" />
 
                 <TextView
                     android:id="@+id/cart_total_extra_value"
@@ -162,7 +188,33 @@
                     android:layout_height="wrap_content"
                     android:textColor="?attr/colorError"
                     android:textDirection="ltr"
-                    tools:text="100.00 EUR" />
+                    tools:text="100.00 EUR (+ 0.5 %)" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/cart_total_fee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/cart_total_fee_label"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textColor="?attr/colorError"
+                    tools:text="Reduction fee" />
+
+                <TextView
+                    android:id="@+id/cart_total_fee_value"
+                    style="@style/TextAppearance.Material3.LabelSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?attr/colorError"
+                    android:textDirection="ltr"
+                    tools:text="0.50 EUR (− 0.5 %)" />
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/main_display.xml
+++ b/app/src/main/res/layout/main_display.xml
@@ -58,11 +58,38 @@
             app:layout_constraintTop_toTopOf="@+id/guideline_display"
             app:tint="?attr/colorOnPrimary" />
 
-        <!-- true cost hint *********************************************** -->
+        <!-- fee-amount + cost-with-fee hints ***************************** -->
 
-        <!-- Hangs directly under textFrom so it reads as "input + fee note".
-             textFrom's constraints are independent of this view, so toggling
+        <!-- Fee amount hangs directly under textFrom, cost-with-fee under it.
+             textFrom's constraints are independent of both, so toggling
              visibility here doesn't shift the input row. -->
+        <HorizontalScrollView
+            android:id="@+id/scrollViewOriginalFeeAmount"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin2x"
+            android:scrollbars="none"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/spinnerFrom"
+            app:layout_constraintTop_toBottomOf="@id/scrollViewTextFrom">
+
+            <TextView
+                android:id="@+id/textOriginalFeeAmount"
+                style="@style/TextAppearance.Material3.TitleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:accessibilityLiveRegion="polite"
+                android:lines="1"
+                android:textColor="?attr/colorError"
+                android:textDirection="ltr"
+                android:textSize="12sp"
+                android:visibility="gone"
+                tools:text="Conversion fee: 0.25 USD (+ 0.5 %)"
+                tools:visibility="visible" />
+
+        </HorizontalScrollView>
+
         <HorizontalScrollView
             android:id="@+id/scrollViewTrueCost"
             android:layout_width="0dp"
@@ -71,7 +98,7 @@
             android:scrollbars="none"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/spinnerFrom"
-            app:layout_constraintTop_toBottomOf="@id/scrollViewTextFrom">
+            app:layout_constraintTop_toBottomOf="@id/scrollViewOriginalFeeAmount">
 
             <TextView
                 android:id="@+id/textTrueCost"
@@ -85,7 +112,7 @@
                 android:textDirection="ltr"
                 android:textSize="12sp"
                 android:visibility="gone"
-                tools:text="True cost: 102.20 EUR"
+                tools:text="Cost with fee: 50.25 USD (+ 0.5 %)"
                 tools:visibility="visible" />
 
         </HorizontalScrollView>
@@ -249,16 +276,43 @@
                 tools:text="€ 383.99" />
         </HorizontalScrollView>
 
-        <!-- Hangs directly above textTo so it reads as "fee note + total".
-             textTo's constraints are independent of this view, so toggling
+        <!-- Value-before-fee sits above reduction-fee, both stacked above
+             textTo. textTo's constraints are independent of both, so toggling
              visibility here doesn't shift the total row. -->
+        <HorizontalScrollView
+            android:id="@+id/scrollViewConvertedFeeAmount"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin2x"
+            android:scrollbars="none"
+            app:layout_constraintBottom_toTopOf="@id/scrollViewTextTo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/spinnerTo">
+
+            <TextView
+                android:id="@+id/textConvertedFeeAmount"
+                style="@style/TextAppearance.Material3.TitleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:accessibilityLiveRegion="polite"
+                android:lines="1"
+                android:textColor="?attr/colorError"
+                android:textDirection="ltr"
+                android:textSize="12sp"
+                android:visibility="gone"
+                tools:text="Reduction fee: 0.50 EUR (− 0.5 %)"
+                tools:visibility="visible" />
+
+        </HorizontalScrollView>
+
         <HorizontalScrollView
             android:id="@+id/scrollViewOriginalValue"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin2x"
             android:scrollbars="none"
-            app:layout_constraintBottom_toTopOf="@id/scrollViewTextTo"
+            app:layout_constraintBottom_toTopOf="@id/scrollViewConvertedFeeAmount"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/spinnerTo">
 
@@ -274,7 +328,7 @@
                 android:textDirection="ltr"
                 android:textSize="12sp"
                 android:visibility="gone"
-                tools:text="Original value: 100.00 EUR"
+                tools:text="Value before fee: 100.00 EUR"
                 tools:visibility="visible" />
 
         </HorizontalScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="quick_conversions_title">Quick conversions</string>
     <string name="quick_conversions_no_rates">Rates not loaded yet.</string>
     <string name="quick_conversions_fees_applied">Fees applied: %s</string>
+    <string name="quick_conversions_fee_conversion">conversion %s</string>
+    <string name="quick_conversions_fee_reduction">reduction %s</string>
     <string name="title_preferences" translatable="false">@string/menu_settings</string>
 
     <string name="tooltip_filter_starred">Show only starred currencies.</string>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -25,6 +25,8 @@
     <string name="fee_pair_pick_currency">Select currency</string>
     <string name="fee_true_cost_prefix">"Conversion fee: "</string>
     <string name="fee_original_value_prefix">"Reduction fee: "</string>
+    <string name="fee_cost_with_fee_prefix">"Cost with fee: "</string>
+    <string name="fee_value_before_fee_prefix">"Value before fee: "</string>
     <string name="fee_side_summary_original">Displayed converted amount stays at mid-market; fees are shown separately as \"Conversion fee\".</string>
     <string name="fee_side_summary_converted">Fees are baked into the displayed converted amount.</string>
     <string name="fee_empty">No fees yet</string>


### PR DESCRIPTION
## Summary

### Fee display split (original motivation)

- Previously "Conversion fee: 50.25 \$" showed `amount * stack` — the cost including the fee, not the fee itself. Now each side surfaces four lines in on-screen order: fee then cost-with-fee on ORIGINAL; value-before-fee then reduction-fee on CONVERTED. Same layout on main, cart, share sheet, and quick-conversions dialog.
- Collapsed the four per-side fee `MediatorLiveData` blocks in `MainViewModel` into a shared `feeSideLiveData(source, selector, multiplier)` helper on `combineWith`; added `BigDecimal.feeStackDelta()` in `MathUtils` (which `feePercentDelta` now delegates through); absorbed `.abs()` at source so consumers stop repeating it.
- Bundled QuickConversions' four prefix params into `FeeRowPrefixes`; pulled a local `line()` helper out of the share-extra builder.

### Cart module refactor (added later)

While wiring the new fee-line rendering into the cart footer I hit a display bug — "Value before fee" and "Reduction fee" rendered 0.00 despite the main screen showing the correct values. Root cause: `CartViewModel` returned a fresh `MediatorLiveData` per accessor call, so synchronous `.value` reads landed on unobserved instances that never advanced. Fixing that surfaced how much unrelated code lived in `CartActivity` (1371 lines) and `CartViewModel` (526 lines), so this PR also splits both apart:

- **fix**: memoize derived LiveData (`baseCurrency`, `destinationCurrency`, `subtotal`, `total`) so the fee-extra rows read the actual current values
- **hoist** `util/CartFormatting.kt` — display / percent / amount helpers used by both view and export layers (deduped `toCartExportString` and `toCartDisplayString`, which were byte-identical)
- **extract** `CartFileIo` (SAF export/import launchers)
- **extract** `CartShareCoordinator` + `CartChoiceDialog` (share picker + reusable "title + explainer per option" dialog, also reused by Clear)
- **extract** `CartSaveLoadCoordinator` (Save/Save-as/Load/Rename/Delete + unsaved-changes prompt)
- **extract** `CartFooterBinding` (14 footer views + all `updateFeeLine`/`updateFeeExtras`/`renderFeeExtraRow` logic)
- **extract** `CartKeypadController` (slide-up keypad state, IME visibility guard, drag-to-dismiss, seed/serialise `CalculatorInputState`; activity keeps the six `android:onClick` reflection targets and forwards through `keypad.forwardKeypadAction`)
- **split** `CartViewModel` into `CartMath.kt` (pure functions — `evaluateItem`, `subtotalOf`, `totalOf`, `convertAmount`, `applyConvertedStack`, `resolveCurrency`, `resolvedPair`) and `CartRatesCache.kt` (owns the four `observeForever` subscriptions and exposes each source both as LiveData and last-known scalar)

Net line-count deltas:

- `CartActivity.kt`: 1371 → 366
- `CartViewModel.kt`: 526 → 446
- new files add ~1250 lines of focused, single-responsibility code

The refactor is behaviour-preserving — no user-visible changes beyond the fee-display feature and the 0.00 fix.

## Test plan

### Fee display

- [ ] Main screen: pick a currency pair with an ORIGINAL-side markup — confirm "Conversion fee: 0.25 \$ (+0.5%)" and "Cost with fee: 50.25 \$ (+0.5%)" stack correctly and don't shift the main amount rows.
- [ ] Same, CONVERTED-side markup — confirm "Value before fee" + "Reduction fee" appear in that order and hide when the fee is trivial.
- [ ] Cart screen: subtotal and total rows show both fee-amount and cost-with-fee lines in the same order (previously showed 0.00 for two of them).
- [ ] Quick-conversions dialog: each row shows both lines per side; fees turned off collapses back to two columns.
- [ ] Share sheet: shared text contains the four fee lines in the same order as the on-screen layout.
- [ ] Toggling the fees setting live keeps the layout stable (no jitter, no orphan rows).

### Cart refactor (behaviour parity)

- [ ] Add / edit / delete / reorder / pin cart rows — including drag-reorder mid-edit.
- [ ] Keypad: slide-in animation, drag-down-to-dismiss, tap outside to close, back-press to close, system-IME variant still routes through the inline EditText.
- [ ] Save / Save as / Load / Rename / Delete a saved cart; unsaved-changes prompt fires on close and load.
- [ ] Share as text / CSV / PDF; Export / Import to SAF; Clear (items only + reset all).
- [ ] Swap base and destination currencies, including when destination is unset.
- [ ] Rotate / kill and relaunch — session cart survives, `_cart_current_json` restores correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)