### PR TITLE
fix(cart): pin from/to spinner order to LTR in RTL locales

### DIFF
--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -50,11 +50,14 @@
             android:orientation="vertical"
             android:padding="@dimen/margin2x">
 
-            <!-- header: FROM  ⇄  TO — same SearchableSpinner as the main screen. -->
+            <!-- header: FROM  ⇄  TO — same SearchableSpinner as the main screen.
+                 Pin LTR so "from" stays on the left and "to" on the right even
+                 in RTL locales (e.g. Hebrew); the swap-FAB direction stays intuitive. -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
+                android:layoutDirection="ltr"
                 android:orientation="horizontal">
 
                 <com.eliormachlev.currencix.view.main.spinner.SearchableSpinner


### PR DESCRIPTION
## Summary
- In RTL locales (e.g. Hebrew), the cart header row inherited the locale layout direction and flipped the **from** spinner to the right and **to** to the left — inverting the intended original→converted reading order.
- Force `android:layoutDirection="ltr"` on the from/swap-FAB/to `LinearLayout` in `activity_cart.xml` so the original currency stays on the left and the converted currency on the right regardless of locale. The swap-FAB icon direction stays intuitive.

## Test plan
- [ ] Set device language to Hebrew, open Cart — confirm "from" spinner is on the left, swap FAB in the middle, "to" spinner on the right.
- [ ] Set device language to English (or another LTR locale) — confirm ordering is unchanged.
- [ ] Tap the swap FAB and confirm the two spinners still swap their selections correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)