### PR TITLE
refactor: code-shape sweep — rateFor, URL centralization, Period offsets, legacy prefs, sideStacksFor

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/ExchangeRates.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/ExchangeRates.kt
@@ -15,3 +15,5 @@ data class ExchangeRates(
     @Transient val time: LocalTime? = null,
     @Transient val provider: ApiProvider? = null,
 )
+
+fun ExchangeRates.rateFor(currency: Currency?): Rate? = currency?.let { c -> rates?.firstOrNull { it.currency == c } }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
@@ -41,10 +41,6 @@ import timber.log.Timber
 import java.time.LocalDate
 import java.util.UUID
 
-private const val LEGACY_FEE_KEY = "_fee"
-private const val LEGACY_FEE_STR_KEY = "_fee_str"
-private const val LEGACY_FEE_ENABLED_KEY = "_feeEnabled"
-
 // Sentinel for "no historical date stored" in the millis-since-epoch pref.
 // -1L is used because it can't collide with any real epoch millis (1970-01-01
 // stores as 0L; anything after is positive).
@@ -356,31 +352,23 @@ class Database(
 
     // fees
 
-    fun getFees(): LiveData<List<Fee>> {
-        migrateLegacyFeeIfNeeded()
-        return SharedPreferenceStringLiveData(prefs, keyFeesJson, "[]")
+    fun getFees(): LiveData<List<Fee>> =
+        SharedPreferenceStringLiveData(prefs, keyFeesJson, "[]")
             .map { parseFeeList(it ?: "[]") }
-    }
 
-    fun getFeesBlocking(): List<Fee> {
-        migrateLegacyFeeIfNeeded()
-        return parseFeeList(prefs.getString(keyFeesJson, "[]") ?: "[]")
-    }
+    fun getFeesBlocking(): List<Fee> = parseFeeList(prefs.getString(keyFeesJson, "[]") ?: "[]")
 
     fun addFee(fee: Fee) {
-        migrateLegacyFeeIfNeeded()
         val next = getFeesBlocking() + fee
         writeFees(next)
     }
 
     fun updateFee(fee: Fee) {
-        migrateLegacyFeeIfNeeded()
         val next = getFeesBlocking().map { if (it.id == fee.id) fee else it }
         writeFees(next)
     }
 
     fun deleteFee(id: String) {
-        migrateLegacyFeeIfNeeded()
         val next = getFeesBlocking().filter { it.id != id }
         writeFees(next)
     }
@@ -415,58 +403,6 @@ class Database(
 
     private fun writeFees(list: List<Fee>) {
         prefs.edit().putString(keyFeesJson, serializeFeeList(list)).apply()
-    }
-
-    /**
-     * Migrate the legacy single-fee representation into the new [Fee] list.
-     * Runs at most once (the presence of the [keyFeesJson] key marks completion).
-     * The old markup direction is preserved: an enabled fee becomes a
-     * [Fee.GlobalExchange] with `isMarkup=true`; a disabled fee migrates to
-     * an empty list.
-     */
-    private fun migrateLegacyFeeIfNeeded() {
-        if (prefs.contains(keyFeesJson)) return
-        if (!prefs.contains(LEGACY_FEE_STR_KEY) && !prefs.contains(LEGACY_FEE_KEY)) {
-            // no legacy data at all: initialize with empty list
-            prefs
-                .edit()
-                .putString(keyFeesJson, "[]")
-                .remove(LEGACY_FEE_ENABLED_KEY)
-                .remove(LEGACY_FEE_STR_KEY)
-                .remove(LEGACY_FEE_KEY)
-                .apply()
-            return
-        }
-        val enabled = prefs.getBoolean(LEGACY_FEE_ENABLED_KEY, false)
-        val migrated =
-            if (enabled) {
-                val legacyStr = prefs.getString(LEGACY_FEE_STR_KEY, null)
-                val legacyFloat = runCatching { prefs.getFloat(LEGACY_FEE_KEY, Float.NaN) }.getOrNull()
-                val percent =
-                    legacyStr?.toBigDecimalOrNull()
-                        ?: legacyFloat?.takeIf { !it.isNaN() }?.toString()?.toBigDecimalOrNull()
-                if (percent != null) {
-                    listOf(
-                        Fee.GlobalExchange(
-                            id = UUID.randomUUID().toString(),
-                            name = "",
-                            percent = percent,
-                            isMarkup = true,
-                        ),
-                    )
-                } else {
-                    emptyList()
-                }
-            } else {
-                emptyList()
-            }
-        prefs
-            .edit()
-            .putString(keyFeesJson, serializeFeeList(migrated))
-            .remove(LEGACY_FEE_ENABLED_KEY)
-            .remove(LEGACY_FEE_STR_KEY)
-            .remove(LEGACY_FEE_KEY)
-            .apply()
     }
 
     private fun serializeFeeList(list: List<Fee>): String {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/AppUrls.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/AppUrls.kt
@@ -1,4 +1,22 @@
 package com.eliormachlev.currencix.util
 
+import com.eliormachlev.currencix.BuildConfig
+
 internal const val URL_REPO = "https://github.com/EliorMachlev/CurrenciX"
 internal const val URL_DOCS_BASE = "$URL_REPO/blob/master/docs/markDown/"
+internal const val URL_RELEASES_TAG = "$URL_REPO/releases/tag/v"
+internal const val URL_PULLS = "$URL_REPO/pulls"
+internal const val URL_COMMIT = "$URL_REPO/commit/"
+
+// Debug APKs prefer the PR URL, then fall back to the commit page for the
+// SHA the APK was built from (GitHub renders the associated PR badge on the
+// commit page — one click from the exact PR). If neither is available (git
+// unavailable at build time), fall back to the repo pulls list.
+internal fun releaseNotesUrl(): String =
+    if (BuildConfig.DEBUG) {
+        BuildConfig.PR_URL.takeIf { it.isNotBlank() }
+            ?: BuildConfig.COMMIT_SHA.takeIf { it.isNotBlank() }?.let { "$URL_COMMIT$it" }
+            ?: URL_PULLS
+    } else {
+        "$URL_RELEASES_TAG${BuildConfig.VERSION_NAME}"
+    }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsRowBuilder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.SideStacks
+import com.eliormachlev.currencix.model.rateFor
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import com.eliormachlev.currencix.util.ltrIsolate
 import com.eliormachlev.currencix.util.toHumanReadableNumber
@@ -24,8 +25,8 @@ fun buildQuickConversionRows(
     sideStacks: SideStacks,
     costWithFeePrefix: String,
 ): List<QuickConversionsRow> {
-    val baseRate = rates.rates?.find { it.currency == from }?.value ?: return emptyList()
-    val destRate = rates.rates.find { it.currency == to }?.value ?: return emptyList()
+    val baseRate = rates.rateFor(from)?.value ?: return emptyList()
+    val destRate = rates.rateFor(to)?.value ?: return emptyList()
     val hasOriginalFee = !sideStacks.original.isNeutralFeeStack()
     val hasConvertedFee = !sideStacks.converted.isNeutralFeeStack()
     val fromIso = from.iso4217Alpha()

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
@@ -24,8 +24,8 @@ import com.eliormachlev.currencix.util.ChoiceOption
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_MAX
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_MIN
-import com.eliormachlev.currencix.util.URL_REPO
 import com.eliormachlev.currencix.util.asPreferenceSummary
+import com.eliormachlev.currencix.util.releaseNotesUrl
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.view.main.MainActivity
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
@@ -41,24 +41,8 @@ private const val UNKNOWN_PROVIDER_ID = -1
 // instead of the "rate on Play" entry.
 private const val FLAVOR_PLAY = "play"
 
-private const val URL_RELEASES_TAG = "$URL_REPO/releases/tag/v"
-private const val URL_PULLS = "$URL_REPO/pulls"
-private const val URL_COMMIT = "$URL_REPO/commit/"
 private const val URL_PLAY_MARKET = "market://details?id=com.eliormachlev.currencix"
 private const val URL_PLAY_WEB = "https://play.google.com/store/apps/details?id=com.eliormachlev.currencix"
-
-// Debug APKs prefer the PR URL, then fall back to the commit page for the
-// SHA the APK was built from (GitHub renders the associated PR badge on the
-// commit page — one click from the exact PR). If neither is available (git
-// unavailable at build time), fall back to the repo pulls list.
-private fun releaseNotesUrl(): String =
-    if (BuildConfig.DEBUG) {
-        BuildConfig.PR_URL.takeIf { it.isNotBlank() }
-            ?: BuildConfig.COMMIT_SHA.takeIf { it.isNotBlank() }?.let { "$URL_COMMIT$it" }
-            ?: URL_PULLS
-    } else {
-        "$URL_RELEASES_TAG${BuildConfig.VERSION_NAME}"
-    }
 
 @Suppress("unused")
 class PreferenceFragment : PreferenceFragmentCompat() {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartMath.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartMath.kt
@@ -6,6 +6,7 @@ import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.Fee
 import com.eliormachlev.currencix.model.FeeCalculator
 import com.eliormachlev.currencix.model.SavedCart
+import com.eliormachlev.currencix.model.rateFor
 import com.eliormachlev.currencix.util.evaluateCalculatorExpression
 import com.eliormachlev.currencix.util.isNeutralFeeStack
 import java.math.BigDecimal
@@ -79,8 +80,8 @@ internal fun convertAmount(
     rates: ExchangeRates?,
 ): BigDecimal {
     if (base == dest) return amount
-    val baseRate = rates?.rates?.find { it.currency == base }?.value ?: return amount
-    val destRate = rates.rates.find { it.currency == dest }?.value ?: return amount
+    val baseRate = rates?.rateFor(base)?.value ?: return amount
+    val destRate = rates.rateFor(dest)?.value ?: return amount
     return amount.divide(baseRate, MathContext.DECIMAL128).multiply(destRate)
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartRatesCache.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartRatesCache.kt
@@ -2,8 +2,11 @@ package com.eliormachlev.currencix.viewmodel.cart
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.Fee
+import com.eliormachlev.currencix.model.FeeCalculator
+import com.eliormachlev.currencix.model.SideStacks
 import com.eliormachlev.currencix.repository.Database
 
 /**
@@ -53,3 +56,8 @@ class CartRatesCache(
         activeBank.removeObserver(activeBankObserver)
     }
 }
+
+fun CartRatesCache.sideStacksFor(
+    base: Currency?,
+    dest: Currency?,
+): SideStacks = FeeCalculator.sideStacks(lastFees, base, dest, lastActiveExchangeId, lastActiveBankId)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -10,7 +10,6 @@ import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.ExchangeRates
 import com.eliormachlev.currencix.model.Fee
-import com.eliormachlev.currencix.model.FeeCalculator
 import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.model.SavedCart
 import com.eliormachlev.currencix.model.SideStacks
@@ -310,13 +309,7 @@ class CartViewModel(
     fun currentSideStacks(): SideStacks {
         val cart = current.value ?: return SideStacks.NEUTRAL
         val (base, dest) = cart.resolvedPair()
-        return FeeCalculator.sideStacks(
-            ratesCache.lastFees,
-            base,
-            dest,
-            ratesCache.lastActiveExchangeId,
-            ratesCache.lastActiveBankId,
-        )
+        return ratesCache.sideStacksFor(base, dest)
     }
 
     /** Snapshot used by the "Share" flow — computed against the latest fees & rates. */
@@ -326,14 +319,7 @@ class CartViewModel(
         val evaluated = cart.items.map { it to evaluateItem(it) }
         val subtotal = evaluated.fold(BigDecimal.ZERO) { acc, (_, value) -> acc + value }
         val (base, dest) = cart.resolvedPair()
-        val stacks =
-            FeeCalculator.sideStacks(
-                ratesCache.lastFees,
-                base,
-                dest,
-                ratesCache.lastActiveExchangeId,
-                ratesCache.lastActiveBankId,
-            )
+        val stacks = ratesCache.sideStacksFor(base, dest)
         val converted = convertAmount(subtotal, base, dest, ratesCache.lastRates)
         val total = applyConvertedStack(converted, stacks.converted)
         return CartSnapshot(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/main/MainViewModel.kt
@@ -18,6 +18,7 @@ import com.eliormachlev.currencix.model.Fee
 import com.eliormachlev.currencix.model.FeeCalculator
 import com.eliormachlev.currencix.model.KeyboardType
 import com.eliormachlev.currencix.model.SideStacks
+import com.eliormachlev.currencix.model.rateFor
 import com.eliormachlev.currencix.repository.Database
 import com.eliormachlev.currencix.repository.ExchangeRatesRepository
 import com.eliormachlev.currencix.util.OPERATOR_DIVIDE
@@ -190,7 +191,7 @@ class MainViewModel(
                 private fun update() {
                     this.value =
                         // last used is present in the current currency set
-                        rates?.rates?.find { it.currency == base }?.currency
+                        rates?.rateFor(base)?.currency
                             // not present, so just return the first of the set
                             ?: rates?.rates?.firstOrNull()?.currency
                 }
@@ -339,9 +340,9 @@ class MainViewModel(
             fun update() {
                 if (exchangeRates != null && baseCurrency != null && destinationCurrency != null) {
                     // base currency
-                    val baseValue = exchangeRates!!.rates?.find { it.currency == baseCurrency }?.value
+                    val baseValue = exchangeRates!!.rateFor(baseCurrency)?.value
                     // target currency
-                    val destinationValue = exchangeRates!!.rates?.find { it.currency == destinationCurrency }?.value
+                    val destinationValue = exchangeRates!!.rateFor(destinationCurrency)?.value
                     val destinationValueCalculated =
                         baseValue?.let {
                             destinationValue?.divide(it, MathContext.DECIMAL128)
@@ -529,8 +530,8 @@ class MainViewModel(
 
             private fun calculateResult() {
                 val amount: BigDecimal = baseValue?.toBigDecimal() ?: BigDecimal.ZERO
-                val baseRate = rates?.rates?.find { it.currency == baseCurrency } ?: return
-                val destinationRate = rates?.rates?.find { it.currency == destinationCurrency } ?: return
+                val baseRate = rates?.rateFor(baseCurrency) ?: return
+                val destinationRate = rates?.rateFor(destinationCurrency) ?: return
                 val fair =
                     amount
                         .divide(baseRate.value, MathContext.DECIMAL128)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -24,7 +24,6 @@ import java.time.LocalDate
 import kotlin.math.min
 
 private const val DEFAULT_DECIMAL_PLACES = 3
-private const val WEEK_DAYS = 7L
 private const val SIGNIFICANT_DIGITS = 3
 private const val MAX_DECIMAL_PLACES = 7
 
@@ -72,6 +71,14 @@ class TimelineViewModel(
         WEEK,
         MONTH,
         YEAR,
+        ;
+
+        fun startDate(today: LocalDate = LocalDate.now()): LocalDate =
+            when (this) {
+                WEEK -> today.minusWeeks(1)
+                MONTH -> today.minusMonths(1)
+                YEAR -> today.minusYears(1)
+            }
     }
 
     private var repository: ExchangeRatesRepository = ExchangeRatesRepository(app)
@@ -114,12 +121,7 @@ class TimelineViewModel(
 
             // selected time period
             addSource(periodLiveData) {
-                startDate =
-                    when (it) {
-                        Period.WEEK -> LocalDate.now().minusDays(WEEK_DAYS)
-                        Period.MONTH -> LocalDate.now().minusMonths(1)
-                        else -> LocalDate.now().minusYears(1)
-                    }
+                startDate = it.startDate()
                 update()
             }
         }


### PR DESCRIPTION
## Summary
Code-shape sweep. Five small, behavior-preserving cleanups in one PR.

- **\`ExchangeRates.rateFor(currency)\` extension** — collapses the repeated \`rates.find { it.currency == X }\` pattern across \`MainViewModel\`, \`CartMath\`, and \`QuickConversionsRowBuilder\` into one extension on the model.
- **URLs into \`util/AppUrls.kt\`** — \`releaseNotesUrl()\` and its supporting \`URL_RELEASES_TAG\` / \`URL_PULLS\` / \`URL_COMMIT\` constants move next to the other repo-URL constants. Play Store URLs stay in \`PreferenceFragment\` (single call site, not shared config).
- **\`Period.startDate()\`** — the \`week/month/year\` enum in \`TimelineViewModel\` now owns its offset via a method on the enum. The \`WEEK_DAYS = 7L\` constant and the \`when\` block over \`Period\` go away; adding a new \`Period\` in the future forces the offset choice at the enum, not at the caller.
- **Drop the legacy fee prefs migration** — \`LEGACY_FEE_KEY\` / \`LEGACY_FEE_STR_KEY\` / \`LEGACY_FEE_ENABLED_KEY\` and the \`migrateLegacyFeeIfNeeded()\` function existed to migrate a pre-multi-fee representation. App is pre-launch with no installed base, so this is dead weight. Removes the three constants, the migration function, and its five per-call sites in \`getFees\` / \`getFeesBlocking\` / \`addFee\` / \`updateFee\` / \`deleteFee\`. Reads already default to \`\"[]\"\` when the key is missing, so no init required.
- **\`CartRatesCache.sideStacksFor(base, dest)\` extension** — \`CartViewModel.currentSideStacks()\` and \`snapshotForShare()\` were both spelling out \`FeeCalculator.sideStacks(ratesCache.lastFees, base, dest, ratesCache.lastActiveExchangeId, ratesCache.lastActiveBankId)\`. Put that call on the cache itself so both sites read as one line.

Two items from the original scan were skipped as false positives:
- \`isNeutralFeeStack\` is already in \`util/MathUtils.kt\` (not \`TextUtils.kt\`).
- The \`LEGACY_*\` pref keys had been proposed for hoisting into a shared \`PreferenceKeys\` object — irrelevant after the deletion above.

A generic N-source \`MediatorLiveData\` combine helper was also considered but deferred — the remaining \`MediatorLiveData\` sites here have per-source semantics (stateful reducers, equality guards, conditional \`addSource\`) that don't collapse cleanly onto a shared combinator.

## Test plan
- [ ] \`./gradlew :app:spotlessCheck\` — passes locally
- [ ] Existing unit tests still green
- [ ] Manual: rate conversion in Main, cart totals, Quick Conversions dialog values unchanged
- [ ] Manual: About > release-notes tap opens correct URL for debug and release flavors
- [ ] Manual: Timeline week/month/year period buttons still restrict the chart window correctly
- [ ] Manual: fees CRUD (add / update / delete) still round-trips through prefs
- [ ] Manual: cart inline fee annotations + Share snapshot show the same totals as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)