### PR TITLE
fix(haptic): fire on every interaction, honour battery saver

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/repository/Database.kt
@@ -502,6 +502,8 @@ class Database(
 
     fun isHapticFeedbackEnabled(): LiveData<Boolean> = SharedPreferenceBooleanLiveData(prefs, keyHapticFeedback, true)
 
+    fun isHapticFeedbackEnabledBlocking(): Boolean = prefs.getBoolean(keyHapticFeedback, true)
+
     // decimal places
 
     fun setDecimalPlaces(places: Int) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -70,10 +70,7 @@ fun choiceExplainerRow(
             setPadding(0, padV, 0, padV)
             isClickable = true
             applySelectableRowBackground()
-            setOnClickListener {
-                it.hapticTap()
-                onClick()
-            }
+            setOnHapticClickListener { onClick() }
             if (clickActionLabel != null) {
                 ViewCompat.replaceAccessibilityAction(
                     this,
@@ -175,6 +172,5 @@ fun showChoiceExplainerDialog(
             .setTitle(titleRes)
             .setView(container)
             .setNegativeButton(android.R.string.cancel, null)
-            .show()
-            .also { it.wireHapticButtons() }
+            .showWithHapticButtons()
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/DialogUtils.kt
@@ -70,7 +70,10 @@ fun choiceExplainerRow(
             setPadding(0, padV, 0, padV)
             isClickable = true
             applySelectableRowBackground()
-            setOnClickListener { onClick() }
+            setOnClickListener {
+                it.hapticTap()
+                onClick()
+            }
             if (clickActionLabel != null) {
                 ViewCompat.replaceAccessibilityAction(
                     this,
@@ -173,4 +176,5 @@ fun showChoiceExplainerDialog(
             .setView(container)
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { it.wireHapticButtons() }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -205,6 +206,22 @@ fun rememberHapticOnClick(onClick: () -> Unit): () -> Unit {
         }
     }
 }
+
+/**
+ * Fires a keyboard-tap haptic the moment the modified node gains focus.
+ * Use on text fields (BasicTextField, etc.) so tap-to-edit feels the same
+ * as tap-to-click, honouring the user's preference and battery-saver state.
+ */
+fun Modifier.hapticOnFocus(): Modifier =
+    composed {
+        val ctx = LocalContext.current
+        val haptic = LocalHapticFeedback.current
+        onFocusChanged { state ->
+            if (state.isFocused && ctx.shouldHaptic()) {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+        }
+    }
 
 /**
  * Compose analogue of [Modifier.combinedClickable] with the same

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -1,15 +1,52 @@
 package com.eliormachlev.currencix.util
 
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.os.PowerManager
 import android.view.HapticFeedbackConstants
+import android.view.MotionEvent
 import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import com.eliormachlev.currencix.repository.Database
 
 /**
- * Perform a "keyboard tap" haptic if the user has enabled haptic feedback in
- * settings. Shared between the main calculator screen and the cart screen so
- * both surfaces honour the same preference the same way.
+ * True when the device is in battery-saver mode. Haptic feedback is suppressed
+ * in this state regardless of the user's own preference — the system's
+ * power-saving contract asks apps to skip non-essential vibrations.
+ */
+private fun Context.isInPowerSaveMode(): Boolean {
+    val pm = getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return false
+    return pm.isPowerSaveMode
+}
+
+/**
+ * Resolve whether haptic feedback should currently fire: the user's preference
+ * AND the device NOT being in battery-saver mode. Reads SharedPreferences on
+ * the calling thread — fine for tap-time use.
+ */
+private fun Context.shouldHaptic(): Boolean = Database(this).isHapticFeedbackEnabledBlocking() && !isInPowerSaveMode()
+
+/**
+ * Perform a "keyboard tap" haptic when [enabled] says the user wants it AND
+ * the device isn't in battery-saver mode. Used by activities that already
+ * observe the preference as LiveData (the calculator keypad, cart keypad).
  */
 fun View.hapticTap(enabled: Boolean) {
     if (!enabled) return
+    if (context.isInPowerSaveMode()) return
     // FLAG_IGNORE_VIEW_SETTING: some parent chains disable haptic feedback
     // (e.g. cards, RecyclerView rows), so force the tap regardless of the
     // view-tree setting. The user's global "haptic feedback" system toggle
@@ -19,3 +56,127 @@ fun View.hapticTap(enabled: Boolean) {
         HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING,
     )
 }
+
+/**
+ * No-arg variant that reads the preference and power-save state itself. Use
+ * this at sites without an observed [Boolean] handy — menu items, dialog
+ * buttons, spinner selections, one-off click listeners.
+ */
+fun View.hapticTap() {
+    if (!context.shouldHaptic()) return
+    performHapticFeedback(
+        HapticFeedbackConstants.KEYBOARD_TAP,
+        HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING,
+    )
+}
+
+/**
+ * Activity-scoped haptic tap for callbacks that don't have a specific source
+ * View — menu items, back-press callbacks, dialog buttons routed through the
+ * activity. Falls back to the window's decor view for the vibration source.
+ */
+fun Activity.hapticTap() {
+    window?.decorView?.hapticTap()
+}
+
+/**
+ * Attach haptic taps to the standard positive/negative/neutral buttons of a
+ * shown [AlertDialog]. Uses a touch-listener on ACTION_DOWN so the vibration
+ * fires immediately with the press — the built-in click behaviour (dismiss +
+ * user callback) is preserved because the listener returns false.
+ *
+ * Deferred to the dialog's onShow callback so it works whether called before
+ * or after [AlertDialog.show]. Currently the codebase has no other
+ * OnShowListener, so a plain [AlertDialog.setOnShowListener] is safe.
+ */
+@SuppressLint("ClickableViewAccessibility")
+fun AlertDialog.wireHapticButtons() {
+    fun applyNow() {
+        listOf(
+            AlertDialog.BUTTON_POSITIVE,
+            AlertDialog.BUTTON_NEGATIVE,
+            AlertDialog.BUTTON_NEUTRAL,
+        ).forEach { which ->
+            getButton(which)?.setOnTouchListener { v, ev ->
+                if (ev.action == MotionEvent.ACTION_DOWN) v.hapticTap()
+                false
+            }
+        }
+    }
+    if (isShowing) applyNow() else setOnShowListener { applyNow() }
+}
+
+/**
+ * Compose analogue of [Modifier.clickable] that also fires a keyboard-tap
+ * haptic on click, honouring the user's preference and battery-saver state.
+ */
+fun Modifier.hapticClickable(
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+): Modifier =
+    composed {
+        val ctx = LocalContext.current
+        val haptic = LocalHapticFeedback.current
+        clickable(enabled = enabled) {
+            if (ctx.shouldHaptic()) {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+            onClick()
+        }
+    }
+
+/**
+ * Wraps a Compose [onClick] callback so the wrapped lambda fires the same
+ * battery-saver-aware haptic before delegating to the original. Use at sites
+ * that already take an `onClick: () -> Unit` (e.g. Material3 [IconButton])
+ * where a full [Modifier.hapticClickable] would be awkward. The returned
+ * lambda is remembered across recompositions so IconButton's `onClick`
+ * identity stays stable.
+ */
+@Composable
+fun rememberHapticOnClick(onClick: () -> Unit): () -> Unit {
+    val ctx = LocalContext.current
+    val haptic = LocalHapticFeedback.current
+    val current by rememberUpdatedState(onClick)
+    return remember {
+        {
+            if (ctx.shouldHaptic()) {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+            current()
+        }
+    }
+}
+
+/**
+ * Compose analogue of [Modifier.combinedClickable] with the same
+ * battery-saver-aware haptic behaviour on click and long-click.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.hapticCombinedClickable(
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
+): Modifier =
+    composed {
+        val ctx = LocalContext.current
+        val haptic = LocalHapticFeedback.current
+
+        fun tap() {
+            if (ctx.shouldHaptic()) {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+        }
+        combinedClickable(
+            onClick = {
+                tap()
+                onClick()
+            },
+            onLongClick =
+                onLongClick?.let {
+                    {
+                        tap()
+                        it()
+                    }
+                },
+        )
+    }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -90,7 +90,7 @@ fun Activity.hapticTap() {
  * OnShowListener, so a plain [AlertDialog.setOnShowListener] is safe.
  */
 @SuppressLint("ClickableViewAccessibility")
-fun AlertDialog.wireHapticButtons() {
+private fun AlertDialog.wireHapticButtons() {
     fun applyNow() {
         listOf(
             AlertDialog.BUTTON_POSITIVE,
@@ -104,6 +104,29 @@ fun AlertDialog.wireHapticButtons() {
         }
     }
     if (isShowing) applyNow() else setOnShowListener { applyNow() }
+}
+
+/**
+ * Build the dialog and wire haptics onto its buttons in one call. Covers both
+ * [AlertDialog.Builder] and [com.google.android.material.dialog.MaterialAlertDialogBuilder]
+ * (which extends it) so every dialog show-site in the app collapses to a
+ * single terminal call instead of repeating `.show().also { it.wireHapticButtons() }`.
+ */
+fun AlertDialog.Builder.showWithHapticButtons(): AlertDialog = show().also { it.wireHapticButtons() }
+
+/** [showWithHapticButtons] counterpart for sites that want the dialog created but not yet shown. */
+fun AlertDialog.Builder.createWithHapticButtons(): AlertDialog = create().apply { wireHapticButtons() }
+
+/**
+ * [View.setOnClickListener] plus a haptic tap on the source view before the
+ * click callback runs. Use at every click-listener site in the app so the
+ * "vibrate then dispatch" pattern lives in one place.
+ */
+fun View.setOnHapticClickListener(onClick: (View) -> Unit) {
+    setOnClickListener { v ->
+        v.hapticTap()
+        onClick(v)
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.preference.Preference
 import com.eliormachlev.currencix.repository.Database
 
 /**
@@ -126,6 +127,26 @@ fun View.setOnHapticClickListener(onClick: (View) -> Unit) {
     setOnClickListener { v ->
         v.hapticTap()
         onClick(v)
+    }
+}
+
+/**
+ * [Preference.setOnPreferenceClickListener] that first fires a haptic tap on
+ * the hosting Activity, then runs [onClick]. Returns `true` from the listener
+ * — the preference framework treats that as "handled, don't open the default
+ * dialog", which is what every current call site wants (they open their own
+ * dialog / navigate / push a fragment).
+ *
+ * For built-in [androidx.preference.DialogPreference] rows whose default
+ * dialog SHOULD open, override
+ * [androidx.preference.PreferenceFragmentCompat.onDisplayPreferenceDialog]
+ * instead — that path fires haptic without short-circuiting the framework.
+ */
+fun Preference.setOnHapticClickListener(onClick: () -> Unit) {
+    setOnPreferenceClickListener {
+        (context as? Activity)?.hapticTap()
+        onClick()
+        true
     }
 }
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -151,6 +151,20 @@ fun Preference.setOnHapticClickListener(onClick: () -> Unit) {
 }
 
 /**
+ * [Preference.setOnPreferenceChangeListener] that first fires a haptic tap on
+ * the hosting Activity, then runs [onChange]. Always returns `true` so the
+ * new value is persisted — the callers we have here uniformly want that; if
+ * a future site needs conditional persistence, wire the raw listener directly.
+ */
+fun Preference.setOnHapticChangeListener(onChange: (newValue: Any?) -> Unit) {
+    setOnPreferenceChangeListener { _, newValue ->
+        (context as? Activity)?.hapticTap()
+        onChange(newValue)
+        true
+    }
+}
+
+/**
  * Compose analogue of [Modifier.clickable] that also fires a keyboard-tap
  * haptic on click, honouring the user's preference and battery-saver state.
  */

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
@@ -2,6 +2,7 @@ package com.eliormachlev.currencix.view
 
 import android.graphics.Color
 import android.os.Bundle
+import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -10,6 +11,7 @@ import androidx.window.layout.FoldingFeature
 import androidx.window.layout.WindowInfoTracker
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.Database
+import com.eliormachlev.currencix.util.hapticTap
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -27,6 +29,19 @@ abstract class BaseActivity : AppCompatActivity() {
         )
 
         super.onCreate(savedInstanceState)
+    }
+
+    /**
+     * Fires a haptic tap whenever the options-menu overflow opens. Individual
+     * item selection still fires its own tap from `onOptionsItemSelected`, so
+     * this only covers the "open the menu" gesture that would otherwise be silent.
+     */
+    override fun onMenuOpened(
+        featureId: Int,
+        menu: Menu,
+    ): Boolean {
+        hapticTap()
+        return super.onMenuOpened(featureId, menu)
     }
 
     /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
@@ -3,6 +3,7 @@ package com.eliormachlev.currencix.view
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -32,9 +33,8 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     /**
-     * Fires a haptic tap whenever the options-menu overflow opens. Individual
-     * item selection still fires its own tap from `onOptionsItemSelected`, so
-     * this only covers the "open the menu" gesture that would otherwise be silent.
+     * Fires a haptic tap whenever the options-menu overflow opens — covers the
+     * "open the popup" gesture that item-selection haptic wouldn't reach.
      */
     override fun onMenuOpened(
         featureId: Int,
@@ -42,6 +42,20 @@ abstract class BaseActivity : AppCompatActivity() {
     ): Boolean {
         hapticTap()
         return super.onMenuOpened(featureId, menu)
+    }
+
+    /**
+     * Central haptic for every menu-item tap (options menu, context menu,
+     * submenu). Fires before the framework dispatches to
+     * [onOptionsItemSelected] / [onContextItemSelected], so subclasses no
+     * longer need to call `hapticTap()` at the top of those overrides.
+     */
+    override fun onMenuItemSelected(
+        featureId: Int,
+        item: MenuItem,
+    ): Boolean {
+        hapticTap()
+        return super.onMenuItemSelected(featureId, item)
     }
 
     /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/BaseActivity.kt
@@ -3,7 +3,6 @@ package com.eliormachlev.currencix.view
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
-import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -42,20 +41,6 @@ abstract class BaseActivity : AppCompatActivity() {
     ): Boolean {
         hapticTap()
         return super.onMenuOpened(featureId, menu)
-    }
-
-    /**
-     * Central haptic for every menu-item tap (options menu, context menu,
-     * submenu). Fires before the framework dispatches to
-     * [onOptionsItemSelected] / [onContextItemSelected], so subclasses no
-     * longer need to call `hapticTap()` at the top of those overrides.
-     */
-    override fun onMenuItemSelected(
-        featureId: Int,
-        item: MenuItem,
-    ): Boolean {
-        hapticTap()
-        return super.onMenuItemSelected(featureId, item)
     }
 
     /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -198,9 +198,8 @@ class CartActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        hapticTap()
-        return when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
             android.R.id.home -> {
                 saveLoadCoordinator.attemptClose()
                 true
@@ -235,7 +234,6 @@ class CartActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
 
     private fun observe() {
         viewModel.isHapticFeedbackEnabled.observe(this) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -198,8 +198,9 @@ class CartActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean =
-        when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        hapticTap()
+        return when (item.itemId) {
             android.R.id.home -> {
                 saveLoadCoordinator.attemptClose()
                 true
@@ -234,6 +235,7 @@ class CartActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
 
     private fun observe() {
         viewModel.isHapticFeedbackEnabled.observe(this) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.paddedDialogContainer
+import com.eliormachlev.currencix.util.wireHapticButtons
 
 /**
  * Shared "title + one-line explainer per option" picker used by every
@@ -44,4 +45,5 @@ fun AppCompatActivity.showCartChoiceExplainerDialog(
             .setView(container)
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { it.wireHapticButtons() }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartChoiceDialog.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.paddedDialogContainer
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.showWithHapticButtons
 
 /**
  * Shared "title + one-line explainer per option" picker used by every
@@ -44,6 +44,5 @@ fun AppCompatActivity.showCartChoiceExplainerDialog(
             .setTitle(titleRes)
             .setView(container)
             .setNegativeButton(android.R.string.cancel, null)
-            .show()
-            .also { it.wireHapticButtons() }
+            .showWithHapticButtons()
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
@@ -9,7 +9,8 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.SavedCart
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.createWithHapticButtons
+import com.eliormachlev.currencix.util.showWithHapticButtons
 import com.eliormachlev.currencix.view.cart.compose.SavedCartsList
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
@@ -108,8 +109,7 @@ class CartSaveLoadCoordinator(
                                         saved.removeAll { it.id == cart.id }
                                         if (saved.isEmpty()) dialog.dismiss()
                                     }.setNegativeButton(android.R.string.cancel, null)
-                                    .show()
-                                    .also { it.wireHapticButtons() }
+                                    .showWithHapticButtons()
                             },
                         )
                     }
@@ -121,8 +121,7 @@ class CartSaveLoadCoordinator(
                 .setTitle(R.string.cart_menu_load)
                 .setView(composeView)
                 .setNegativeButton(android.R.string.cancel, null)
-                .create()
-                .apply { wireHapticButtons() }
+                .createWithHapticButtons()
         dialog.show()
     }
 
@@ -176,8 +175,7 @@ class CartSaveLoadCoordinator(
             .setItems(options.map { it.first }.toTypedArray()) { _, which ->
                 options[which].second.invoke()
             }.setNegativeButton(android.R.string.cancel, null)
-            .show()
-            .also { it.wireHapticButtons() }
+            .showWithHapticButtons()
     }
 
     // Shared "one-line text input" dialog for cart name prompts (Save-as,
@@ -205,7 +203,6 @@ class CartSaveLoadCoordinator(
                         .ifBlank { activity.getString(R.string.cart_default_saved_name) },
                 )
             }.setNegativeButton(android.R.string.cancel, null)
-            .show()
-            .also { it.wireHapticButtons() }
+            .showWithHapticButtons()
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartSaveLoadCoordinator.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.SavedCart
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.cart.compose.SavedCartsList
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.viewmodel.cart.CartViewModel
@@ -108,6 +109,7 @@ class CartSaveLoadCoordinator(
                                         if (saved.isEmpty()) dialog.dismiss()
                                     }.setNegativeButton(android.R.string.cancel, null)
                                     .show()
+                                    .also { it.wireHapticButtons() }
                             },
                         )
                     }
@@ -120,6 +122,7 @@ class CartSaveLoadCoordinator(
                 .setView(composeView)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
+                .apply { wireHapticButtons() }
         dialog.show()
     }
 
@@ -174,6 +177,7 @@ class CartSaveLoadCoordinator(
                 options[which].second.invoke()
             }.setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { it.wireHapticButtons() }
     }
 
     // Shared "one-line text input" dialog for cart name prompts (Save-as,
@@ -202,5 +206,6 @@ class CartSaveLoadCoordinator(
                 )
             }.setNegativeButton(android.R.string.cancel, null)
             .show()
+            .also { it.wireHapticButtons() }
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -51,6 +51,7 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.util.CalculatorKeyListener
 import com.eliormachlev.currencix.util.hapticClickable
+import com.eliormachlev.currencix.util.hapticOnFocus
 import com.eliormachlev.currencix.util.normaliseGlyphsToAscii
 import com.eliormachlev.currencix.util.roundForDisplay
 import com.eliormachlev.currencix.util.setTextAndCursorToEnd
@@ -285,6 +286,7 @@ private fun NameField(
             modifier =
                 Modifier
                     .fillMaxWidth()
+                    .hapticOnFocus()
                     .semantics { contentDescription = fieldLabel },
         )
         if (text.isEmpty()) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/CartItemRow.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.widget.EditText
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,6 +50,7 @@ import androidx.core.widget.doAfterTextChanged
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.CartItem
 import com.eliormachlev.currencix.util.CalculatorKeyListener
+import com.eliormachlev.currencix.util.hapticClickable
 import com.eliormachlev.currencix.util.normaliseGlyphsToAscii
 import com.eliormachlev.currencix.util.roundForDisplay
 import com.eliormachlev.currencix.util.setTextAndCursorToEnd
@@ -306,7 +306,7 @@ private fun ExpressionField(
             Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = FIELD_MIN_HEIGHT)
-                .clickable(onClick = onTap),
+                .hapticClickable(onClick = onTap),
         contentAlignment = Alignment.CenterStart,
     ) {
         Text(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/SavedCartsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/SavedCartsList.kt
@@ -1,6 +1,5 @@
 package com.eliormachlev.currencix.view.cart.compose
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +22,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.SavedCart
+import com.eliormachlev.currencix.util.hapticClickable
+import com.eliormachlev.currencix.util.rememberHapticOnClick
 
 private const val ROW_MIN_HEIGHT_DP = 48
 
@@ -57,7 +58,7 @@ private fun SavedCartRow(
             Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = ROW_MIN_HEIGHT_DP.dp)
-                .clickable(onClick = onPick)
+                .hapticClickable(onClick = onPick)
                 .padding(horizontal = dimensionResource(id = R.dimen.margin2x)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -69,13 +70,13 @@ private fun SavedCartRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
-        IconButton(onClick = onRename) {
+        IconButton(onClick = rememberHapticOnClick(onRename)) {
             Icon(
                 imageVector = Icons.Filled.Edit,
                 contentDescription = stringResource(id = R.string.cart_rename),
             )
         }
-        IconButton(onClick = onDelete) {
+        IconButton(onClick = rememberHapticOnClick(onDelete)) {
             Icon(
                 imageVector = Icons.Filled.Delete,
                 contentDescription = stringResource(id = R.string.cart_delete_item),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/compose/ComposeCommon.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
 import com.eliormachlev.currencix.model.Currency
+import com.eliormachlev.currencix.util.rememberHapticOnClick
 
 // The picker needs a small rounded thumbnail, the quick-conversions header a
 // larger square, and the chart layer wants none of that — so size + clip stay
@@ -70,7 +71,7 @@ fun FavoriteToggleIcon(
     contentDescription: String?,
     onClick: () -> Unit,
 ) {
-    IconButton(onClick = onClick) {
+    IconButton(onClick = rememberHapticOnClick(onClick)) {
         Icon(
             imageVector = if (active) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
             contentDescription = contentDescription,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -55,6 +55,7 @@ import com.eliormachlev.currencix.util.paintParenCycle
 import com.eliormachlev.currencix.util.rateSpinnerListener
 import com.eliormachlev.currencix.util.setTextAndCursorToEnd
 import com.eliormachlev.currencix.util.showSoftInputOn
+import com.eliormachlev.currencix.util.showWithHapticButtons
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.stripTimePattern
 import com.eliormachlev.currencix.util.toHumanReadableNumber
@@ -369,9 +370,7 @@ class MainActivity : BaseActivity() {
                     },
                 )
             }.setNegativeButton(android.R.string.cancel, null)
-            .create()
-            .apply { wireHapticButtons() }
-            .show()
+            .showWithHapticButtons()
     }
 
     override fun onCreateContextMenu(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -185,8 +185,9 @@ class MainActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean =
-        when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        hapticTap()
+        return when (item.itemId) {
             R.id.settings -> {
                 startActivity(Intent(this, PreferenceActivity::class.java))
                 true
@@ -222,6 +223,7 @@ class MainActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
 
     private fun showApiProviderPicker() {
         showProviderPickerDialog(
@@ -368,6 +370,7 @@ class MainActivity : BaseActivity() {
                 )
             }.setNegativeButton(android.R.string.cancel, null)
             .create()
+            .apply { wireHapticButtons() }
             .show()
     }
 
@@ -391,6 +394,7 @@ class MainActivity : BaseActivity() {
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {
+        hapticTap()
         when (item.itemId) {
             CTX_MENU_COPY_FROM -> copyToClipboard(findViewById<TextView>(R.id.textFrom).text.toString())
             CTX_MENU_PASTE_FROM -> {
@@ -424,6 +428,7 @@ class MainActivity : BaseActivity() {
         // long click on delete
         arrayOf<View>(findViewById(R.id.keypad), findViewById(R.id.keypad_extended)).forEach {
             it.findViewById<AppCompatImageButton>(R.id.btn_delete).setOnLongClickListener {
+                it.hapticTap(hapticEnabled)
                 viewModel.clear()
                 true
             }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -186,8 +186,9 @@ class MainActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean =
-        when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        hapticTap()
+        return when (item.itemId) {
             R.id.settings -> {
                 startActivity(Intent(this, PreferenceActivity::class.java))
                 true
@@ -223,6 +224,7 @@ class MainActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
 
     private fun showApiProviderPicker() {
         showProviderPickerDialog(
@@ -391,6 +393,7 @@ class MainActivity : BaseActivity() {
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {
+        hapticTap()
         when (item.itemId) {
             CTX_MENU_COPY_FROM -> copyToClipboard(findViewById<TextView>(R.id.textFrom).text.toString())
             CTX_MENU_PASTE_FROM -> {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -452,6 +452,12 @@ class MainActivity : BaseActivity() {
         // long-press on the main swap arrow opens the Fees settings,
         // mirroring the swap arrow inside the quick-conversions dialog.
         findViewById<View>(R.id.btn_toggle).setOnLongClickListener { openFeesSettings(it) }
+
+        // In system-keyboard mode `tvCalculations` becomes the tap target that
+        // opens the IME; every other tap in the app vibrates, so this one
+        // should too. Gated on the mode flag because the field isn't tappable
+        // when the custom keypads are in use.
+        tvCalculations.setOnClickListener { v -> if (isSystemKeyboardMode) v.hapticTap() }
     }
 
     private fun openFeesSettings(source: View): Boolean {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -186,9 +186,8 @@ class MainActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        hapticTap()
-        return when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
             R.id.settings -> {
                 startActivity(Intent(this, PreferenceActivity::class.java))
                 true
@@ -224,7 +223,6 @@ class MainActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
 
     private fun showApiProviderPicker() {
         showProviderPickerDialog(
@@ -393,7 +391,6 @@ class MainActivity : BaseActivity() {
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {
-        hapticTap()
         when (item.itemId) {
             CTX_MENU_COPY_FROM -> copyToClipboard(findViewById<TextView>(R.id.textFrom).text.toString())
             CTX_MENU_PASTE_FROM -> {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.ViewModelProvider
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.SideStacks
+import com.eliormachlev.currencix.util.createWithHapticButtons
 import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
-import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsContent
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsRow
@@ -87,8 +87,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             .setTitle(R.string.quick_conversions_title)
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
-            .create()
-            .apply { wireHapticButtons() }
+            .createWithHapticButtons()
     }
 
     private fun openFeesSettings(ctx: Context) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/QuickConversionsDialog.kt
@@ -15,6 +15,7 @@ import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.SideStacks
 import com.eliormachlev.currencix.util.feePercentDelta
 import com.eliormachlev.currencix.util.isNeutralFeeStack
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsContent
 import com.eliormachlev.currencix.view.main.compose.QuickConversionsRow
@@ -87,6 +88,7 @@ class QuickConversionsDialog : AppCompatDialogFragment() {
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
             .create()
+            .apply { wireHapticButtons() }
     }
 
     private fun openFeesSettings(ctx: Context) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/compose/QuickConversionsContent.kt
@@ -1,7 +1,5 @@
 package com.eliormachlev.currencix.view.main.compose
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
+import com.eliormachlev.currencix.util.hapticCombinedClickable
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
 import com.eliormachlev.currencix.view.compose.Ltr
 
@@ -155,7 +154,6 @@ private fun QuickConversionsHeader(
 // (WCAG 2.1 AA target size) with long-press support. Keeps the .size and
 // .combinedClickable chained together so no intermediate padding can shrink
 // the click target below 48dp.
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun LongPressIconButton(
     onClick: () -> Unit,
@@ -167,7 +165,7 @@ private fun LongPressIconButton(
         modifier =
             modifier
                 .size(ICON_BUTTON_SIZE_DP.dp)
-                .combinedClickable(
+                .hapticCombinedClickable(
                     onClick = onClick,
                     onLongClick = onLongClick,
                 ),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -1,7 +1,6 @@
 package com.eliormachlev.currencix.view.main.spinner
 
 import android.content.Context
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -57,8 +56,10 @@ import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
 import com.eliormachlev.currencix.util.DISABLED_ROW_ALPHA
+import com.eliormachlev.currencix.util.hapticClickable
 import com.eliormachlev.currencix.util.hasAppendedCurrencySymbol
 import com.eliormachlev.currencix.util.normalizeForSearch
+import com.eliormachlev.currencix.util.rememberHapticOnClick
 import com.eliormachlev.currencix.util.stripRtlMark
 import com.eliormachlev.currencix.util.toHumanReadableNumber
 import com.eliormachlev.currencix.view.compose.CurrencyFlagImage
@@ -172,7 +173,7 @@ private fun SearchBar(
             },
             trailingIcon = {
                 if (query.isNotEmpty()) {
-                    IconButton(onClick = { onQueryChange("") }) {
+                    IconButton(onClick = rememberHapticOnClick { onQueryChange("") }) {
                         Icon(
                             imageVector = Icons.Filled.Clear,
                             contentDescription = stringResource(id = R.string.a11y_clear_search),
@@ -190,7 +191,7 @@ private fun SearchBar(
                     .onFocusChanged { if (it.isFocused) keyboard?.show() },
         )
         IconButton(
-            onClick = onToggleStarredFilter,
+            onClick = rememberHapticOnClick(onToggleStarredFilter),
             modifier = Modifier.padding(start = dimensionResource(id = R.dimen.margin1x)),
         ) {
             Icon(
@@ -378,7 +379,7 @@ private fun CurrencyRow(
             modifier =
                 Modifier
                     .weight(1f)
-                    .clickable(enabled = !isDisabled, onClick = onClick)
+                    .hapticClickable(enabled = !isDisabled, onClick = onClick)
                     .alpha(if (isDisabled) DISABLED_ROW_ALPHA else 1f)
                     .padding(
                         horizontal = dimensionResource(id = R.dimen.margin2x),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentActivity
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
+import com.eliormachlev.currencix.util.hapticTap
 import java.math.BigDecimal
 
 // Matches AdapterView.INVALID_POSITION; used when there's no rate for the
@@ -73,7 +74,10 @@ class SearchableSpinner : AppCompatSpinner {
             // else show dialog, if this spinner is backed by an adapter
             !spinnerDialog.isVisible -> {
                 val fm = findActivity(mContext)?.supportFragmentManager
-                if (fm != null) spinnerDialog.show(fm, null)
+                if (fm != null) {
+                    hapticTap()
+                    spinnerDialog.show(fm, null)
+                }
                 true
             }
             // else do nothing

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.createWithHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.viewmodel.main.MainViewModel
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
@@ -112,8 +112,7 @@ class SearchableSpinnerDialog(
             .Builder(requireContext())
             .setNegativeButton(getString(android.R.string.cancel), null)
             .setView(composeView)
-            .create()
-            .apply { wireHapticButtons() }
+            .createWithHapticButtons()
     }
 
     override fun onStart() {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinnerDialog.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.model.Rate
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.viewmodel.main.MainViewModel
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
@@ -112,6 +113,7 @@ class SearchableSpinnerDialog(
             .setNegativeButton(getString(android.R.string.cancel), null)
             .setView(composeView)
             .create()
+            .apply { wireHapticButtons() }
     }
 
     override fun onStart() {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
@@ -21,7 +21,7 @@ import androidx.preference.PreferenceScreen
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.BackupManager
 import com.eliormachlev.currencix.repository.BackupResult
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.showWithHapticButtons
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
 
@@ -188,8 +188,7 @@ class BackupFragment : PreferenceFragmentCompat() {
                     }
                 pendingExportPassword = password
                 launchExport()
-            }.show()
-            .also { it.wireHapticButtons() }
+            }.showWithHapticButtons()
     }
 
     private fun launchExport() {
@@ -274,8 +273,7 @@ class BackupFragment : PreferenceFragmentCompat() {
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 val password = extractCharArray(passwordInput)
                 confirmAndImport(uri, password)
-            }.show()
-            .also { it.wireHapticButtons() }
+            }.showWithHapticButtons()
     }
 
     private fun confirmAndImport(
@@ -289,8 +287,7 @@ class BackupFragment : PreferenceFragmentCompat() {
                 password?.fill('\u0000')
             }.setPositiveButton(R.string.backup_import_confirm_positive) { _, _ ->
                 runImport(uri, password)
-            }.show()
-            .also { it.wireHapticButtons() }
+            }.showWithHapticButtons()
     }
 
     private fun runImport(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
@@ -21,6 +21,7 @@ import androidx.preference.PreferenceScreen
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.BackupManager
 import com.eliormachlev.currencix.repository.BackupResult
+import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.util.showWithHapticButtons
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
@@ -132,10 +133,7 @@ class BackupFragment : PreferenceFragmentCompat() {
             title = getString(titleRes)
             summary = getString(summaryRes)
             isIconSpaceReserved = false
-            setOnPreferenceClickListener {
-                onClick()
-                true
-            }
+            setOnHapticClickListener(onClick)
         }
 
     /**

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/BackupFragment.kt
@@ -21,6 +21,7 @@ import androidx.preference.PreferenceScreen
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.BackupManager
 import com.eliormachlev.currencix.repository.BackupResult
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
 
@@ -188,6 +189,7 @@ class BackupFragment : PreferenceFragmentCompat() {
                 pendingExportPassword = password
                 launchExport()
             }.show()
+            .also { it.wireHapticButtons() }
     }
 
     private fun launchExport() {
@@ -273,6 +275,7 @@ class BackupFragment : PreferenceFragmentCompat() {
                 val password = extractCharArray(passwordInput)
                 confirmAndImport(uri, password)
             }.show()
+            .also { it.wireHapticButtons() }
     }
 
     private fun confirmAndImport(
@@ -287,6 +290,7 @@ class BackupFragment : PreferenceFragmentCompat() {
             }.setPositiveButton(R.string.backup_import_confirm_positive) { _, _ ->
                 runImport(uri, password)
             }.show()
+            .also { it.wireHapticButtons() }
     }
 
     private fun runImport(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/CreditsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/CreditsDialog.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.compose.ui.platform.ComposeView
 import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.preference.compose.CreditsList
 import com.eliormachlev.currencix.view.preference.compose.creditsSections
@@ -28,5 +29,6 @@ class CreditsDialog : AppCompatDialogFragment() {
             .setTitle(R.string.title_credits)
             .setView(view)
             .create()
+            .apply { wireHapticButtons() }
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/CreditsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/CreditsDialog.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.compose.ui.platform.ComposeView
 import com.eliormachlev.currencix.R
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.createWithHapticButtons
 import com.eliormachlev.currencix.view.compose.AppTheme
 import com.eliormachlev.currencix.view.preference.compose.CreditsList
 import com.eliormachlev.currencix.view.preference.compose.creditsSections
@@ -28,7 +28,6 @@ class CreditsDialog : AppCompatDialogFragment() {
             .setPositiveButton(android.R.string.ok, null)
             .setTitle(R.string.title_credits)
             .setView(view)
-            .create()
-            .apply { wireHapticButtons() }
+            .createWithHapticButtons()
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -36,11 +36,11 @@ import com.eliormachlev.currencix.util.DISABLED_ROW_ALPHA
 import com.eliormachlev.currencix.util.applySelectableRowBackground
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.dpToPx
-import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.paddedDialogContainer
+import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
+import com.eliormachlev.currencix.util.showWithHapticButtons
 import com.eliormachlev.currencix.util.toHumanReadableNumber
-import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -439,8 +439,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .setTitle(title)
                 .setView(container)
                 .setNegativeButton(android.R.string.cancel, null)
-                .show()
-                .also { it.wireHapticButtons() }
+                .showWithHapticButtons()
     }
 
     private fun buildPickerRadio(
@@ -455,8 +454,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             isFocusable = true
             minWidth = minTouchPx
             minHeight = minTouchPx
-            setOnClickListener {
-                it.hapticTap()
+            setOnHapticClickListener {
                 onClick()
             }
         }
@@ -473,8 +471,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             setPadding(0, padV, 0, padV)
             isClickable = true
             applySelectableRowBackground()
-            setOnClickListener {
-                it.hapticTap()
+            setOnHapticClickListener {
                 onClick()
             }
             addView(buildRowIcon(ctx, R.drawable.ic_add, null, onClick = null))
@@ -505,8 +502,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 applySelectableRowBackground()
                 isClickable = true
                 isFocusable = true
-                setOnClickListener {
-                    it.hapticTap()
+                setOnHapticClickListener {
                     onClick()
                 }
             }
@@ -728,8 +724,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .setNegativeButton(android.R.string.cancel, null)
                 .withDeleteButton(onDelete)
                 .setPositiveButton(android.R.string.ok) { _, _ -> onOk() }
-                .show()
-                .also { it.wireHapticButtons() }
+                .showWithHapticButtons()
         val width = (ctx.resources.displayMetrics.widthPixels * FEE_EDITOR_DIALOG_WIDTH_FRACTION).toInt()
         dialog.window?.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
@@ -966,8 +961,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 applySelectableRowBackground()
                 addView(titleView)
                 addView(descView)
-                setOnClickListener {
-                    it.hapticTap()
+                setOnHapticClickListener {
                     val sides = listOf(FeeSide.ORIGINAL, FeeSide.CONVERTED)
                     showChoiceExplainerDialog(
                         ctx = ctx,
@@ -999,8 +993,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
     ): MaterialButton =
         outlinedMaterialButton(ctx).apply {
             applyCurrencyIcon(this, initial, placeholder, ctx)
-            setOnClickListener {
-                it.hapticTap()
+            setOnHapticClickListener {
                 // Resolve the disabled side lazily at click time so a "from"
                 // picked *after* the button was built still greys out inside
                 // the "to" picker (and vice-versa).

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -369,7 +369,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             pref.title = displayNameOf(effective)
             pref.summary = formatFeeDescription(effective)
         }
-        pref.setOnPreferenceClickListener {
+        pref.setOnHapticClickListener {
             showGlobalPickerDialog(
                 entries = entries,
                 effectiveId = effective?.id,
@@ -383,7 +383,6 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 onAdd = onAdd,
                 onEdit = onEdit,
             )
-            true
         }
     }
 
@@ -556,10 +555,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                         title = formatFeeTitle(fee)
                         summary = withInactiveMarker(summaryFor(fee), fee.isActive)
                         isIconSpaceReserved = false
-                        setOnPreferenceClickListener {
-                            onEdit(fee)
-                            true
-                        }
+                        setOnHapticClickListener { onEdit(fee) }
                     },
                 )
             }
@@ -568,10 +564,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             Preference(ctx).apply {
                 title = getString(R.string.fee_add)
                 setIcon(R.drawable.ic_add)
-                setOnPreferenceClickListener {
-                    onAdd()
-                    true
-                }
+                setOnHapticClickListener(onAdd)
             },
         )
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/FeeManagerFragment.kt
@@ -36,9 +36,11 @@ import com.eliormachlev.currencix.util.DISABLED_ROW_ALPHA
 import com.eliormachlev.currencix.util.applySelectableRowBackground
 import com.eliormachlev.currencix.util.choiceExplainerRow
 import com.eliormachlev.currencix.util.dpToPx
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.paddedDialogContainer
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.util.toHumanReadableNumber
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.view.main.spinner.SearchableSpinnerDialog
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -438,6 +440,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .setView(container)
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()
+                .also { it.wireHapticButtons() }
     }
 
     private fun buildPickerRadio(
@@ -452,7 +455,10 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             isFocusable = true
             minWidth = minTouchPx
             minHeight = minTouchPx
-            setOnClickListener { onClick() }
+            setOnClickListener {
+                it.hapticTap()
+                onClick()
+            }
         }
     }
 
@@ -467,7 +473,10 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
             setPadding(0, padV, 0, padV)
             isClickable = true
             applySelectableRowBackground()
-            setOnClickListener { onClick() }
+            setOnClickListener {
+                it.hapticTap()
+                onClick()
+            }
             addView(buildRowIcon(ctx, R.drawable.ic_add, null, onClick = null))
             addView(
                 TextView(ctx).apply {
@@ -496,7 +505,10 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 applySelectableRowBackground()
                 isClickable = true
                 isFocusable = true
-                setOnClickListener { onClick() }
+                setOnClickListener {
+                    it.hapticTap()
+                    onClick()
+                }
             }
         }
     }
@@ -717,6 +729,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 .withDeleteButton(onDelete)
                 .setPositiveButton(android.R.string.ok) { _, _ -> onOk() }
                 .show()
+                .also { it.wireHapticButtons() }
         val width = (ctx.resources.displayMetrics.widthPixels * FEE_EDITOR_DIALOG_WIDTH_FRACTION).toInt()
         dialog.window?.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
@@ -954,6 +967,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
                 addView(titleView)
                 addView(descView)
                 setOnClickListener {
+                    it.hapticTap()
                     val sides = listOf(FeeSide.ORIGINAL, FeeSide.CONVERTED)
                     showChoiceExplainerDialog(
                         ctx = ctx,
@@ -986,6 +1000,7 @@ class FeeManagerFragment : PreferenceFragmentCompat() {
         outlinedMaterialButton(ctx).apply {
             applyCurrencyIcon(this, initial, placeholder, ctx)
             setOnClickListener {
+                it.hapticTap()
                 // Resolve the disabled side lazily at click time so a "from"
                 // picked *after* the button was built still greys out inside
                 // the "to" picker (and vice-versa).

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/GraphOptionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/GraphOptionsDialog.kt
@@ -7,6 +7,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.Database
+import com.eliormachlev.currencix.util.hapticTap
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.google.android.material.materialswitch.MaterialSwitch
 
 class GraphOptionsDialog : AppCompatDialogFragment() {
@@ -51,6 +53,7 @@ class GraphOptionsDialog : AppCompatDialogFragment() {
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
             .create()
+            .apply { wireHapticButtons() }
     }
 
     private fun bindSwitch(
@@ -61,7 +64,10 @@ class GraphOptionsDialog : AppCompatDialogFragment() {
     ) {
         root.findViewById<MaterialSwitch>(id).apply {
             isChecked = getter()
-            setOnCheckedChangeListener { _, checked -> setter(checked) }
+            setOnCheckedChangeListener { view, checked ->
+                view.hapticTap()
+                setter(checked)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/GraphOptionsDialog.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/GraphOptionsDialog.kt
@@ -7,8 +7,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.repository.Database
+import com.eliormachlev.currencix.util.createWithHapticButtons
 import com.eliormachlev.currencix.util.hapticTap
-import com.eliormachlev.currencix.util.wireHapticButtons
 import com.google.android.material.materialswitch.MaterialSwitch
 
 class GraphOptionsDialog : AppCompatDialogFragment() {
@@ -52,8 +52,7 @@ class GraphOptionsDialog : AppCompatDialogFragment() {
             .setTitle(R.string.category_graph_options)
             .setView(view)
             .setPositiveButton(android.R.string.ok, null)
-            .create()
-            .apply { wireHapticButtons() }
+            .createWithHapticButtons()
     }
 
     private fun bindSwitch(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
@@ -17,9 +17,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Language
-import com.eliormachlev.currencix.util.hapticTap
+import com.eliormachlev.currencix.util.createWithHapticButtons
 import com.eliormachlev.currencix.util.normalizeForSearch
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
 import com.google.android.material.radiobutton.MaterialRadioButton
 
@@ -75,8 +75,7 @@ class LanguagePickerPreference : ListPreference {
                 .setTitle(R.string.language_title)
                 .setView(view)
                 .setNegativeButton(android.R.string.cancel, null)
-                .create()
-                .apply { wireHapticButtons() }
+                .createWithHapticButtons()
         adapter.onLanguageClicked = { language: Language ->
             callChangeListener(language.iso)
             dialog.dismiss()
@@ -158,8 +157,7 @@ class LanguagePickerPreference : ListPreference {
             holder.run {
                 val language = languages[position]
                 // register clicks
-                parentView?.setOnClickListener {
-                    it.hapticTap()
+                parentView?.setOnHapticClickListener {
                     onLanguageClicked?.invoke(language)
                 }
                 // check current active language

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
@@ -18,6 +18,7 @@ import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Language
 import com.eliormachlev.currencix.util.createWithHapticButtons
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.normalizeForSearch
 import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
@@ -64,6 +65,7 @@ class LanguagePickerPreference : ListPreference {
 
     // open dialog
     override fun onClick() {
+        (context as? Activity)?.hapticTap()
         val view =
             LayoutInflater
                 .from(context)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/LanguagePickerPreference.kt
@@ -17,7 +17,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Language
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.normalizeForSearch
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
 import com.google.android.material.radiobutton.MaterialRadioButton
 
@@ -74,6 +76,7 @@ class LanguagePickerPreference : ListPreference {
                 .setView(view)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
+                .apply { wireHapticButtons() }
         adapter.onLanguageClicked = { language: Language ->
             callChangeListener(language.iso)
             dialog.dismiss()
@@ -155,7 +158,10 @@ class LanguagePickerPreference : ListPreference {
             holder.run {
                 val language = languages[position]
                 // register clicks
-                parentView?.setOnClickListener { onLanguageClicked?.invoke(language) }
+                parentView?.setOnClickListener {
+                    it.hapticTap()
+                    onLanguageClicked?.invoke(language)
+                }
                 // check current active language
                 radioButton?.isChecked = (language == selectedItem)
                 // fill text

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
@@ -25,6 +25,7 @@ import com.eliormachlev.currencix.util.DECIMAL_PLACES_DEFAULT
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_MAX
 import com.eliormachlev.currencix.util.DECIMAL_PLACES_MIN
 import com.eliormachlev.currencix.util.asPreferenceSummary
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.releaseNotesUrl
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.view.main.MainActivity
@@ -73,6 +74,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     private fun setupGraphOptionsPreference() {
         findPreference<Preference>(getString(R.string.graph_options_key))?.apply {
             setOnPreferenceClickListener {
+                requireActivity().hapticTap()
                 GraphOptionsDialog().show(childFragmentManager, null)
                 true
             }
@@ -92,6 +94,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         factory: () -> Fragment,
     ) {
         findPreference<Preference>(getString(keyRes))?.setOnPreferenceClickListener {
+            requireActivity().hapticTap()
             parentFragmentManager
                 .beginTransaction()
                 .replace(R.id.preferences_fragment, factory())
@@ -108,6 +111,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         val pref = findPreference<Preference>(getString(R.string.keyboard_key)) ?: return
         pref.summary = summaryForKeyboardType(viewModel.getKeyboardTypeBlocking())
         pref.setOnPreferenceClickListener {
+            requireActivity().hapticTap()
             showKeyboardPickerDialog { picked ->
                 viewModel.setKeyboardType(picked)
                 pref.summary = summaryForKeyboardType(picked)
@@ -163,6 +167,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     private fun setupDisplayPreferences() {
         findPreference<SwitchPreferenceCompat>(getString(R.string.previewConversion_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 viewModel.setPreviewConversionEnabled(newValue.toString().toBoolean())
                 true
             }
@@ -170,6 +175,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         setupKeyboardPreference()
         findPreference<ListPreference>(getString(R.string.decimal_places_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 viewModel.setDecimalPlaces(
                     (newValue.toString().toIntOrNull() ?: DECIMAL_PLACES_DEFAULT)
                         .coerceIn(DECIMAL_PLACES_MIN, DECIMAL_PLACES_MAX),
@@ -179,12 +185,14 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         findPreference<SwitchPreferenceCompat>(getString(R.string.haptic_feedback_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 viewModel.setHapticFeedbackEnabled(newValue.toString().toBoolean())
                 true
             }
         }
         findPreference<ListPreference>(getString(R.string.theme_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 val theme = AppTheme.fromId(newValue.toString().toInt())
                 if (viewModel.setTheme(theme)) {
                     rebuildActivityStack()
@@ -194,6 +202,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         findPreference<LanguagePickerPreference>(getString(R.string.language_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 viewModel.setLanguage(newValue.toString())
                 true
             }
@@ -207,6 +216,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         val apiKeyPref = findPreference<EditTextPreference>(getString(R.string.api_open_exchangerates_id_key))
         apiKeyPref?.apply {
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 viewModel.setOpenExchangeratesApiKey(newValue.toString().trim())
                 true
             }
@@ -223,6 +233,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             entries = providers.map { it.getName() }.toTypedArray()
             entryValues = providers.map { it.id.toString() }.toTypedArray()
             setOnPreferenceChangeListener { _, newValue ->
+                requireActivity().hapticTap()
                 val provider = ApiProvider.fromId(newValue.toString().toIntOrNull() ?: UNKNOWN_PROVIDER_ID)
                 viewModel.setApiProvider(provider)
                 apiKeyPref?.isVisible = provider == ApiProvider.OPEN_EXCHANGERATES
@@ -248,6 +259,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     private fun setupAboutPreferences() {
         findPreference<Preference>(getString(R.string.credits_key))?.apply {
             setOnPreferenceClickListener {
+                requireActivity().hapticTap()
                 CreditsDialog().show(childFragmentManager, null)
                 true
             }
@@ -256,6 +268,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             @Suppress("KotlinConstantConditions")
             isVisible = BuildConfig.FLAVOR == FLAVOR_PLAY
             setOnPreferenceClickListener {
+                requireActivity().hapticTap()
                 try {
                     startActivity(createIntent(URL_PLAY_MARKET))
                 } catch (e: ActivityNotFoundException) {
@@ -267,6 +280,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         findPreference<Preference>(getString(R.string.changelog_key))?.apply {
             setOnPreferenceClickListener {
+                requireActivity().hapticTap()
                 startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(releaseNotesUrl())))
                 true
             }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
@@ -27,6 +27,7 @@ import com.eliormachlev.currencix.util.DECIMAL_PLACES_MIN
 import com.eliormachlev.currencix.util.asPreferenceSummary
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.releaseNotesUrl
+import com.eliormachlev.currencix.util.setOnHapticChangeListener
 import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.view.main.MainActivity
@@ -167,48 +168,33 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupDisplayPreferences() {
-        findPreference<SwitchPreferenceCompat>(getString(R.string.previewConversion_key))?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+        findPreference<SwitchPreferenceCompat>(getString(R.string.previewConversion_key))
+            ?.setOnHapticChangeListener { newValue ->
                 viewModel.setPreviewConversionEnabled(newValue.toString().toBoolean())
-                true
             }
-        }
         setupKeyboardPreference()
-        findPreference<ListPreference>(getString(R.string.decimal_places_key))?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+        findPreference<ListPreference>(getString(R.string.decimal_places_key))
+            ?.setOnHapticChangeListener { newValue ->
                 viewModel.setDecimalPlaces(
                     (newValue.toString().toIntOrNull() ?: DECIMAL_PLACES_DEFAULT)
                         .coerceIn(DECIMAL_PLACES_MIN, DECIMAL_PLACES_MAX),
                 )
-                true
             }
-        }
-        findPreference<SwitchPreferenceCompat>(getString(R.string.haptic_feedback_key))?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+        findPreference<SwitchPreferenceCompat>(getString(R.string.haptic_feedback_key))
+            ?.setOnHapticChangeListener { newValue ->
                 viewModel.setHapticFeedbackEnabled(newValue.toString().toBoolean())
-                true
             }
-        }
-        findPreference<ListPreference>(getString(R.string.theme_key))?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+        findPreference<ListPreference>(getString(R.string.theme_key))
+            ?.setOnHapticChangeListener { newValue ->
                 val theme = AppTheme.fromId(newValue.toString().toInt())
                 if (viewModel.setTheme(theme)) {
                     rebuildActivityStack()
                 }
-                true
             }
-        }
-        findPreference<LanguagePickerPreference>(getString(R.string.language_key))?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+        findPreference<LanguagePickerPreference>(getString(R.string.language_key))
+            ?.setOnHapticChangeListener { newValue ->
                 viewModel.setLanguage(newValue.toString())
-                true
             }
-        }
         findPreference<ListPreference>(getString(R.string.date_format_key))?.apply {
             summaryProvider = Preference.SummaryProvider<ListPreference> { pref -> pref.value }
         }
@@ -217,10 +203,8 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     private fun setupApiPreferences() {
         val apiKeyPref = findPreference<EditTextPreference>(getString(R.string.api_open_exchangerates_id_key))
         apiKeyPref?.apply {
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+            setOnHapticChangeListener { newValue ->
                 viewModel.setOpenExchangeratesApiKey(newValue.toString().trim())
-                true
             }
             dialogMessage = getText(R.string.api_open_exchangerates_api_key_message)
         }
@@ -234,12 +218,10 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             val providers = ApiProvider.entries
             entries = providers.map { it.getName() }.toTypedArray()
             entryValues = providers.map { it.id.toString() }.toTypedArray()
-            setOnPreferenceChangeListener { _, newValue ->
-                requireActivity().hapticTap()
+            setOnHapticChangeListener { newValue ->
                 val provider = ApiProvider.fromId(newValue.toString().toIntOrNull() ?: UNKNOWN_PROVIDER_ID)
                 viewModel.setApiProvider(provider)
                 apiKeyPref?.isVisible = provider == ApiProvider.OPEN_EXCHANGERATES
-                true
             }
             if (entry == null) {
                 val defaultProvider = ApiProvider.fromId(UNKNOWN_PROVIDER_ID)

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
@@ -27,6 +27,7 @@ import com.eliormachlev.currencix.util.DECIMAL_PLACES_MIN
 import com.eliormachlev.currencix.util.asPreferenceSummary
 import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.releaseNotesUrl
+import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.eliormachlev.currencix.util.showChoiceExplainerDialog
 import com.eliormachlev.currencix.view.main.MainActivity
 import com.eliormachlev.currencix.viewmodel.preference.PreferenceViewModel
@@ -57,6 +58,15 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         activity?.setTitle(R.string.title_preferences)
     }
 
+    // Every built-in DialogPreference (theme, decimal places, date format,
+    // API-key EditText) routes through this callback before its dialog opens.
+    // Custom pickers like LanguagePickerPreference / ProviderPickerPreference
+    // fire haptic in their own overridden onClick() instead.
+    override fun onDisplayPreferenceDialog(preference: Preference) {
+        requireActivity().hapticTap()
+        super.onDisplayPreferenceDialog(preference)
+    }
+
     override fun onCreatePreferences(
         savedInstanceState: Bundle?,
         rootKey: String?,
@@ -72,12 +82,8 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupGraphOptionsPreference() {
-        findPreference<Preference>(getString(R.string.graph_options_key))?.apply {
-            setOnPreferenceClickListener {
-                requireActivity().hapticTap()
-                GraphOptionsDialog().show(childFragmentManager, null)
-                true
-            }
+        findPreference<Preference>(getString(R.string.graph_options_key))?.setOnHapticClickListener {
+            GraphOptionsDialog().show(childFragmentManager, null)
         }
     }
 
@@ -93,14 +99,12 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         keyRes: Int,
         factory: () -> Fragment,
     ) {
-        findPreference<Preference>(getString(keyRes))?.setOnPreferenceClickListener {
-            requireActivity().hapticTap()
+        findPreference<Preference>(getString(keyRes))?.setOnHapticClickListener {
             parentFragmentManager
                 .beginTransaction()
                 .replace(R.id.preferences_fragment, factory())
                 .addToBackStack(null)
                 .commit()
-            true
         }
     }
 
@@ -110,13 +114,11 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     private fun setupKeyboardPreference() {
         val pref = findPreference<Preference>(getString(R.string.keyboard_key)) ?: return
         pref.summary = summaryForKeyboardType(viewModel.getKeyboardTypeBlocking())
-        pref.setOnPreferenceClickListener {
-            requireActivity().hapticTap()
+        pref.setOnHapticClickListener {
             showKeyboardPickerDialog { picked ->
                 viewModel.setKeyboardType(picked)
                 pref.summary = summaryForKeyboardType(picked)
             }
-            true
         }
     }
 
@@ -257,33 +259,23 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupAboutPreferences() {
-        findPreference<Preference>(getString(R.string.credits_key))?.apply {
-            setOnPreferenceClickListener {
-                requireActivity().hapticTap()
-                CreditsDialog().show(childFragmentManager, null)
-                true
-            }
+        findPreference<Preference>(getString(R.string.credits_key))?.setOnHapticClickListener {
+            CreditsDialog().show(childFragmentManager, null)
         }
         findPreference<Preference>(getString(R.string.rate_key))?.apply {
             @Suppress("KotlinConstantConditions")
             isVisible = BuildConfig.FLAVOR == FLAVOR_PLAY
-            setOnPreferenceClickListener {
-                requireActivity().hapticTap()
+            setOnHapticClickListener {
                 try {
                     startActivity(createIntent(URL_PLAY_MARKET))
                 } catch (e: ActivityNotFoundException) {
                     Timber.tag("PreferenceFragment").d(e, "Play Store not available, opening browser")
                     startActivity(createIntent(URL_PLAY_WEB))
                 }
-                true
             }
         }
-        findPreference<Preference>(getString(R.string.changelog_key))?.apply {
-            setOnPreferenceClickListener {
-                requireActivity().hapticTap()
-                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(releaseNotesUrl())))
-                true
-            }
+        findPreference<Preference>(getString(R.string.changelog_key))?.setOnHapticClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(releaseNotesUrl())))
         }
         findPreference<Preference>(getString(R.string.version_key))?.apply {
             title = BuildConfig.VERSION_NAME

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
@@ -12,6 +12,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.ApiProvider
+import com.eliormachlev.currencix.util.hapticTap
+import com.eliormachlev.currencix.util.wireHapticButtons
 import com.google.android.material.radiobutton.MaterialRadioButton
 
 /**
@@ -34,6 +36,7 @@ internal fun showProviderPickerDialog(
             .setTitle(R.string.api_title)
             .setNegativeButton(android.R.string.cancel, null)
             .create()
+            .apply { wireHapticButtons() }
     adapter.onProviderClicked = { provider ->
         onSelected(provider)
         dialog.dismiss()
@@ -111,7 +114,10 @@ internal class ProviderPickerDialogAdapter(
         holder.run {
             val provider = providers[position]
             // register clicks
-            parentView?.setOnClickListener { onProviderClicked?.invoke(provider) }
+            parentView?.setOnClickListener {
+                it.hapticTap()
+                onProviderClicked?.invoke(provider)
+            }
             // check current active api provider
             radioButton?.isChecked = (provider == selectedItem)
             // fill text

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
@@ -12,8 +12,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.ApiProvider
-import com.eliormachlev.currencix.util.hapticTap
-import com.eliormachlev.currencix.util.wireHapticButtons
+import com.eliormachlev.currencix.util.createWithHapticButtons
+import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.google.android.material.radiobutton.MaterialRadioButton
 
 /**
@@ -35,8 +35,7 @@ internal fun showProviderPickerDialog(
             .setSingleChoiceItems(adapter, current?.let { ApiProvider.entries.indexOf(it) } ?: -1, null)
             .setTitle(R.string.api_title)
             .setNegativeButton(android.R.string.cancel, null)
-            .create()
-            .apply { wireHapticButtons() }
+            .createWithHapticButtons()
     adapter.onProviderClicked = { provider ->
         onSelected(provider)
         dialog.dismiss()
@@ -114,8 +113,7 @@ internal class ProviderPickerDialogAdapter(
         holder.run {
             val provider = providers[position]
             // register clicks
-            parentView?.setOnClickListener {
-                it.hapticTap()
+            parentView?.setOnHapticClickListener {
                 onProviderClicked?.invoke(provider)
             }
             // check current active api provider

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
@@ -13,6 +13,7 @@ import androidx.preference.ListPreference
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.ApiProvider
 import com.eliormachlev.currencix.util.createWithHapticButtons
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.setOnHapticClickListener
 import com.google.android.material.radiobutton.MaterialRadioButton
 
@@ -59,6 +60,7 @@ class ProviderPickerPreference : ListPreference {
 
     // open dialog
     override fun onClick() {
+        (context as? Activity)?.hapticTap()
         showProviderPickerDialog(
             context = context,
             current = ApiProvider.fromId(value.toInt()),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/compose/CreditsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/compose/CreditsList.kt
@@ -2,7 +2,6 @@ package com.eliormachlev.currencix.view.preference.compose
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -22,6 +21,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.eliormachlev.currencix.R
+import com.eliormachlev.currencix.util.hapticClickable
 
 @Composable
 fun CreditsList(sections: List<CreditsSection>) {
@@ -73,7 +73,7 @@ private fun CreditRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .hapticClickable(onClick = onClick)
                 .padding(vertical = 8.dp)
                 // Title + subtitle + optional SPDX + URL should read as one
                 // focus stop; without this TalkBack lands on each Text

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
@@ -18,7 +18,6 @@ import androidx.window.layout.FoldingFeature
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.repository.Database
-import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.stripTimePattern
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.preference.GraphOptionsDialog
@@ -142,9 +141,8 @@ class TimelineActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        hapticTap()
-        return when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
             R.id.toggle -> {
                 timelineModel.toggleCurrencies()
                 true
@@ -155,7 +153,6 @@ class TimelineActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
 
     private fun readCurrencyExtra(
         key: String,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/TimelineActivity.kt
@@ -18,6 +18,7 @@ import androidx.window.layout.FoldingFeature
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Currency
 import com.eliormachlev.currencix.repository.Database
+import com.eliormachlev.currencix.util.hapticTap
 import com.eliormachlev.currencix.util.stripTimePattern
 import com.eliormachlev.currencix.view.BaseActivity
 import com.eliormachlev.currencix.view.preference.GraphOptionsDialog
@@ -141,8 +142,9 @@ class TimelineActivity : BaseActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean =
-        when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        hapticTap()
+        return when (item.itemId) {
             R.id.toggle -> {
                 timelineModel.toggleCurrencies()
                 true
@@ -153,6 +155,7 @@ class TimelineActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
 
     private fun readCurrencyExtra(
         key: String,

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineSecondary.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineSecondary.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.model.Rate
+import com.eliormachlev.currencix.util.rememberHapticOnClick
 import com.eliormachlev.currencix.viewmodel.timeline.TimelineViewModel
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -180,7 +181,7 @@ private fun PeriodSegmentedButtons(
         labels.forEachIndexed { index, (period, label) ->
             SegmentedButton(
                 selected = period == selected,
-                onClick = { onSelected(period) },
+                onClick = rememberHapticOnClick { onSelected(period) },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = labels.size),
             ) {
                 Text(label.replaceFirstChar { it.titlecase() })

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -53,7 +53,7 @@
     <string name="decimal_places_summary">Number of decimal places to show for converted values.</string>
     <string name="haptic_feedback_key" translatable="false">KEY_HAPTIC_FEEDBACK</string>
     <string name="haptic_feedback_title">Haptic feedback</string>
-    <string name="haptic_feedback_summary">Vibrate on key press\nFollows system setting</string>
+    <string name="haptic_feedback_summary">Vibrate on taps across the app\nFollows system setting\nAutomatically disabled in battery saver</string>
     <string name="date_format_key" translatable="false">KEY_DATE_FORMAT</string>
     <string name="date_format_title">Date and Time format</string>
     <!-- backup -->


### PR DESCRIPTION
## Summary
- Haptic feedback previously fired only on the custom calculator keypad. This wires it into every interactive surface: menu items, dialog buttons (positive/negative/neutral via touch listener on `AlertDialog`), spinners, preference rows, and Compose (`hapticClickable` / `hapticCombinedClickable` / `rememberHapticOnClick`).
- Suppress haptics when the device is in battery-saver mode (`PowerManager.isPowerSaveMode`) regardless of the user's setting — matches the platform's power-saving contract.
- Update the `haptic_feedback_summary` string to describe the new behaviour ("Vibrate on taps across the app · Follows system setting · Automatically disabled in battery saver").

## Test plan
- [ ] Toggle Settings → Haptic feedback ON and confirm vibration on: bottom-nav menu items, spinner open, currency picker row, favorite toggle, saved-cart row/rename/delete, credits link, fee editor buttons, dialog OK/Cancel, preference rows.
- [ ] Enable battery-saver from quick settings; confirm no haptic fires even with the setting ON.
- [ ] Disable haptic setting; confirm no haptic anywhere.
- [ ] Verify calculator keypad still vibrates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)