### PR TITLE
i18n: localize API provider display names

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/ApiProvider.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/ApiProvider.kt
@@ -1,6 +1,7 @@
 package com.eliormachlev.currencix.model
 
 import android.content.Context
+import androidx.annotation.StringRes
 import com.eliormachlev.currencix.model.provider.BankOfCanada
 import com.eliormachlev.currencix.model.provider.BankOfIsrael
 import com.eliormachlev.currencix.model.provider.BankRossii
@@ -45,7 +46,7 @@ enum class ApiProvider(
                 ?: BANK_OF_ISRAEL
     }
 
-    fun getName(): CharSequence = this.implementation.name
+    fun getName(context: Context): CharSequence = context.getText(this.implementation.nameRes)
 
     fun getDescriptionShort(context: Context): CharSequence = this.implementation.descriptionShort(context)
 
@@ -72,7 +73,16 @@ enum class ApiProvider(
     ): Result<Timeline> = this.implementation.getTimeline(context, base, symbol, startDate, endDate)
 
     abstract class Api {
+        // Stable English identifier used for log/error tags — never shown to
+        // users; keep in ASCII so backend log grep stays predictable.
         abstract val name: String
+
+        // Localized display name shown in the UI (provider picker, share
+        // footer, timeline attribution). Central-bank providers translate;
+        // pure product brands (Frankfurter.app, Fer.ee, …) fall back to the
+        // base-locale string.
+        @get:StringRes
+        abstract val nameRes: Int
 
         abstract fun descriptionShort(context: Context): CharSequence
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankOfCanada.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankOfCanada.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 
 class BankOfCanada : ApiProvider.Api() {
     override val name = "Bank of Canada"
+    override val nameRes = R.string.api_bankOfCanada_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_bankOfCanada_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankOfIsrael.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankOfIsrael.kt
@@ -36,6 +36,7 @@ private fun unitFor(currency: String): BigDecimal = UNIT_PER_CURRENCY[currency] 
 
 class BankOfIsrael : ApiProvider.Api() {
     override val name = "Bank of Israel"
+    override val nameRes = R.string.api_bankOfIsrael_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_bankOfIsrael_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankRossii.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/BankRossii.kt
@@ -27,6 +27,7 @@ private val RUB_CODE: String = Currency.RUB.iso4217Alpha()
 
 class BankRossii : ApiProvider.Api() {
     override val name = "Bank Rossii"
+    override val nameRes = R.string.api_bankRossii_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_bankRossii_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/FerEe.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/FerEe.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 
 class FerEe : ApiProvider.Api() {
     override val name = "Fer.ee"
+    override val nameRes = R.string.api_ferEe_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_ferEe_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/FrankfurterApp.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/FrankfurterApp.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 
 class FrankfurterApp : ApiProvider.Api() {
     override val name = "Frankfurter.app"
+    override val nameRes = R.string.api_frankfurterApp_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_frankfurterApp_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/InforEuro.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/InforEuro.kt
@@ -17,6 +17,7 @@ import java.time.ZoneOffset
 
 class InforEuro : ApiProvider.Api() {
     override val name = "InforEuro"
+    override val nameRes = R.string.api_inforEuro_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_inforEuro_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/NorgesBank.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/NorgesBank.kt
@@ -16,6 +16,7 @@ private const val SDMX_FORMAT_QS = "&format=sdmx-compact-2.1"
 
 class NorgesBank : ApiProvider.Api() {
     override val name = "Norges Bank"
+    override val nameRes = R.string.api_norgesBank_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_norgesBank_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/OpenExchangerates.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/model/provider/OpenExchangerates.kt
@@ -15,6 +15,7 @@ private const val HTTP_UNAUTHORIZED = 401
 
 class OpenExchangerates : ApiProvider.Api() {
     override val name = "Open Exchangerates"
+    override val nameRes = R.string.api_openExchangeRates_name
 
     override fun descriptionShort(context: Context) = context.getText(R.string.api_openExchangeRates_descriptionShort)
 

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -295,7 +295,7 @@ class MainActivity : BaseActivity() {
 
     private fun buildShareFooter(rates: ExchangeRates?): String? {
         if (rates == null) return null
-        val providerName = rates.provider?.getName() ?: return null
+        val providerName = rates.provider?.getName(this) ?: return null
         val dateString = formatRatesTimestamp(rates.date, rates.time) ?: return null
         return getString(R.string.share_footer, providerName, dateString)
     }
@@ -625,7 +625,7 @@ class MainActivity : BaseActivity() {
         rates?.let {
             val date = it.date
             val dateString = formatRatesTimestamp(date, it.time)
-            val providerString = it.provider?.getName()
+            val providerString = it.provider?.getName(this)
             tvInfoDate.text =
                 if (dateString != null && providerString != null) {
                     getString(

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/PreferenceFragment.kt
@@ -216,7 +216,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         findPreference<ProviderPickerPreference>(getString(R.string.api_key))?.apply {
             val providers = ApiProvider.entries
-            entries = providers.map { it.getName() }.toTypedArray()
+            entries = providers.map { it.getName(requireContext()) }.toTypedArray()
             entryValues = providers.map { it.id.toString() }.toTypedArray()
             setOnHapticChangeListener { newValue ->
                 val provider = ApiProvider.fromId(newValue.toString().toIntOrNull() ?: UNKNOWN_PROVIDER_ID)
@@ -232,7 +232,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         viewModel.getApiProvider().observe(this) {
             findPreference<LongSummaryPreference>(getString(R.string.key_apiProvider))?.apply {
-                title = resources.getString(R.string.api_about_title, it.getName())
+                title = resources.getString(R.string.api_about_title, it.getName(requireContext()))
                 summary = it.getDescriptionLong(context)
             }
             findPreference<LongSummaryPreference>(getString(R.string.key_refreshPeriod))?.summary =

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/preference/ProviderPickerPreference.kt
@@ -121,7 +121,7 @@ internal class ProviderPickerDialogAdapter(
             // check current active api provider
             radioButton?.isChecked = (provider == selectedItem)
             // fill text
-            textProviderName?.text = provider.getName()
+            textProviderName?.text = provider.getName(context)
             textDesc?.text = provider.getDescriptionShort(context)
             textHint?.visibility = provider.getHint(context)?.let {
                 textHint?.text = it

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/cart/CartViewModel.kt
@@ -335,7 +335,7 @@ class CartViewModel(
             providerName =
                 ratesCache.lastRates
                     ?.provider
-                    ?.getName()
+                    ?.getName(getApplication())
                     ?.toString(),
             ratesDate = ratesCache.lastRates?.date,
         )

--- a/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/viewmodel/timeline/TimelineViewModel.kt
@@ -155,7 +155,7 @@ class TimelineViewModel(
 
     fun getProvider(): LiveData<CharSequence?> =
         dbLiveItems.map {
-            it?.provider?.getName()
+            it?.provider?.getName(app)
         }
 
     fun getRates(): LiveData<Map<LocalDate, Rate>?> =

--- a/app/src/main/res/values-ar/strings_apis.xml
+++ b/app/src/main/res/values-ar/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">حوالي 160 سعر الصرف\nالمصدر: مزيج من مقدمي خدمات موثوقين متعددين.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">تحديثات كل ساعة.</string>
     <string name="api_openExchangeRates_hint">لاستخدام هذا المصدر، عليك إنشاء مفتاح API الشخصي الخاص بك!</string>
+    <string name="api_bankOfCanada_name">بنك كندا</string>
+    <string name="api_bankOfIsrael_name">بنك إسرائيل</string>
+    <string name="api_bankRossii_name">بنك روسيا</string>
+    <string name="api_norgesBank_name">بنك النرويج</string>
 </resources>

--- a/app/src/main/res/values-bg/strings_apis.xml
+++ b/app/src/main/res/values-bg/strings_apis.xml
@@ -11,4 +11,8 @@
     <string name="api_frankfurterApp_descriptionUpdateInterval">Данните се обновяват около 16:00 CET всеки работен ден.</string>
     <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_bg"><b>InforEuro</b></a> предоставя официалния месечен счетоводен курс на еврото на Европейската комисия и обменните курсове, както са установени от счетоводителя на Европейската комисия в съответствие с член 19 от Финансовия регламент.\nКурсът се използва за изчисляване на суми за възстановяване на разходи, пътни или дневни разходи на външни лица, участващи в заседания, срещи и др. по искане на Европейската комисия.\n<b>Περιλαμβάνει περίπου 150 νομίσματα.</b></string>
     <string name="api_inforEuro_descriptionUpdateInterval">Посочените курсове са пазарните курсове за предпоследния ден от предходния месец, както са предоставени от Европейската централна банка или, в зависимост от наличността, от делегациите или други подходящи източници на близка дата.</string>
+    <string name="api_bankOfCanada_name">Банка на Канада</string>
+    <string name="api_bankOfIsrael_name">Банка на Израел</string>
+    <string name="api_bankRossii_name">Банка на Русия</string>
+    <string name="api_norgesBank_name">Банка на Норвегия</string>
 </resources>

--- a/app/src/main/res/values-bn/strings_apis.xml
+++ b/app/src/main/res/values-bn/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">প্রায় ১৬০টি বিনিময় হার\nউৎস: কতিপয় নির্ভরযোগ্য সরবরাহকারীর সংমিশ্রণে।</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">ঘণ্টাপ্রতি হালনাগাদ।</string>
     <string name="api_openExchangeRates_hint">এই উৎসটি ব্যবহার করতে তোমার ব্যক্তিগত এপিআই কি(চাবি) বানাতে হবে!</string>
+    <string name="api_bankOfCanada_name">ব্যাংক অফ কানাডা</string>
+    <string name="api_bankOfIsrael_name">ব্যাংক অফ ইসরায়েল</string>
+    <string name="api_bankRossii_name">ব্যাংক অফ রাশিয়া</string>
+    <string name="api_norgesBank_name">ব্যাংক অফ নরওয়ে</string>
 </resources>

--- a/app/src/main/res/values-ca/strings_apis.xml
+++ b/app/src/main/res/values-ca/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Unes 160 taxes de canvi.\nFont: Combinació de diferents proveïdors de confiança.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Actualitzacions cada hora.</string>
     <string name="api_openExchangeRates_hint">Heu de crear una clau API personal per a utilitzar aquesta font.</string>
+    <string name="api_bankOfCanada_name">Banc del Canadà</string>
+    <string name="api_bankOfIsrael_name">Banc d\'Israel</string>
+    <string name="api_bankRossii_name">Banc de Rússia</string>
+    <string name="api_norgesBank_name">Banc de Noruega</string>
 </resources>

--- a/app/src/main/res/values-cs/strings_apis.xml
+++ b/app/src/main/res/values-cs/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Okolo 160 kurzů\nZdroj: Kombinace několika spolehlivých poskytovatelů.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Hodinové aktualizace.</string>
     <string name="api_openExchangeRates_hint">Abyste mohli využívat tento zdroj, musíte si vytvořit osobní klíč API!</string>
+    <string name="api_bankOfCanada_name">Kanadská centrální banka</string>
+    <string name="api_bankOfIsrael_name">Izraelská centrální banka</string>
+    <string name="api_bankRossii_name">Ruská centrální banka</string>
+    <string name="api_norgesBank_name">Norská centrální banka</string>
 </resources>

--- a/app/src/main/res/values-da/strings_apis.xml
+++ b/app/src/main/res/values-da/strings_apis.xml
@@ -29,4 +29,8 @@
 
 
 
+    <string name="api_bankOfCanada_name">Canadas nationalbank</string>
+    <string name="api_bankOfIsrael_name">Israels Nationalbank</string>
+    <string name="api_bankRossii_name">Ruslands centralbank</string>
+    <string name="api_norgesBank_name">Norges Bank</string>
 </resources>

--- a/app/src/main/res/values-de/strings_apis.xml
+++ b/app/src/main/res/values-de/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Ungefähr 160 Wechselkurse\nQuelle: Kombination aus mehreren zuverlässigen Quellen.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Stündliche Updates.</string>
     <string name="api_openExchangeRates_hint">Um diese Quelle zu nutzen, muss zuerst ein persönlicher API-Schlüssel erstellt werden!</string>
+    <string name="api_bankOfCanada_name">Bank of Canada</string>
+    <string name="api_bankOfIsrael_name">Bank of Israel</string>
+    <string name="api_bankRossii_name">Russische Zentralbank</string>
+    <string name="api_norgesBank_name">Norges Bank</string>
 </resources>

--- a/app/src/main/res/values-el/strings_apis.xml
+++ b/app/src/main/res/values-el/strings_apis.xml
@@ -17,4 +17,8 @@
     <string name="api_inforEuro_descriptionUpdateInterval">Οι ισοτιμίες που αναφέρονται είναι οι ισοτιμίες της αγοράς για τη δεύτερη έως τελευταία ημέρα του προηγούμενου μήνα, όπως δημοσιοποιούνται από την Ευρωπαϊκή Κεντρική Τράπεζα, ή, ανάλογα με τη διαθεσιμότητα, όπως παρέχονται από τις αντιπροσωπείες ή άλλες κατάλληλες πηγές κοντά στην ημερομηνία αυτή.</string>
     <string name="api_norgesBank_descriptionFull">Συναλλαγματικές ισοτιμίες, όπως παρέχονται από την Κεντρική Τράπεζα της Νορβηγίας <a href="https://www.norges-bank.no/en/topics/Statistics/exchange_rates/"><b>Norges Bank</b></a>\n<b>Η Norges Bank παρέχει περίπου 40 συναλλαγματικές ισοτιμίες.</b></string>
     <string name="api_norgesBank_descriptionUpdateInterval">Η ώρα δημοσίευσης των ημερήσιων ισοτιμιών είναι περίπου στις 16:00 CET.</string>
+    <string name="api_bankOfCanada_name">Τράπεζα του Καναδά</string>
+    <string name="api_bankOfIsrael_name">Τράπεζα του Ισραήλ</string>
+    <string name="api_bankRossii_name">Τράπεζα της Ρωσίας</string>
+    <string name="api_norgesBank_name">Τράπεζα της Νορβηγίας</string>
 </resources>

--- a/app/src/main/res/values-eo/strings_apis.xml
+++ b/app/src/main/res/values-eo/strings_apis.xml
@@ -4,4 +4,8 @@
     <string name="api_bankOfIsrael_descriptionShort">Ĉirkaŭ 14 valutkurzoj\nFonto: Centra Banko de Israelo</string>
     <string name="api_bankOfIsrael_descriptionUpdateInterval">Reprezentaj kurzoj estas publikigitaj unufoje ĉiun labortagon ĉirkaŭ la 15:30 israela tempo.</string>
     <string name="api_exchangerateHost_descriptionFull"><a href="https://exchangerate.host/"><b>Exchangerate.host</b></a> fontas la valutajn kurzoj el diversaj financaj datumprovizantoj kaj bankoj, inkluzive de la Eŭropa Centra Banko. Ĉiuj kurzoj-datumoj estas liveritaj en mezpunkto-datumoj. Mezpunktaj kurzoj estas determinitaj kalkulante la mezan kurzon de Bid and Ask.\n<b>Proksime 160 valutoj estas inkluzivitaj.</b></string>
+    <string name="api_bankOfCanada_name">Banko de Kanado</string>
+    <string name="api_bankOfIsrael_name">Banko de Israelo</string>
+    <string name="api_bankRossii_name">Banko de Rusio</string>
+    <string name="api_norgesBank_name">Banko de Norvegio</string>
 </resources>

--- a/app/src/main/res/values-es/strings_apis.xml
+++ b/app/src/main/res/values-es/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Unos 160 tipos de cambio\nFuente: Combinación de múltiples proveedores fiables.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Actualizaciones cada hora.</string>
     <string name="api_openExchangeRates_hint">Para utilizar esta Fuente, ¡tiene que crear su Clave API personal!</string>
+    <string name="api_bankOfCanada_name">Banco de Canadá</string>
+    <string name="api_bankOfIsrael_name">Banco de Israel</string>
+    <string name="api_bankRossii_name">Banco de Rusia</string>
+    <string name="api_norgesBank_name">Banco de Noruega</string>
 </resources>

--- a/app/src/main/res/values-et/strings_apis.xml
+++ b/app/src/main/res/values-et/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Umbes 160 valuuta vahetuskursid\nAndmeallikas: mitme usaldusväärse allika kombinatsioon.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Andmed uuenevad kord tunnis.</string>
     <string name="api_openExchangeRates_hint">Selle andmeallika kasutamiseks peab sul olema isiklik liidestuse tunnus (API key)!</string>
+    <string name="api_bankOfCanada_name">Kanada keskpank</string>
+    <string name="api_bankOfIsrael_name">Iisraeli keskpank</string>
+    <string name="api_bankRossii_name">Venemaa Pank</string>
+    <string name="api_norgesBank_name">Norra keskpank</string>
 </resources>

--- a/app/src/main/res/values-fa/strings_apis.xml
+++ b/app/src/main/res/values-fa/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">حدود 160 نرخ ارز\nمنبع: ترکیبی از چندین ارائه دهنده قابل اعتماد.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">به روز رسانی ساعتی.</string>
     <string name="api_openExchangeRates_hint">برای استفاده از این منبع، باید کلید API شخصی خود را ایجاد کنید!</string>
+    <string name="api_bankOfCanada_name">بانک کانادا</string>
+    <string name="api_bankOfIsrael_name">بانک اسرائیل</string>
+    <string name="api_bankRossii_name">بانک روسیه</string>
+    <string name="api_norgesBank_name">بانک نروژ</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_apis.xml
+++ b/app/src/main/res/values-fr/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">À peu près 160 taux de change\nSource : Combinaision de plusieurs fournisseurs fiables.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Actualisation toutes les heures.</string>
     <string name="api_openExchangeRates_hint">Pour utiliser cette source, vous devez créer votre propre clé API !</string>
+    <string name="api_bankOfCanada_name">Banque du Canada</string>
+    <string name="api_bankOfIsrael_name">Banque d\'Israël</string>
+    <string name="api_bankRossii_name">Banque de Russie</string>
+    <string name="api_norgesBank_name">Banque de Norvège</string>
 </resources>

--- a/app/src/main/res/values-hr/strings_apis.xml
+++ b/app/src/main/res/values-hr/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Oko 160 tečajeva\nIzvor: Kombinacija više pouzdanih izvora podataka.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Ažurira se svakoga sata.</string>
     <string name="api_openExchangeRates_hint">Prije početka uporabe ovog izvora morate izraditi svoj osobni API ključ!</string>
+    <string name="api_bankOfCanada_name">Kanadska banka</string>
+    <string name="api_bankOfIsrael_name">Izraelska banka</string>
+    <string name="api_bankRossii_name">Ruska banka</string>
+    <string name="api_norgesBank_name">Norveška banka</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_apis.xml
+++ b/app/src/main/res/values-hu/strings_apis.xml
@@ -11,4 +11,8 @@
     <string name="api_frankfurterApp_descriptionUpdateInterval">Az adatok minden munkanapon 16:00 CET körül frissülnek.</string>
     <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_hu"><b>InforEuro</b></a> a világ pénznemei közötti átváltási számításokat segíti. Az alkalmazás az Európai Bizottság euróra vonatkozó hivatalos havi elszámolási árfolyamán és az annak megfelelő átváltási árfolyamokon alapul, melyeket a költségvetési rendelet 19. cikkével összhangban a Bizottság számvitelért felelős tisztviselője határoz meg.\nEzek az átváltási árfolyamok használatosak az Európai Bizottság által szervezett üléseken, interjúkon stb. részt vevő külső személyeknek térítendő utazási, napidíj- vagy egyéb költségek kiszámítására.\n<b>Körülbelül 150 pénznemet tartalmaz.</b></string>
     <string name="api_inforEuro_descriptionUpdateInterval">A feltüntetett árfolyamok az előző hónap utolsó előtti napján érvényes, az Európai Központi Bank által megadott piaci árfolyamok, vagy – a rendelkezésre állástól függően – a küldöttségek vagy más források által az említett dátumhoz közeli időpontokban megadott árfolyamok.</string>
+    <string name="api_bankOfCanada_name">Kanadai Központi Bank</string>
+    <string name="api_bankOfIsrael_name">Izraeli Központi Bank</string>
+    <string name="api_bankRossii_name">Oroszországi Központi Bank</string>
+    <string name="api_norgesBank_name">Norvégiai Központi Bank</string>
 </resources>

--- a/app/src/main/res/values-in/strings_apis.xml
+++ b/app/src/main/res/values-in/strings_apis.xml
@@ -9,4 +9,8 @@
     <string name="api_ferEe_descriptionUpdateInterval">Nilai tukar diperbarui setiap hari kerja.</string>
     <string name="api_frankfurterApp_descriptionFull"><a href="https://www.frankfurter.app/"><b>Frankfurter.app</b></a> memantau nilai valas yang dipublikasikan oleh Bank Sentral Eropa (European Central Bank).\n<b>Sekitar 30 mata uang tersedia.</b></string>
     <string name="api_frankfurterApp_descriptionUpdateInterval">Data diperbarui sekitar pukul 16.00 CET setiap hari kerja.</string>
+    <string name="api_bankOfCanada_name">Bank Kanada</string>
+    <string name="api_bankOfIsrael_name">Bank Israel</string>
+    <string name="api_bankRossii_name">Bank Rusia</string>
+    <string name="api_norgesBank_name">Bank Norwegia</string>
 </resources>

--- a/app/src/main/res/values-is/strings_apis.xml
+++ b/app/src/main/res/values-is/strings_apis.xml
@@ -6,4 +6,8 @@
     <string name="api_exchangerateHost_descriptionUpdateInterval">Gengi eru uppfærð um miðnætti UTC alla virka daga.</string>
     <string name="api_ferEe_descriptionUpdateInterval">Gengi eru uppfærð alla virka daga.</string>
     <string name="api_frankfurterApp_descriptionUpdateInterval">Gengi eru uppfærð um 16:00 CET alla virka daga.</string>
+    <string name="api_bankOfCanada_name">Kanadabanki</string>
+    <string name="api_bankOfIsrael_name">Ísraelsbanki</string>
+    <string name="api_bankRossii_name">Rússneski seðlabankinn</string>
+    <string name="api_norgesBank_name">Norski seðlabankinn</string>
 </resources>

--- a/app/src/main/res/values-it/strings_apis.xml
+++ b/app/src/main/res/values-it/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Circa 160 tassi di cambio\nFonte: Combinazione di più fornitori affidabili.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Aggiornamenti orari.</string>
     <string name="api_openExchangeRates_hint">Per utilizzare questa fonte, è necessario creare una chiave API personale!</string>
+    <string name="api_bankOfCanada_name">Banca del Canada</string>
+    <string name="api_bankOfIsrael_name">Banca d\'Israele</string>
+    <string name="api_bankRossii_name">Banca di Russia</string>
+    <string name="api_norgesBank_name">Banca di Norvegia</string>
 </resources>

--- a/app/src/main/res/values-iw/strings_apis.xml
+++ b/app/src/main/res/values-iw/strings_apis.xml
@@ -37,4 +37,8 @@
     <string name="api_openExchangeRates_descriptionShort">כ־160 שערי חליפין\nמקור: שילוב של מספר ספקים אמינים.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">עדכונים שעתיים.</string>
     <string name="api_openExchangeRates_hint">כדי להשתמש במקור זה, יש ליצור API Key אישי!</string>
+    <string name="api_bankOfCanada_name">בנק קנדה</string>
+    <string name="api_bankOfIsrael_name">בנק ישראל</string>
+    <string name="api_bankRossii_name">בנק רוסיה</string>
+    <string name="api_norgesBank_name">בנק נורווגיה</string>
 </resources>

--- a/app/src/main/res/values-ml/strings_apis.xml
+++ b/app/src/main/res/values-ml/strings_apis.xml
@@ -36,4 +36,8 @@
     <string name="api_openExchangeRates_descriptionShort">ഏകദേശം 160 വിനിമയ നിരക്കുകൾ\nഉറവിടം: ഒന്നിലധികം വിശ്വസനീയമായ ദാതാക്കളുടെ സംയോജനം.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">മണിക്കൂറിലൊരിക്കൽ അപ്ഡേറ്റുകൾ.</string>
     <string name="api_openExchangeRates_hint">ഈ ഉറവിടം ഉപയോഗിക്കാൻ, നിങ്ങളുടെ വ്യക്തിഗത API കീ സൃഷ്ടിക്കണം!</string>
+    <string name="api_bankOfCanada_name">ബാങ്ക് ഓഫ് കാനഡ</string>
+    <string name="api_bankOfIsrael_name">ബാങ്ക് ഓഫ് ഇസ്രായേൽ</string>
+    <string name="api_bankRossii_name">ബാങ്ക് ഓഫ് റഷ്യ</string>
+    <string name="api_norgesBank_name">ബാങ്ക് ഓഫ് നോർവേ</string>
 </resources>

--- a/app/src/main/res/values-nb/strings_apis.xml
+++ b/app/src/main/res/values-nb/strings_apis.xml
@@ -9,4 +9,8 @@
     <string name="api_ferEe_descriptionUpdateInterval">Vekslingskursene oppdateres hver arbeidsdag.</string>
     <string name="api_frankfurterApp_descriptionFull"><a href="https://www.frankfurter.app/"><b>Frankfurter.app</b></a> sporer referansekursene (forex) som publisert av den Europeiske sentralbanken.\n<b>Ca. 30 valutaer.</b></string>
     <string name="api_frankfurterApp_descriptionUpdateInterval">Dataen oppdateres ~16.00 CET hver dag.</string>
+    <string name="api_bankOfCanada_name">Canadas sentralbank</string>
+    <string name="api_bankOfIsrael_name">Israels sentralbank</string>
+    <string name="api_bankRossii_name">Russlands sentralbank</string>
+    <string name="api_norgesBank_name">Norges Bank</string>
 </resources>

--- a/app/src/main/res/values-nl/strings_apis.xml
+++ b/app/src/main/res/values-nl/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Ongeveer 160 wisselkoersen\nBron: Combinatie van meerdere betrouwbare aanbieders.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Elk uur updates.</string>
     <string name="api_openExchangeRates_hint">Om deze bron te gebruiken moet u een persoonlijke API sleutel aanmaken!</string>
+    <string name="api_bankOfCanada_name">Bank van Canada</string>
+    <string name="api_bankOfIsrael_name">Bank van Israël</string>
+    <string name="api_bankRossii_name">Bank van Rusland</string>
+    <string name="api_norgesBank_name">Bank van Noorwegen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_apis.xml
+++ b/app/src/main/res/values-pl/strings_apis.xml
@@ -12,4 +12,8 @@
     <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_pl"><b>InforEuro</b></a> podaje oficjalny miesięczny kurs księgowy euro Komisji Europejskiej i kursy wymiany ustalone przez jej księgowego zgodnie z art. 19 rozporządzenia finansowego.\nKursy te wykorzystuje się do obliczania zwrotu wydatków oraz kosztów podróży lub pobytu osób z zewnątrz, które biorą udział w spotkaniach, rozmowach kwalifikacyjnych i innych wydarzeniach na zaproszenie Komisji Europejskiej.\n<b>Około 150 walut jest zawartych.</b></string>
     <string name="api_inforEuro_descriptionUpdateInterval">Wyświetlane kursy wymiany są kursami rynkowymi od drugiego do ostatniego dnia poprzedniego miesiąca, zgodnie z kursami publikowanymi przez Europejski Bank Centralny, przekazanymi przez delegatury lub pochodzącymi z innych właściwych źródeł w danym terminie, co zależy od dostępności danych.</string>
     <string name="api_norgesBank_descriptionUpdateInterval">Dzienny czas publikacji średnich kursów wymiany to 16:00 CET.</string>
+    <string name="api_bankOfCanada_name">Bank Kanady</string>
+    <string name="api_bankOfIsrael_name">Bank Izraela</string>
+    <string name="api_bankRossii_name">Bank Rosji</string>
+    <string name="api_norgesBank_name">Bank Norwegii</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings_apis.xml
+++ b/app/src/main/res/values-pt-rBR/strings_apis.xml
@@ -11,4 +11,8 @@
     <string name="api_frankfurterApp_descriptionUpdateInterval">A informação é atualizada cerca das 16:00 CET a cada dia útil.</string>
     <string name="api_inforEuro_descriptionFull"><a href="https://commission.europa.eu/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_pt"><b>InforEuro</b></a> indica a taxa contabilística mensal oficial da Comissão Europeia para o euro e as taxas de conversão fixadas pelo contabilista da Comissão Europeia, em conformidade com o artigo 19.º do Regulamento Financeiro.\nEstas taxas são utilizadas para calcular os montantes dos reembolsos das despesas, nomeadamente de deslocação e de estada, de pessoas externas que participam, a convite da Comissão Europeia, em reuniões, entrevistas, etc.\n<b>Cerca de 150 moedas estão incluídas.</b></string>
     <string name="api_inforEuro_descriptionUpdateInterval">As taxas indicadas são as taxas de mercado do período compreendido entre o segundo e o último dia do mês anterior, divulgadas pelo Banco Central Europeu, ou, caso estejam disponíveis, fornecidas pelas delegações ou por outras fontes adequadas existentes na proximidade dessa data.</string>
+    <string name="api_bankOfCanada_name">Banco do Canadá</string>
+    <string name="api_bankOfIsrael_name">Banco de Israel</string>
+    <string name="api_bankRossii_name">Banco da Rússia</string>
+    <string name="api_norgesBank_name">Banco da Noruega</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_apis.xml
+++ b/app/src/main/res/values-ru/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Около 160 обменных курсов\nИсточник: Комбинация нескольких надежных поставщиков.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Ежечасные обновления.</string>
     <string name="api_openExchangeRates_hint">Чтобы использовать этот источник, вам необходимо создать свой личный ключ API!</string>
+    <string name="api_bankOfCanada_name">Банк Канады</string>
+    <string name="api_bankOfIsrael_name">Банк Израиля</string>
+    <string name="api_bankRossii_name">Банк России</string>
+    <string name="api_norgesBank_name">Банк Норвегии</string>
 </resources>

--- a/app/src/main/res/values-sv/strings_apis.xml
+++ b/app/src/main/res/values-sv/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_norgesBank_descriptionFull">Växelkurser tillhandahållna av norska centralbanken <a href="https://www.norges-bank.no/tema/Statistikk/Valutakurser/"><b>Norges Bank</b></a>.\n<b>Norges Bank listar runt 40 växelkurser.</b></string>
     <string name="api_openExchangeRates_descriptionFull">Data följs och kombineras från flera pålitliga källor, vilket ger opartiska växelkurser. Se <a href="https://openexchangerates.org/"><b>openexchangerates.org</b></a> för mer information.\n<b>Open Exchange Rates tillhandahåller hela 160 växelkurser.\n<i>För att använda denna källa så behöver du ange din personliga API-nyckel!</i></b></string>
     <string name="api_bankRossii_descriptionFull">Växelkurser som tillhandahålls av den Ryska centralbanken &lt;a href=\"https://cbr.ru/eng/currency_base/daily/\"&gt;Bank Rossi&lt;/b&gt;&lt;/a&gt;. Med de nuvarande sanktionerna så ger den här källan förmodligen de mest pålitliga växlingskurserna för Rysk Rubel.\n&lt;b&gt;Bank Rossii listar 44 växlingskurser.&lt;/b&gt;</string>
+    <string name="api_bankOfCanada_name">Kanadas centralbank</string>
+    <string name="api_bankOfIsrael_name">Israels centralbank</string>
+    <string name="api_bankRossii_name">Rysslands centralbank</string>
+    <string name="api_norgesBank_name">Norges Bank</string>
 </resources>

--- a/app/src/main/res/values-tr/strings_apis.xml
+++ b/app/src/main/res/values-tr/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Yaklaşık 160 döviz kuru\nKaynak: Birden fazla güvenilir sağlayıcının birleşimi.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Saatlik güncellemeler.</string>
     <string name="api_openExchangeRates_hint">Bu kaynağı kullanmak için kişisel API anahtarınızı oluşturmanız gerekir!</string>
+    <string name="api_bankOfCanada_name">Kanada Merkez Bankası</string>
+    <string name="api_bankOfIsrael_name">İsrail Merkez Bankası</string>
+    <string name="api_bankRossii_name">Rusya Merkez Bankası</string>
+    <string name="api_norgesBank_name">Norveç Merkez Bankası</string>
 </resources>

--- a/app/src/main/res/values-uk/strings_apis.xml
+++ b/app/src/main/res/values-uk/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Близько 160 курсів валют\nДжерело: поєднання кількох надійних постачальників.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Дані оновлюються щогодини.</string>
     <string name="api_openExchangeRates_hint">Щоб використовувати це джерело, ви повинні створити свій особистий ключ API!</string>
+    <string name="api_bankOfCanada_name">Банк Канади</string>
+    <string name="api_bankOfIsrael_name">Банк Ізраїлю</string>
+    <string name="api_bankRossii_name">Банк Росії</string>
+    <string name="api_norgesBank_name">Банк Норвегії</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_apis.xml
+++ b/app/src/main/res/values-vi/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">Khoảng 160 tỉ lệ chuyển đổi.\nNguồn: Kết hợp nhiều nhà cung cấp đáng tin cậy.</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">Cập nhật hàng giờ.</string>
     <string name="api_openExchangeRates_hint">Để sử dụng Nguồn này, bạn phải tạo mã API cá nhân!</string>
+    <string name="api_bankOfCanada_name">Ngân hàng Canada</string>
+    <string name="api_bankOfIsrael_name">Ngân hàng Israel</string>
+    <string name="api_bankRossii_name">Ngân hàng Nga</string>
+    <string name="api_norgesBank_name">Ngân hàng Na Uy</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_apis.xml
+++ b/app/src/main/res/values-zh-rCN/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">约 160 种汇率\n来源：多家可靠提供者的组合。</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">每小时更新。</string>
     <string name="api_openExchangeRates_hint">要使用此源，您必须创建您的个人 API 密钥！</string>
+    <string name="api_bankOfCanada_name">加拿大银行</string>
+    <string name="api_bankOfIsrael_name">以色列银行</string>
+    <string name="api_bankRossii_name">俄罗斯银行</string>
+    <string name="api_norgesBank_name">挪威银行</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings_apis.xml
+++ b/app/src/main/res/values-zh-rTW/strings_apis.xml
@@ -28,4 +28,8 @@
     <string name="api_openExchangeRates_descriptionShort">大約有 160 種匯率\n來源：由眾多可信賴的供應商組成。</string>
     <string name="api_openExchangeRates_descriptionUpdateInterval">每小時更新。</string>
     <string name="api_openExchangeRates_hint">要使用這個來源，您必須建立您的個人 API 金鑰！</string>
+    <string name="api_bankOfCanada_name">加拿大銀行</string>
+    <string name="api_bankOfIsrael_name">以色列銀行</string>
+    <string name="api_bankRossii_name">俄羅斯銀行</string>
+    <string name="api_norgesBank_name">挪威銀行</string>
 </resources>

--- a/app/src/main/res/values/strings_apis.xml
+++ b/app/src/main/res/values/strings_apis.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Provider display names. Locales are free to translate central-bank
+         names (Bank of Israel, Bank of Canada, …) into their own official
+         form; pure product/brand names (Frankfurter.app, Fer.ee, InforEuro,
+         Open Exchangerates) should stay verbatim across locales. -->
+    <string name="api_bankOfCanada_name">Bank of Canada</string>
+    <string name="api_bankOfIsrael_name">Bank of Israel</string>
+    <string name="api_bankRossii_name">Bank Rossii</string>
+    <string name="api_ferEe_name" translatable="false">Fer.ee</string>
+    <string name="api_frankfurterApp_name" translatable="false">Frankfurter.app</string>
+    <string name="api_inforEuro_name" translatable="false">InforEuro</string>
+    <string name="api_norgesBank_name">Norges Bank</string>
+    <string name="api_openExchangeRates_name" translatable="false">Open Exchangerates</string>
+
     <string name="api_bankOfCanada_descriptionFull">Daily average exchange rates of the <a href="https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates/"><b>Bank of Canada</b></a>.\n<b>About 23 currencies are included.</b></string>
     <string name="api_bankOfCanada_descriptionShort">About 23 exchange rates\nSource: Central Bank of Canada</string>
     <string name="api_bankOfCanada_descriptionUpdateInterval">The rates are published once each business day by 16:30 ET</string>


### PR DESCRIPTION
## Summary
- Split provider `name` into an internal English identifier (kept for log/error tags) and a new localized `nameRes` used everywhere the provider is shown to users (picker, share footer, timeline attribution).
- Added official native names for the 4 central-bank providers (Bank of Canada, Bank of Israel, Bank Rossii, Norges Bank) across all 31 locales — e.g. בנק ישראל, Банк России, 加拿大银行.
- Marked the 4 pure product brands (Frankfurter.app, Fer.ee, InforEuro, Open Exchangerates) `translatable="false"` so they stay verbatim across locales.

## Test plan
- [ ] Provider picker shows localized names for central banks in Hebrew / Russian / Chinese
- [ ] Brand-name providers (Frankfurter.app, Fer.ee, InforEuro, Open Exchangerates) still render verbatim in every locale
- [ ] Timeline attribution and share footer show the localized name
- [ ] Log/error output still uses the stable English `name` identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)