### PR TITLE
refactor(settings): rename Appearance to Look & Feel, reorder categories

### DIFF
--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -101,7 +101,7 @@
     <string name="graph_highlight_period_change_key" translatable="false">KEY_GRAPH_HIGHLIGHT_PERIOD_CHANGE</string>
     <string name="graph_highlight_period_change_title">Highlight year/month change</string>
     <string name="graph_highlight_period_change_summary">Draw vertical guide lines where the year or month changes across the chart.</string>
-    <string name="category_appearance">Appearance</string>
+    <string name="category_appearance">Look &amp; Feel</string>
     <string name="system_default">System default</string>
     <string name="theme_key" translatable="false">KEY_THEME</string>
     <string name="theme_title">Design</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -10,13 +10,6 @@
             android:summary="@string/fee_summary"
             android:title="@string/fee_title" />
 
-        <SwitchPreferenceCompat
-            android:icon="@drawable/ic_conversion_preview"
-            android:key="@string/previewConversion_key"
-            android:summary="@string/previewConversion_summary"
-            android:title="@string/previewConversion_title"
-            app:defaultValue="false" />
-
         <Preference
             android:icon="@drawable/ic_keyboard_extended"
             android:key="@string/keyboard_key"
@@ -32,21 +25,6 @@
             android:title="@string/decimal_places_title"
             app:useSimpleSummaryProvider="true" />
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:icon="@drawable/ic_vibration"
-            android:key="@string/haptic_feedback_key"
-            android:summary="@string/haptic_feedback_summary"
-            android:title="@string/haptic_feedback_title" />
-
-        <ListPreference
-            android:defaultValue="dd/MM/yy HH:mm"
-            android:entries="@array/date_format_names"
-            android:entryValues="@array/date_format_values"
-            android:icon="@drawable/ic_event"
-            android:key="@string/date_format_key"
-            android:title="@string/date_format_title" />
-
         <Preference
             android:icon="@drawable/ic_backup"
             android:key="@string/backup_key"
@@ -54,24 +32,8 @@
             android:title="@string/backup_title" />
     </PreferenceCategory>
 
-    <PreferenceCategory
-        android:title="@string/category_appearance"
+    <PreferenceCategory android:title="@string/category_api"
         app:allowDividerAbove="false">
-        <ListPreference
-            android:defaultValue="3"
-            android:entries="@array/theme_names"
-            android:entryValues="@array/theme_values"
-            android:icon="@drawable/ic_theme"
-            android:key="@string/theme_key"
-            android:title="@string/theme_title"
-            app:useSimpleSummaryProvider="true" />
-        <com.eliormachlev.currencix.view.preference.LanguagePickerPreference
-            android:icon="@drawable/ic_language"
-            android:key="@string/language_key"
-            android:title="@string/language_title" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="@string/category_api">
         <com.eliormachlev.currencix.view.preference.ProviderPickerPreference
             android:icon="@drawable/ic_data_provider"
             android:key="@string/api_key"
@@ -95,6 +57,42 @@
             android:key="@string/key_refreshPeriod"
             android:selectable="false"
             android:title="@string/api_refreshPeriod_title" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/category_appearance"
+        app:allowDividerAbove="false">
+        <ListPreference
+            android:defaultValue="3"
+            android:entries="@array/theme_names"
+            android:entryValues="@array/theme_values"
+            android:icon="@drawable/ic_theme"
+            android:key="@string/theme_key"
+            android:title="@string/theme_title"
+            app:useSimpleSummaryProvider="true" />
+        <com.eliormachlev.currencix.view.preference.LanguagePickerPreference
+            android:icon="@drawable/ic_language"
+            android:key="@string/language_key"
+            android:title="@string/language_title" />
+        <ListPreference
+            android:defaultValue="dd/MM/yy HH:mm"
+            android:entries="@array/date_format_names"
+            android:entryValues="@array/date_format_values"
+            android:icon="@drawable/ic_event"
+            android:key="@string/date_format_key"
+            android:title="@string/date_format_title" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:icon="@drawable/ic_vibration"
+            android:key="@string/haptic_feedback_key"
+            android:summary="@string/haptic_feedback_summary"
+            android:title="@string/haptic_feedback_title" />
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_conversion_preview"
+            android:key="@string/previewConversion_key"
+            android:summary="@string/previewConversion_summary"
+            android:title="@string/previewConversion_title"
+            app:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Summary
- Rename **Appearance** category to **Look & Feel**
- Move **Date format**, **Haptic feedback**, and **Conversion preview** from General Settings into Look & Feel (alongside theme and language)
- Hoist **Exchange rates** category to sit directly below General Settings

Only the base `values/strings_preference.xml` was updated for the category rename; localized files will fall back to English until translated.

## Test plan
- [ ] Open Settings and confirm category order: General Settings → Exchange rates → Look & Feel → Graph options → About → Version info
- [ ] Confirm Look & Feel contains: Design, Language, Date format, Haptic feedback, Conversion preview
- [ ] Confirm General Settings contains: Manage fees, Extended keyboard, Decimal places, Backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)