### PR TITLE
fix(main): preserve selected currencies across app restart

### DIFF
--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/cart/CartActivity.kt
@@ -269,12 +269,8 @@ class CartActivity : BaseActivity() {
             // Feed the same rate list the spinner shows on the main screen so
             // its picker shows flags, ISO codes, and (when enabled) preview
             // conversions.
-            spinnerFrom.setRates(rates?.rates)
-            spinnerTo.setRates(rates?.rates)
-            // Re-apply the saved base/dest selections: setRates rebuilds the
-            // adapter, which drops the previous selection unless we re-set it.
-            spinnerFrom.setSelection(viewModel.getBaseCurrency().value)
-            spinnerTo.setSelection(viewModel.getDestinationCurrency().value)
+            spinnerFrom.setRates(rates?.rates, viewModel.getBaseCurrency().value)
+            spinnerTo.setRates(rates?.rates, viewModel.getDestinationCurrency().value)
             footerBinding.refreshFeeAnnotations()
         }
     }

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/MainActivity.kt
@@ -653,8 +653,8 @@ class MainActivity : BaseActivity() {
             findViewById<ImageView>(R.id.iconHistorical).visibility =
                 if (viewModel.getHistoricalDate() != null) View.VISIBLE else View.GONE
         }
-        spinnerFrom.setRates(rates?.rates)
-        spinnerTo.setRates(rates?.rates)
+        spinnerFrom.setRates(rates?.rates, viewModel.getBaseCurrency().value)
+        spinnerTo.setRates(rates?.rates, viewModel.getDestinationCurrency().value)
     }
 
     private fun showErrorSnackbar(message: String?) {

--- a/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
+++ b/app/src/main/kotlin/com/eliormachlev/currencix/view/main/spinner/SearchableSpinner.kt
@@ -89,6 +89,19 @@ class SearchableSpinner : AppCompatSpinner {
         adapter.setRates(rates)
     }
 
+    // Repopulate the adapter and immediately restore [selection]. setRates
+    // alone drops the previous selection; without re-applying, AbsSpinner
+    // auto-picks position 0 on the next layout pass and its onItemSelected
+    // callback clobbers any persisted currency. If [selection] isn't in the
+    // new rate set (provider dropped it), the fallback to position 0 stands.
+    fun setRates(
+        rates: List<Rate>?,
+        selection: Currency?,
+    ) {
+        setRates(rates)
+        setSelection(selection)
+    }
+
     //  conversion preview
     fun setCurrentRate(currentRate: Rate) {
         // set in dialog


### PR DESCRIPTION
## Summary
- Main screen was forgetting its base/dest currency picks on cold start — user selects USD → JPY, closes the app, reopens, gets USD → EUR (defaults).
- Root cause: `spinnerFrom.setRates(...)` in `MainActivity.observeExchangeRates` rebuilt the adapter; on the next layout pass `AbsSpinner` auto-selected position 0 and fired `onItemSelected(0)`, which routed through `MainViewModel.setBaseCurrency` and overwrote the persisted `_last_from` / `_last_to` prefs with whatever was alphabetically first.
- `CartActivity` already worked around this by re-applying the saved selection immediately after `setRates`. Extracted that pattern into a `SearchableSpinner.setRates(rates, selection)` overload and used it from both activities.
- If the saved currency isn't in the new rate set (provider dropped it), `setSelection` resolves to `NO_SELECTION` and the `AbsSpinner` fallback to position 0 stands, refreshing prefs to a valid pick.

## Test plan
- [ ] Cold start: pick USD → JPY, force-stop the app, reopen — spinners restore USD → JPY.
- [ ] Same for cart screen (regression check, was already working).
- [ ] Switch provider to one that doesn't list the currently-selected currency — spinner falls back cleanly instead of crashing or showing a blank slot.
- [ ] Swap, pick via searchable dialog, spinner haptics — no behavior change on warm interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)