### PR TITLE
i18n: translate 15 a11y/cart/quick-conversions strings across all locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">متابعة</string>
     <string name="a11y_delete">حذف</string>
     <string name="a11y_historical_rate">سعر سابق</string>
+    <string name="a11y_search_currencies">ابحث عن العملات</string>
+    <string name="a11y_clear_search">امسح البحث</string>
+    <string name="a11y_cart_item_name">اسم العنصر</string>
+    <string name="a11y_chart_summary">مخطط سجل أسعار الصرف. الإحصائيات — الحد الأدنى والمتوسط والحد الأقصى والسعر الحالي — معروضة أدناه.</string>
+    <string name="a11y_star_currency">ضع نجمة على %1$s</string>
+    <string name="a11y_unstar_currency">أزل النجمة من %1$s</string>
+    <string name="a11y_action_select">اختيار</string>
+    <string name="a11y_action_load">تحميل</string>
+    <string name="a11y_action_open">فتح</string>
+    <string name="quick_conversions_fee_conversion">تحويل %s</string>
+    <string name="quick_conversions_fee_reduction">خصم %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">ثبّت العنصر في الأعلى</string>
+    <string name="cart_unpin_item">إلغاء تثبيت العنصر</string>
+    <string name="cart_reorder_item">إعادة ترتيب العنصر</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_no_api_key">Трябва да зададеш валиден API ключ, за да използваш този източник.</string>
     <string name="error_try_another_api">Все пак, в настройките има и други доставчици на данни, от които можеш да избираш. Просто опитай!</string>
     <string name="error_unsupported_timeline">Данните за график не се поддържат от този API.</string>
+    <string name="a11y_search_currencies">Търсене на валути</string>
+    <string name="a11y_clear_search">Изчисти търсенето</string>
+    <string name="a11y_cart_item_name">Име на артикула</string>
+    <string name="a11y_chart_summary">Диаграма на историческите валутни курсове. Статистиките — минимум, среден, максимум и текущ курс — са показани по-долу.</string>
+    <string name="a11y_star_currency">Отбележи със звезда %1$s</string>
+    <string name="a11y_unstar_currency">Премахни звездата от %1$s</string>
+    <string name="a11y_action_select">Избери</string>
+    <string name="a11y_action_load">Зареди</string>
+    <string name="a11y_action_open">Отвори</string>
+    <string name="quick_conversions_fee_conversion">конверсия %s</string>
+    <string name="quick_conversions_fee_reduction">намаление %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Закачи най-горе</string>
+    <string name="cart_unpin_item">Откачи артикула</string>
+    <string name="cart_reorder_item">Пренареди артикула</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">চালিয়ে যান</string>
     <string name="a11y_delete">মুছুন</string>
     <string name="a11y_historical_rate">ঐতিহাসিক হার</string>
+    <string name="a11y_search_currencies">মুদ্রা অনুসন্ধান</string>
+    <string name="a11y_clear_search">অনুসন্ধান সাফ করুন</string>
+    <string name="a11y_cart_item_name">আইটেমের নাম</string>
+    <string name="a11y_chart_summary">বিনিময় হারের ইতিহাসের চার্ট। পরিসংখ্যান — সর্বনিম্ন, গড়, সর্বোচ্চ এবং বর্তমান হার — নিচে দেখানো হয়েছে।</string>
+    <string name="a11y_star_currency">%1$s কে তারা দিন</string>
+    <string name="a11y_unstar_currency">%1$s থেকে তারা সরান</string>
+    <string name="a11y_action_select">নির্বাচন</string>
+    <string name="a11y_action_load">লোড করুন</string>
+    <string name="a11y_action_open">খুলুন</string>
+    <string name="quick_conversions_fee_conversion">রূপান্তর %s</string>
+    <string name="quick_conversions_fee_reduction">হ্রাস %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">শীর্ষে পিন করুন</string>
+    <string name="cart_unpin_item">পিন সরান</string>
+    <string name="cart_reorder_item">পুনর্বিন্যাস করুন</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Continua</string>
     <string name="a11y_delete">Suprimeix</string>
     <string name="a11y_historical_rate">Cotització històrica</string>
+    <string name="a11y_search_currencies">Cerca divises</string>
+    <string name="a11y_clear_search">Neteja la cerca</string>
+    <string name="a11y_cart_item_name">Nom de l\'article</string>
+    <string name="a11y_chart_summary">Gràfic històric del tipus de canvi. Les estadístiques — mínim, mitjana, màxim i tipus actual — es mostren a sota.</string>
+    <string name="a11y_star_currency">Marca %1$s amb estrella</string>
+    <string name="a11y_unstar_currency">Treu l\'estrella de %1$s</string>
+    <string name="a11y_action_select">Selecciona</string>
+    <string name="a11y_action_load">Carrega</string>
+    <string name="a11y_action_open">Obre</string>
+    <string name="quick_conversions_fee_conversion">conversió %s</string>
+    <string name="quick_conversions_fee_reduction">reducció %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fixa a dalt</string>
+    <string name="cart_unpin_item">Desfixa l\'article</string>
+    <string name="cart_reorder_item">Reordena l\'article</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">Pokračovat</string>
     <string name="a11y_delete">Smazat</string>
     <string name="a11y_historical_rate">Historický kurz</string>
+    <string name="a11y_search_currencies">Hledat měny</string>
+    <string name="a11y_clear_search">Vymazat hledání</string>
+    <string name="a11y_cart_item_name">Název položky</string>
+    <string name="a11y_chart_summary">Graf historie směnného kurzu. Statistiky — minimum, průměr, maximum a aktuální kurz — jsou uvedeny níže.</string>
+    <string name="a11y_star_currency">Přidat hvězdičku k %1$s</string>
+    <string name="a11y_unstar_currency">Odebrat hvězdičku z %1$s</string>
+    <string name="a11y_action_select">Vybrat</string>
+    <string name="a11y_action_load">Načíst</string>
+    <string name="a11y_action_open">Otevřít</string>
+    <string name="quick_conversions_fee_conversion">konverze %s</string>
+    <string name="quick_conversions_fee_reduction">snížení %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Připnout nahoru</string>
+    <string name="cart_unpin_item">Odepnout položku</string>
+    <string name="cart_reorder_item">Přeuspořádat položku</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Fortsæt</string>
     <string name="a11y_delete">Slet</string>
     <string name="a11y_historical_rate">Historisk kurs</string>
+    <string name="a11y_search_currencies">Søg valutaer</string>
+    <string name="a11y_clear_search">Ryd søgning</string>
+    <string name="a11y_cart_item_name">Varenavn</string>
+    <string name="a11y_chart_summary">Diagram over valutakursens historik. Statistikker — minimum, gennemsnit, maksimum og aktuel kurs — vises nedenfor.</string>
+    <string name="a11y_star_currency">Markér %1$s med stjerne</string>
+    <string name="a11y_unstar_currency">Fjern stjerne fra %1$s</string>
+    <string name="a11y_action_select">Vælg</string>
+    <string name="a11y_action_load">Indlæs</string>
+    <string name="a11y_action_open">Åbn</string>
+    <string name="quick_conversions_fee_conversion">konvertering %s</string>
+    <string name="quick_conversions_fee_reduction">reduktion %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fastgør øverst</string>
+    <string name="cart_unpin_item">Frigør vare</string>
+    <string name="cart_reorder_item">Omarrangér vare</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Weiter</string>
     <string name="a11y_delete">Löschen</string>
     <string name="a11y_historical_rate">Historischer Kurs</string>
+    <string name="a11y_search_currencies">Währungen suchen</string>
+    <string name="a11y_clear_search">Suche löschen</string>
+    <string name="a11y_cart_item_name">Artikelname</string>
+    <string name="a11y_chart_summary">Diagramm zum Wechselkursverlauf. Statistiken — Minimum, Durchschnitt, Maximum und aktueller Kurs — sind unten aufgeführt.</string>
+    <string name="a11y_star_currency">%1$s favorisieren</string>
+    <string name="a11y_unstar_currency">Favoritenmarkierung von %1$s entfernen</string>
+    <string name="a11y_action_select">Auswählen</string>
+    <string name="a11y_action_load">Laden</string>
+    <string name="a11y_action_open">Öffnen</string>
+    <string name="quick_conversions_fee_conversion">Umrechnung %s</string>
+    <string name="quick_conversions_fee_reduction">Reduktion %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Artikel oben anheften</string>
+    <string name="cart_unpin_item">Artikel loslösen</string>
+    <string name="cart_reorder_item">Artikel neu anordnen</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_invalid_api_key">HTTP 401 – Ελέγξτε το κλειδί API σας.</string>
     <string name="error_no_api_key">Πρέπει να οριστεί έγκυρο κλειδί API για να χρησιμοποιήσετε αυτήν την πηγή.</string>
     <string name="error_unsupported_timeline">Τα δεδομένα χρονογραμμής δεν υποστηρίζονται από αυτό το API.</string>
+    <string name="a11y_search_currencies">Αναζήτηση νομισμάτων</string>
+    <string name="a11y_clear_search">Καθαρισμός αναζήτησης</string>
+    <string name="a11y_cart_item_name">Όνομα στοιχείου</string>
+    <string name="a11y_chart_summary">Γράφημα ιστορικού συναλλαγματικής ισοτιμίας. Οι στατιστικές — ελάχιστο, μέσο, μέγιστο και τρέχουσα ισοτιμία — εμφανίζονται παρακάτω.</string>
+    <string name="a11y_star_currency">Επισήμανση %1$s</string>
+    <string name="a11y_unstar_currency">Αφαίρεση επισήμανσης από %1$s</string>
+    <string name="a11y_action_select">Επιλογή</string>
+    <string name="a11y_action_load">Φόρτωση</string>
+    <string name="a11y_action_open">Άνοιγμα</string>
+    <string name="quick_conversions_fee_conversion">μετατροπή %s</string>
+    <string name="quick_conversions_fee_reduction">μείωση %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Καρφίτσωμα στην κορυφή</string>
+    <string name="cart_unpin_item">Ξεκαρφίτσωμα στοιχείου</string>
+    <string name="cart_reorder_item">Αναδιάταξη στοιχείου</string>
 </resources>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_invalid_api_key">HTTP 401 – Bonvolu kontroli vian API-ŝlosilon.</string>
     <string name="error_no_api_key">Valida API-ŝlosilo devas esti agordita por uzi ĉi tiun fonton.</string>
     <string name="error_unsupported_timeline">Templiniaj datumoj ne estas subtenataj de ĉi tiu API.</string>
+    <string name="a11y_search_currencies">Serĉi valutojn</string>
+    <string name="a11y_clear_search">Vakigi serĉon</string>
+    <string name="a11y_cart_item_name">Nomo de artikolo</string>
+    <string name="a11y_chart_summary">Diagramo de historio de kurzoj. Statistikoj — minimumo, mezumo, maksimumo, kaj nuna kurzo — montriĝas sube.</string>
+    <string name="a11y_star_currency">Steligi %1$s</string>
+    <string name="a11y_unstar_currency">Malsteligi %1$s</string>
+    <string name="a11y_action_select">Elekti</string>
+    <string name="a11y_action_load">Ŝargi</string>
+    <string name="a11y_action_open">Malfermi</string>
+    <string name="quick_conversions_fee_conversion">konvertado %s</string>
+    <string name="quick_conversions_fee_reduction">redukto %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Alpingli artikolon supre</string>
+    <string name="cart_unpin_item">Depingli artikolon</string>
+    <string name="cart_reorder_item">Reordigi artikolon</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Continuar</string>
     <string name="a11y_delete">Eliminar</string>
     <string name="a11y_historical_rate">Tasa histórica</string>
+    <string name="a11y_search_currencies">Buscar divisas</string>
+    <string name="a11y_clear_search">Borrar búsqueda</string>
+    <string name="a11y_cart_item_name">Nombre del artículo</string>
+    <string name="a11y_chart_summary">Gráfico del historial del tipo de cambio. Las estadísticas — mínimo, promedio, máximo y tipo actual — se muestran abajo.</string>
+    <string name="a11y_star_currency">Marcar %1$s con estrella</string>
+    <string name="a11y_unstar_currency">Quitar estrella de %1$s</string>
+    <string name="a11y_action_select">Seleccionar</string>
+    <string name="a11y_action_load">Cargar</string>
+    <string name="a11y_action_open">Abrir</string>
+    <string name="quick_conversions_fee_conversion">conversión %s</string>
+    <string name="quick_conversions_fee_reduction">reducción %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fijar en la parte superior</string>
+    <string name="cart_unpin_item">Desfijar artículo</string>
+    <string name="cart_reorder_item">Reordenar artículo</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">Jätka</string>
     <string name="a11y_delete">Kustuta</string>
     <string name="a11y_historical_rate">Varasem kurss</string>
+    <string name="a11y_search_currencies">Otsi valuutasid</string>
+    <string name="a11y_clear_search">Tühjenda otsing</string>
+    <string name="a11y_cart_item_name">Toote nimi</string>
+    <string name="a11y_chart_summary">Vahetuskursi ajaloo graafik. Statistika — miinimum, keskmine, maksimum ja praegune kurss — kuvatakse allpool.</string>
+    <string name="a11y_star_currency">Märgi %1$s tärniga</string>
+    <string name="a11y_unstar_currency">Eemalda tärn %1$s pealt</string>
+    <string name="a11y_action_select">Vali</string>
+    <string name="a11y_action_load">Laadi</string>
+    <string name="a11y_action_open">Ava</string>
+    <string name="quick_conversions_fee_conversion">konversioon %s</string>
+    <string name="quick_conversions_fee_reduction">vähendus %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Kinnita üles</string>
+    <string name="cart_unpin_item">Vabasta kinnitus</string>
+    <string name="cart_reorder_item">Muuda järjekorda</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -97,4 +97,19 @@
     <string name="a11y_delete">حذف</string>
     <string name="a11y_historical_rate">نرخ گذشته</string>
     <string name="error_unsupported_timeline">داده‌های خط زمانی توسط این API پشتیبانی نمی‌شود.</string>
+    <string name="a11y_search_currencies">جستجوی ارزها</string>
+    <string name="a11y_clear_search">پاک کردن جستجو</string>
+    <string name="a11y_cart_item_name">نام مورد</string>
+    <string name="a11y_chart_summary">نمودار تاریخچه نرخ ارز. آمار — کمینه، میانگین، بیشینه و نرخ کنونی — در پایین نشان داده شده است.</string>
+    <string name="a11y_star_currency">ستاره‌دار کردن %1$s</string>
+    <string name="a11y_unstar_currency">حذف ستاره از %1$s</string>
+    <string name="a11y_action_select">انتخاب</string>
+    <string name="a11y_action_load">بارگذاری</string>
+    <string name="a11y_action_open">باز کردن</string>
+    <string name="quick_conversions_fee_conversion">تبدیل %s</string>
+    <string name="quick_conversions_fee_reduction">کاهش %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">پین کردن در بالا</string>
+    <string name="cart_unpin_item">حذف پین</string>
+    <string name="cart_reorder_item">تغییر ترتیب</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Continuer</string>
     <string name="a11y_delete">Supprimer</string>
     <string name="a11y_historical_rate">Taux historique</string>
+    <string name="a11y_search_currencies">Rechercher des devises</string>
+    <string name="a11y_clear_search">Effacer la recherche</string>
+    <string name="a11y_cart_item_name">Nom de l\'article</string>
+    <string name="a11y_chart_summary">Graphique de l\'historique des taux de change. Les statistiques — minimum, moyenne, maximum et taux actuel — sont affichées ci-dessous.</string>
+    <string name="a11y_star_currency">Ajouter %1$s aux favoris</string>
+    <string name="a11y_unstar_currency">Retirer %1$s des favoris</string>
+    <string name="a11y_action_select">Sélectionner</string>
+    <string name="a11y_action_load">Charger</string>
+    <string name="a11y_action_open">Ouvrir</string>
+    <string name="quick_conversions_fee_conversion">conversion %s</string>
+    <string name="quick_conversions_fee_reduction">réduction %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Épingler l\'article en haut</string>
+    <string name="cart_unpin_item">Désépingler l\'article</string>
+    <string name="cart_reorder_item">Réorganiser l\'article</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">Nastavi</string>
     <string name="a11y_delete">Izbriši</string>
     <string name="a11y_historical_rate">Povijesni tečaj</string>
+    <string name="a11y_search_currencies">Traži valute</string>
+    <string name="a11y_clear_search">Očisti pretragu</string>
+    <string name="a11y_cart_item_name">Naziv stavke</string>
+    <string name="a11y_chart_summary">Grafikon povijesti tečajeva. Statistika — minimum, prosjek, maksimum i trenutni tečaj — prikazana je ispod.</string>
+    <string name="a11y_star_currency">Označi %1$s zvjezdicom</string>
+    <string name="a11y_unstar_currency">Ukloni zvjezdicu s %1$s</string>
+    <string name="a11y_action_select">Odaberi</string>
+    <string name="a11y_action_load">Učitaj</string>
+    <string name="a11y_action_open">Otvori</string>
+    <string name="quick_conversions_fee_conversion">konverzija %s</string>
+    <string name="quick_conversions_fee_reduction">smanjenje %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Prikvači na vrh</string>
+    <string name="cart_unpin_item">Otkvači stavku</string>
+    <string name="cart_reorder_item">Presloži stavku</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_no_api_key">Ennek a forrásnak a használatához érvényes API-kulcsot kell megadni.</string>
     <string name="error_try_another_api">A beállításokban azonban más adatszolgáltatók közül is választhatsz. Csak próbáld ki!</string>
     <string name="error_unsupported_timeline">Idővonal-adatokat ez az API nem támogat.</string>
+    <string name="a11y_search_currencies">Pénznemek keresése</string>
+    <string name="a11y_clear_search">Keresés törlése</string>
+    <string name="a11y_cart_item_name">Tétel neve</string>
+    <string name="a11y_chart_summary">Árfolyam-előzmények grafikonja. A statisztikák — minimum, átlag, maximum és aktuális árfolyam — lent láthatók.</string>
+    <string name="a11y_star_currency">%1$s csillagozása</string>
+    <string name="a11y_unstar_currency">%1$s csillag eltávolítása</string>
+    <string name="a11y_action_select">Kiválasztás</string>
+    <string name="a11y_action_load">Betöltés</string>
+    <string name="a11y_action_open">Megnyitás</string>
+    <string name="quick_conversions_fee_conversion">átváltás %s</string>
+    <string name="quick_conversions_fee_reduction">csökkentés %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Rögzítés felülre</string>
+    <string name="cart_unpin_item">Rögzítés megszüntetése</string>
+    <string name="cart_reorder_item">Tétel átrendezése</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_no_api_key">Kunci API yang valid harus disetel untuk menggunakan Sumber ini.</string>
     <string name="error_try_another_api">Namun, ada penyedia data lain yang dapat Anda pilih di pengaturan. Cobalah!</string>
     <string name="error_unsupported_timeline">Data timeline tidak didukung oleh API ini.</string>
+    <string name="a11y_search_currencies">Cari mata uang</string>
+    <string name="a11y_clear_search">Hapus pencarian</string>
+    <string name="a11y_cart_item_name">Nama item</string>
+    <string name="a11y_chart_summary">Grafik riwayat nilai tukar. Statistik — minimum, rata-rata, maksimum, dan nilai tukar saat ini — ditampilkan di bawah.</string>
+    <string name="a11y_star_currency">Bintangi %1$s</string>
+    <string name="a11y_unstar_currency">Hapus bintang %1$s</string>
+    <string name="a11y_action_select">Pilih</string>
+    <string name="a11y_action_load">Muat</string>
+    <string name="a11y_action_open">Buka</string>
+    <string name="quick_conversions_fee_conversion">konversi %s</string>
+    <string name="quick_conversions_fee_reduction">potongan %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Sematkan ke atas</string>
+    <string name="cart_unpin_item">Lepas sematan</string>
+    <string name="cart_reorder_item">Susun ulang</string>
 </resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -96,4 +96,19 @@
     <string name="error_no_api_key">Gilt API-lykil þarf að stilla til að nota þessa uppsprettu.</string>
     <string name="error_try_another_api">Það eru þó aðrar gagnaveitur sem þú getur valið um í stillingunum. Prófaðu bara!</string>
     <string name="error_unsupported_timeline">Tímalínugögn eru ekki studd af þessu API.</string>
+    <string name="a11y_search_currencies">Leita að gjaldmiðlum</string>
+    <string name="a11y_clear_search">Hreinsa leit</string>
+    <string name="a11y_cart_item_name">Vöruheiti</string>
+    <string name="a11y_chart_summary">Línurit yfir gengissögu. Tölfræði — lágmark, meðaltal, hámark og núverandi gengi — er sýnd að neðan.</string>
+    <string name="a11y_star_currency">Stjörnumerkja %1$s</string>
+    <string name="a11y_unstar_currency">Fjarlægja stjörnu af %1$s</string>
+    <string name="a11y_action_select">Velja</string>
+    <string name="a11y_action_load">Hlaða</string>
+    <string name="a11y_action_open">Opna</string>
+    <string name="quick_conversions_fee_conversion">umbreyting %s</string>
+    <string name="quick_conversions_fee_reduction">lækkun %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Festa efst</string>
+    <string name="cart_unpin_item">Losa festingu</string>
+    <string name="cart_reorder_item">Endurraða atriði</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_continue">Continua</string>
     <string name="a11y_delete">Elimina</string>
     <string name="a11y_historical_rate">Tasso storico</string>
+    <string name="a11y_search_currencies">Cerca valute</string>
+    <string name="a11y_clear_search">Cancella ricerca</string>
+    <string name="a11y_cart_item_name">Nome articolo</string>
+    <string name="a11y_chart_summary">Grafico dello storico dei tassi di cambio. Le statistiche — minimo, media, massimo e tasso attuale — sono mostrate sotto.</string>
+    <string name="a11y_star_currency">Aggiungi stella a %1$s</string>
+    <string name="a11y_unstar_currency">Rimuovi stella da %1$s</string>
+    <string name="a11y_action_select">Seleziona</string>
+    <string name="a11y_action_load">Carica</string>
+    <string name="a11y_action_open">Apri</string>
+    <string name="quick_conversions_fee_conversion">conversione %s</string>
+    <string name="quick_conversions_fee_reduction">riduzione %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fissa in cima</string>
+    <string name="cart_unpin_item">Rimuovi fissaggio</string>
+    <string name="cart_reorder_item">Riordina articolo</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_continue">המשך</string>
     <string name="a11y_delete">מחיקה</string>
     <string name="a11y_historical_rate">שער היסטורי</string>
+    <string name="a11y_search_currencies">חיפוש מטבעות</string>
+    <string name="a11y_clear_search">נקה חיפוש</string>
+    <string name="a11y_cart_item_name">שם פריט</string>
+    <string name="a11y_chart_summary">תרשים היסטוריית שערי חליפין. סטטיסטיקות — מינימום, ממוצע, מקסימום ושער נוכחי — מוצגות למטה.</string>
+    <string name="a11y_star_currency">סמן את %1$s בכוכב</string>
+    <string name="a11y_unstar_currency">הסר כוכב מ־%1$s</string>
+    <string name="a11y_action_select">בחר</string>
+    <string name="a11y_action_load">טען</string>
+    <string name="a11y_action_open">פתח</string>
+    <string name="quick_conversions_fee_conversion">המרה %s</string>
+    <string name="quick_conversions_fee_reduction">הפחתה %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">הצמד לראש הרשימה</string>
+    <string name="cart_unpin_item">בטל הצמדה</string>
+    <string name="cart_reorder_item">סדר מחדש</string>
 </resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -100,4 +100,19 @@
     <string name="cart_unsaved_continue">തുടരുക</string>
     <string name="a11y_delete">നീക്കംചെയ്യുക</string>
     <string name="a11y_historical_rate">ചരിത്ര നിരക്ക്</string>
+    <string name="a11y_search_currencies">കറൻസികൾ തിരയുക</string>
+    <string name="a11y_clear_search">തിരയൽ മായ്ക്കുക</string>
+    <string name="a11y_cart_item_name">ഇനത്തിന്റെ പേര്</string>
+    <string name="a11y_chart_summary">വിനിമയ നിരക്കിന്റെ ചരിത്ര ചാർട്ട്. സ്ഥിതിവിവരക്കണക്കുകൾ — കുറഞ്ഞത്, ശരാശരി, കൂടിയത്, ഇപ്പോഴത്തെ നിരക്ക് — താഴെ കാണിച്ചിരിക്കുന്നു.</string>
+    <string name="a11y_star_currency">%1$s നക്ഷത്രം ചേർക്കുക</string>
+    <string name="a11y_unstar_currency">%1$s നക്ഷത്രം നീക്കുക</string>
+    <string name="a11y_action_select">തിരഞ്ഞെടുക്കുക</string>
+    <string name="a11y_action_load">ലോഡ് ചെയ്യുക</string>
+    <string name="a11y_action_open">തുറക്കുക</string>
+    <string name="quick_conversions_fee_conversion">പരിവർത്തനം %s</string>
+    <string name="quick_conversions_fee_reduction">കുറവ് %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">മുകളിലേക്ക് പിൻ ചെയ്യുക</string>
+    <string name="cart_unpin_item">പിൻ നീക്കുക</string>
+    <string name="cart_reorder_item">പുനഃക്രമീകരിക്കുക</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_save_as">Lagre som ny</string>
     <string name="cart_unsaved_discard">Forkast endringer</string>
     <string name="cart_unsaved_continue">Fortsett</string>
+    <string name="a11y_search_currencies">Søk etter valutaer</string>
+    <string name="a11y_clear_search">Tøm søk</string>
+    <string name="a11y_cart_item_name">Varenavn</string>
+    <string name="a11y_chart_summary">Diagram over valutakurshistorikk. Statistikk — minimum, gjennomsnitt, maksimum og gjeldende kurs — vises nedenfor.</string>
+    <string name="a11y_star_currency">Stjernemerk %1$s</string>
+    <string name="a11y_unstar_currency">Fjern stjerne fra %1$s</string>
+    <string name="a11y_action_select">Velg</string>
+    <string name="a11y_action_load">Last inn</string>
+    <string name="a11y_action_open">Åpne</string>
+    <string name="quick_conversions_fee_conversion">konvertering %s</string>
+    <string name="quick_conversions_fee_reduction">reduksjon %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fest øverst</string>
+    <string name="cart_unpin_item">Løsne vare</string>
+    <string name="cart_reorder_item">Endre rekkefølge</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_save_as">Opslaan als nieuw</string>
     <string name="cart_unsaved_discard">Wijzigingen negeren</string>
     <string name="cart_unsaved_continue">Doorgaan</string>
+    <string name="a11y_search_currencies">Zoek valuta\'s</string>
+    <string name="a11y_clear_search">Zoekopdracht wissen</string>
+    <string name="a11y_cart_item_name">Itemnaam</string>
+    <string name="a11y_chart_summary">Grafiek van wisselkoersgeschiedenis. Statistieken — minimum, gemiddelde, maximum en huidige koers — worden hieronder weergegeven.</string>
+    <string name="a11y_star_currency">%1$s markeren met ster</string>
+    <string name="a11y_unstar_currency">Ster verwijderen bij %1$s</string>
+    <string name="a11y_action_select">Selecteer</string>
+    <string name="a11y_action_load">Laad</string>
+    <string name="a11y_action_open">Open</string>
+    <string name="quick_conversions_fee_conversion">conversie %s</string>
+    <string name="quick_conversions_fee_reduction">verlaging %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Bovenaan vastmaken</string>
+    <string name="cart_unpin_item">Losmaken</string>
+    <string name="cart_reorder_item">Volgorde wijzigen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">Zapisz jako nowy</string>
     <string name="cart_unsaved_discard">Odrzuć zmiany</string>
     <string name="cart_unsaved_continue">Kontynuuj</string>
+    <string name="a11y_search_currencies">Wyszukaj waluty</string>
+    <string name="a11y_clear_search">Wyczyść wyszukiwanie</string>
+    <string name="a11y_cart_item_name">Nazwa pozycji</string>
+    <string name="a11y_chart_summary">Wykres historii kursu wymiany. Statystyki — minimum, średnia, maksimum i bieżący kurs — są pokazane poniżej.</string>
+    <string name="a11y_star_currency">Oznacz %1$s gwiazdką</string>
+    <string name="a11y_unstar_currency">Usuń gwiazdkę z %1$s</string>
+    <string name="a11y_action_select">Wybierz</string>
+    <string name="a11y_action_load">Wczytaj</string>
+    <string name="a11y_action_open">Otwórz</string>
+    <string name="quick_conversions_fee_conversion">konwersja %s</string>
+    <string name="quick_conversions_fee_reduction">obniżka %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Przypnij na górze</string>
+    <string name="cart_unpin_item">Odepnij element</string>
+    <string name="cart_reorder_item">Zmień kolejność</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_save_as">Salvar como novo</string>
     <string name="cart_unsaved_discard">Descartar alterações</string>
     <string name="cart_unsaved_continue">Continuar</string>
+    <string name="a11y_search_currencies">Pesquisar moedas</string>
+    <string name="a11y_clear_search">Limpar pesquisa</string>
+    <string name="a11y_cart_item_name">Nome do item</string>
+    <string name="a11y_chart_summary">Gráfico do histórico da taxa de câmbio. As estatísticas — mínima, média, máxima e taxa atual — são exibidas abaixo.</string>
+    <string name="a11y_star_currency">Marcar %1$s com estrela</string>
+    <string name="a11y_unstar_currency">Remover estrela de %1$s</string>
+    <string name="a11y_action_select">Selecionar</string>
+    <string name="a11y_action_load">Carregar</string>
+    <string name="a11y_action_open">Abrir</string>
+    <string name="quick_conversions_fee_conversion">conversão %s</string>
+    <string name="quick_conversions_fee_reduction">redução %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fixar no topo</string>
+    <string name="cart_unpin_item">Desfixar item</string>
+    <string name="cart_reorder_item">Reordenar item</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">Сохранить как новую</string>
     <string name="cart_unsaved_discard">Отменить изменения</string>
     <string name="cart_unsaved_continue">Продолжить</string>
+    <string name="a11y_search_currencies">Поиск валют</string>
+    <string name="a11y_clear_search">Очистить поиск</string>
+    <string name="a11y_cart_item_name">Название позиции</string>
+    <string name="a11y_chart_summary">График истории обменного курса. Статистика — минимум, среднее, максимум и текущий курс — показана ниже.</string>
+    <string name="a11y_star_currency">Отметить %1$s звёздочкой</string>
+    <string name="a11y_unstar_currency">Убрать звёздочку с %1$s</string>
+    <string name="a11y_action_select">Выбрать</string>
+    <string name="a11y_action_load">Загрузить</string>
+    <string name="a11y_action_open">Открыть</string>
+    <string name="quick_conversions_fee_conversion">конвертация %s</string>
+    <string name="quick_conversions_fee_reduction">уменьшение %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Закрепить сверху</string>
+    <string name="cart_unpin_item">Открепить</string>
+    <string name="cart_reorder_item">Изменить порядок</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -97,4 +97,19 @@
     <string name="cart_unsaved_save_as">Spara som ny</string>
     <string name="cart_unsaved_discard">Kassera ändringar</string>
     <string name="cart_unsaved_continue">Fortsätt</string>
+    <string name="a11y_search_currencies">Sök valutor</string>
+    <string name="a11y_clear_search">Rensa sökning</string>
+    <string name="a11y_cart_item_name">Artikelnamn</string>
+    <string name="a11y_chart_summary">Diagram över växelkurshistorik. Statistik — minimum, medel, maximum och aktuell kurs — visas nedan.</string>
+    <string name="a11y_star_currency">Stjärnmärk %1$s</string>
+    <string name="a11y_unstar_currency">Ta bort stjärna från %1$s</string>
+    <string name="a11y_action_select">Välj</string>
+    <string name="a11y_action_load">Läs in</string>
+    <string name="a11y_action_open">Öppna</string>
+    <string name="quick_conversions_fee_conversion">konvertering %s</string>
+    <string name="quick_conversions_fee_reduction">minskning %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Fäst överst</string>
+    <string name="cart_unpin_item">Ta bort fästning</string>
+    <string name="cart_reorder_item">Ändra ordning</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">Yeni olarak kaydet</string>
     <string name="cart_unsaved_discard">Değişiklikleri sil</string>
     <string name="cart_unsaved_continue">Devam et</string>
+    <string name="a11y_search_currencies">Para birimlerini ara</string>
+    <string name="a11y_clear_search">Aramayı temizle</string>
+    <string name="a11y_cart_item_name">Öğe adı</string>
+    <string name="a11y_chart_summary">Döviz kuru geçmişi grafiği. İstatistikler — minimum, ortalama, maksimum ve mevcut kur — aşağıda gösterilmiştir.</string>
+    <string name="a11y_star_currency">%1$s öğesini yıldızla</string>
+    <string name="a11y_unstar_currency">%1$s öğesinden yıldızı kaldır</string>
+    <string name="a11y_action_select">Seç</string>
+    <string name="a11y_action_load">Yükle</string>
+    <string name="a11y_action_open">Aç</string>
+    <string name="quick_conversions_fee_conversion">dönüşüm %s</string>
+    <string name="quick_conversions_fee_reduction">indirim %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Öğeyi üste sabitle</string>
+    <string name="cart_unpin_item">Sabitlemeyi kaldır</string>
+    <string name="cart_reorder_item">Öğeyi yeniden sırala</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">Зберегти як новий</string>
     <string name="cart_unsaved_discard">Скасувати зміни</string>
     <string name="cart_unsaved_continue">Продовжити</string>
+    <string name="a11y_search_currencies">Пошук валют</string>
+    <string name="a11y_clear_search">Очистити пошук</string>
+    <string name="a11y_cart_item_name">Назва позиції</string>
+    <string name="a11y_chart_summary">Графік історії обмінного курсу. Статистика — мінімум, середнє, максимум і поточний курс — показана нижче.</string>
+    <string name="a11y_star_currency">Позначити %1$s зіркою</string>
+    <string name="a11y_unstar_currency">Прибрати зірку з %1$s</string>
+    <string name="a11y_action_select">Вибрати</string>
+    <string name="a11y_action_load">Завантажити</string>
+    <string name="a11y_action_open">Відкрити</string>
+    <string name="quick_conversions_fee_conversion">конвертація %s</string>
+    <string name="quick_conversions_fee_reduction">зменшення %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Закріпити зверху</string>
+    <string name="cart_unpin_item">Відкріпити</string>
+    <string name="cart_reorder_item">Змінити порядок</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">Lưu thành mới</string>
     <string name="cart_unsaved_discard">Bỏ thay đổi</string>
     <string name="cart_unsaved_continue">Tiếp tục</string>
+    <string name="a11y_search_currencies">Tìm tiền tệ</string>
+    <string name="a11y_clear_search">Xóa tìm kiếm</string>
+    <string name="a11y_cart_item_name">Tên mục</string>
+    <string name="a11y_chart_summary">Biểu đồ lịch sử tỷ giá hối đoái. Thống kê — tối thiểu, trung bình, tối đa và tỷ giá hiện tại — được hiển thị bên dưới.</string>
+    <string name="a11y_star_currency">Gắn sao %1$s</string>
+    <string name="a11y_unstar_currency">Bỏ sao %1$s</string>
+    <string name="a11y_action_select">Chọn</string>
+    <string name="a11y_action_load">Tải</string>
+    <string name="a11y_action_open">Mở</string>
+    <string name="quick_conversions_fee_conversion">chuyển đổi %s</string>
+    <string name="quick_conversions_fee_reduction">giảm %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">Ghim lên đầu</string>
+    <string name="cart_unpin_item">Bỏ ghim</string>
+    <string name="cart_reorder_item">Sắp xếp lại</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">另存为新的</string>
     <string name="cart_unsaved_discard">放弃更改</string>
     <string name="cart_unsaved_continue">继续</string>
+    <string name="a11y_search_currencies">搜索货币</string>
+    <string name="a11y_clear_search">清除搜索</string>
+    <string name="a11y_cart_item_name">商品名称</string>
+    <string name="a11y_chart_summary">汇率历史走势图。以下显示统计信息 — 最低、平均、最高和当前汇率。</string>
+    <string name="a11y_star_currency">收藏 %1$s</string>
+    <string name="a11y_unstar_currency">取消收藏 %1$s</string>
+    <string name="a11y_action_select">选择</string>
+    <string name="a11y_action_load">加载</string>
+    <string name="a11y_action_open">打开</string>
+    <string name="quick_conversions_fee_conversion">转换 %s</string>
+    <string name="quick_conversions_fee_reduction">减免 %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">置顶</string>
+    <string name="cart_unpin_item">取消置顶</string>
+    <string name="cart_reorder_item">重新排序</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -96,4 +96,19 @@
     <string name="cart_unsaved_save_as">另存為新的</string>
     <string name="cart_unsaved_discard">捨棄變更</string>
     <string name="cart_unsaved_continue">繼續</string>
+    <string name="a11y_search_currencies">搜尋貨幣</string>
+    <string name="a11y_clear_search">清除搜尋</string>
+    <string name="a11y_cart_item_name">項目名稱</string>
+    <string name="a11y_chart_summary">匯率歷史走勢圖。下方顯示統計資訊 — 最低、平均、最高及目前匯率。</string>
+    <string name="a11y_star_currency">收藏 %1$s</string>
+    <string name="a11y_unstar_currency">取消收藏 %1$s</string>
+    <string name="a11y_action_select">選擇</string>
+    <string name="a11y_action_load">載入</string>
+    <string name="a11y_action_open">開啟</string>
+    <string name="quick_conversions_fee_conversion">換算 %s</string>
+    <string name="quick_conversions_fee_reduction">減免 %s</string>
+    <string name="cart_fee_extra_value">%1$s (%2$s%%)</string>
+    <string name="cart_pin_item">置頂</string>
+    <string name="cart_unpin_item">取消置頂</string>
+    <string name="cart_reorder_item">重新排序</string>
 </resources>


### PR DESCRIPTION
## Summary
- Every locale was missing the same 15 translatable keys added since the last upstream sync (chart summary, star / unstar, row action verbs, cart pin / unpin / reorder, quick-conversions fee-side labels, fee extra-value format).
- Filled in across all 31 translated locales so TalkBack no longer falls back to English when the device language is one of the covered ones.
- No source-language (`values/strings.xml`) or code changes.

## Test plan
- [x] `./gradlew spotlessCheck` clean
- [x] Every locale `strings.xml` parses as valid XML
- [x] Each locale grew from 92 → 107 `<string>` entries (base has 107 translatable + 4 `translatable="false"`)
- [ ] Spot-check on device with `adb shell settings put system system_locales <tag>` for a handful of locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)