### PR TITLE
fix(a11y): label unlabeled interactive elements, themed error color, row action verbs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,9 +26,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".view.preference.PreferenceActivity" />
-        <activity android:name=".view.timeline.TimelineActivity" />
-        <activity android:name=".view.cart.CartActivity" />
+        <activity
+            android:name=".view.preference.PreferenceActivity"
+            android:label="@string/title_preferences" />
+        <activity
+            android:name=".view.timeline.TimelineActivity"
+            android:label="@string/menu_timeline" />
+        <activity
+            android:name=".view.cart.CartActivity"
+            android:label="@string/cart_title" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/util/HapticUtils.kt
@@ -168,15 +168,19 @@ fun Preference.setOnHapticChangeListener(onChange: (newValue: Any?) -> Unit) {
 /**
  * Compose analogue of [Modifier.clickable] that also fires a keyboard-tap
  * haptic on click, honouring the user's preference and battery-saver state.
+ * [onClickLabel] is surfaced to TalkBack as the "double-tap to X" verb; pass
+ * a translated action string ("Select", "Load", …) at row-tap sites so the
+ * screen reader announces what activating the row does.
  */
 fun Modifier.hapticClickable(
     enabled: Boolean = true,
+    onClickLabel: String? = null,
     onClick: () -> Unit,
 ): Modifier =
     composed {
         val ctx = LocalContext.current
         val haptic = LocalHapticFeedback.current
-        clickable(enabled = enabled) {
+        clickable(enabled = enabled, onClickLabel = onClickLabel) {
             if (ctx.shouldHaptic()) {
                 haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
             }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/SavedCartsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/compose/SavedCartsList.kt
@@ -58,8 +58,10 @@ private fun SavedCartRow(
             Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = ROW_MIN_HEIGHT_DP.dp)
-                .hapticClickable(onClick = onPick)
-                .padding(horizontal = dimensionResource(id = R.dimen.margin2x)),
+                .hapticClickable(
+                    onClickLabel = stringResource(id = R.string.a11y_action_load),
+                    onClick = onPick,
+                ).padding(horizontal = dimensionResource(id = R.dimen.margin2x)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -417,7 +417,11 @@ private fun CurrencyRow(
         }
         FavoriteToggleIcon(
             active = isStarred,
-            contentDescription = null,
+            contentDescription =
+                stringResource(
+                    id = if (isStarred) R.string.a11y_unstar_currency else R.string.a11y_star_currency,
+                    rate.currency.iso4217Alpha(),
+                ),
             onClick = onStarClick,
         )
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableCurrencyPicker.kt
@@ -379,8 +379,11 @@ private fun CurrencyRow(
             modifier =
                 Modifier
                     .weight(1f)
-                    .hapticClickable(enabled = !isDisabled, onClick = onClick)
-                    .alpha(if (isDisabled) DISABLED_ROW_ALPHA else 1f)
+                    .hapticClickable(
+                        enabled = !isDisabled,
+                        onClickLabel = stringResource(id = R.string.a11y_action_select),
+                        onClick = onClick,
+                    ).alpha(if (isDisabled) DISABLED_ROW_ALPHA else 1f)
                     .padding(
                         horizontal = dimensionResource(id = R.dimen.margin2x),
                         vertical = dimensionResource(id = R.dimen.margin1x),

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/compose/CreditsList.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/compose/CreditsList.kt
@@ -73,8 +73,10 @@ private fun CreditRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .hapticClickable(onClick = onClick)
-                .padding(vertical = 8.dp)
+                .hapticClickable(
+                    onClickLabel = stringResource(id = R.string.a11y_action_open),
+                    onClick = onClick,
+                ).padding(vertical = 8.dp)
                 // Title + subtitle + optional SPDX + URL should read as one
                 // focus stop; without this TalkBack lands on each Text
                 // separately and forces four swipes per credit.

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineChartCard.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/timeline/compose/TimelineChartCard.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.eliormachlev.currencix.R
 import com.eliormachlev.currencix.util.fromHtmlLegacy
+import com.google.android.material.color.MaterialColors
 
 private val CHART_PADDING = TIMELINE_CONTENT_PADDING
 private val PROVIDER_FONT_SIZE = 12.sp
@@ -52,7 +54,7 @@ internal fun TimelineChartCard(
                 factory = { ctx ->
                     TextView(ctx).apply {
                         typeface = android.graphics.Typeface.MONOSPACE
-                        setTextColor(android.graphics.Color.parseColor("#FF6060"))
+                        setTextColor(MaterialColors.getColor(ctx, R.attr.colorError, 0))
                         gravity = android.view.Gravity.CENTER_VERTICAL
                     }
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
     <string name="a11y_chart_summary">Exchange rate history chart. Statistics — minimum, average, maximum, and current rate — are shown below.</string>
     <string name="a11y_star_currency">Star %1$s</string>
     <string name="a11y_unstar_currency">Unstar %1$s</string>
+    <string name="a11y_action_select">Select</string>
+    <string name="a11y_action_load">Load</string>
+    <string name="a11y_action_open">Open</string>
     <string name="info_conversion">%1$s %2$s ≈ %3$s %4$s</string>
     <string name="info_date_latest">Rates as of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
     <string name="info_date_historical">Historical rates of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="a11y_clear_search">Clear search</string>
     <string name="a11y_cart_item_name">Item name</string>
     <string name="a11y_chart_summary">Exchange rate history chart. Statistics — minimum, average, maximum, and current rate — are shown below.</string>
+    <string name="a11y_star_currency">Star %1$s</string>
+    <string name="a11y_unstar_currency">Unstar %1$s</string>
     <string name="info_conversion">%1$s %2$s ≈ %3$s %4$s</string>
     <string name="info_date_latest">Rates as of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>
     <string name="info_date_historical">Historical rates of &lt;b>%1$s&lt;/b> by &lt;b>%2$s&lt;/b></string>


### PR DESCRIPTION
## Summary

Accessibility pass covering the gaps a TalkBack user would hit today. Split into three focused fixes; two commits so the P0/P1 batch can be reviewed independently of the P2 polish.

### P0 / P1 (`bad60d87`)
- **Picker star toggle** (`SearchableCurrencyPicker`) was passing `contentDescription = null`, so TalkBack announced nothing when the star IconButton took focus. Wired a state-aware string (`Star EUR` / `Unstar EUR`) that includes the ISO code, matching the cart pin toggle's existing convention.
- **Timeline error text** (`TimelineChartCard`) used a hardcoded `#FF6060` that failed WCAG AA contrast on the light theme's `surfaceVariant` background. Reads `colorError` via `MaterialColors` now, so both light and dark render with the documented contrast ratios from `colors.xml`.
- **Activity labels** — `PreferenceActivity`, `TimelineActivity`, and `CartActivity` had no `android:label`, so TalkBack fell back to the app name when opening them. Each now points at its existing title string; runtime titles (e.g. Timeline's dynamic pair title) still take over after `onCreate`.

### P2 (`ed0f2cb8`)
- Added an `onClickLabel` parameter to `Modifier.hapticClickable` so callers can surface a translated verb to TalkBack (framework reads it as "double-tap to X").
- Wired the label at three row-tap sites where the generic "double-tap to activate" was uninformative: currency picker rows → **Select**, saved-cart rows → **Load**, credit rows → **Open**.

## Test plan

- [ ] Enable TalkBack, open the currency picker, focus a star — confirm it announces `Star <ISO>` / `Unstar <ISO>` and toggles independently of the row.
- [ ] Force a timeline error state (e.g. airplane mode with no cache), verify the error text is readable in both light and dark themes.
- [ ] With TalkBack on, open Preferences / Timeline / Cart — confirm the correct screen title is announced instead of the app name.
- [ ] With TalkBack on, focus a picker row, saved cart row, and credits row — confirm the announcement includes "double-tap to Select / Load / Open".
- [ ] `./gradlew spotlessCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)